### PR TITLE
GH-20: Remove deterministic output functionality

### DIFF
--- a/src/main/java/io/github/ascopes/protobufmavenplugin/AbstractGenerateMojo.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/AbstractGenerateMojo.java
@@ -60,7 +60,6 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
   private Set<Path> sourceDirectories;
   private Path outputDirectory;
   private Boolean fatalWarnings;
-  private Boolean reproducibleBuilds;
 
   /**
    * Initialise this Mojo.
@@ -72,7 +71,6 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
     sourceDirectories = null;
     outputDirectory = null;
     fatalWarnings = null;
-    reproducibleBuilds = null;
   }
 
   /**
@@ -145,18 +143,6 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
   }
 
   /**
-   * Request that {@code protoc} should try to keep things like map ordering consistent between
-   * builds while a consistent version of {@code protoc} is in use.
-   *
-   * @param reproducibleBuilds whether to enable reproducible builds or not.
-   * @since 0.0.1
-   */
-  @Parameter(defaultValue = "false")
-  public final void setReproducibleBuilds(boolean reproducibleBuilds) {
-    this.reproducibleBuilds = reproducibleBuilds;
-  }
-
-  /**
    * Execute this goal.
    *
    * @throws MojoExecutionException if a user/configuration error is encountered.
@@ -172,7 +158,6 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
     registerSource(mavenSession.getCurrentProject(), outputDirectory);
 
     var compilerExecutor = new ProtocExecutorBuilder(protocPath)
-        .deterministicOutput(reproducibleBuilds)
         .fatalWarnings(fatalWarnings)
         .includeDirectories(sourceDirectories)
         .outputDirectory(getSourceOutputType(), outputDirectory)

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/execute/ProtocExecutorBuilder.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/execute/ProtocExecutorBuilder.java
@@ -71,21 +71,6 @@ public final class ProtocExecutorBuilder {
   }
 
   /**
-   * Enable/disable deterministic output.
-   *
-   * <p>Calling this more than once is undefined behaviour.
-   *
-   * @param deterministicOutput whether to enable deterministic output or not.
-   * @return this builder.
-   */
-  public ProtocExecutorBuilder deterministicOutput(boolean deterministicOutput) {
-    if (deterministicOutput) {
-      arguments.add("--deterministic_output");
-    }
-    return this;
-  }
-
-  /**
    * Enable/disable fatal warnings.
    *
    * <p>Calling this more than once is undefined behaviour.


### PR DESCRIPTION
Deterministic output/reproducible build functionality only affects the output when using --encode with protoc from a compiled descriptor, which we are not doing.

Closes GH-20.