### PR TITLE
GH-18: Opt into generating lite-only sources for Java

### DIFF
--- a/src/it/java-test-simple/src/test/java/org/example/helloworld/ProtobufTest.java
+++ b/src/it/java-test-simple/src/test/java/org/example/helloworld/ProtobufTest.java
@@ -16,12 +16,29 @@
 package org.example.helloworld;
 
 import java.io.ByteArrayOutputStream;
+import java.util.ArrayList;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ProtobufTest {
+
+  @Test
+  void generatedProtobufSourcesAreFullMessages() throws Throwable {
+    // When
+    var superClasses = new ArrayList<String>();
+    Class<?> superClass = GreetingRequest.class;
+
+    do {
+      superClasses.add(superClass.getName());
+      superClass = superClass.getSuperclass();
+    } while (superClass != null);
+
+    // Then
+    assertTrue(superClasses.contains("com.google.protobuf.GeneratedMessageV3"));
+  }
 
   @Test
   void generatedProtobufSourcesAreValid() throws Throwable {

--- a/src/it/lite-java-simple/invoker.properties
+++ b/src/it/lite-java-simple/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals = clean package
+invoker.quiet = false

--- a/src/it/lite-java-simple/pom.xml
+++ b/src/it/lite-java-simple/pom.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2023, Ashley Scopes.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.example</groupId>
+  <artifactId>example</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+
+  <properties>
+    <junit.version>5.10.1</junit.version>
+    <protobuf.version>3.25.0</protobuf.version>
+
+    <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
+    <maven-surefire-plugin.version>3.2.2</maven-surefire-plugin.version>
+
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-javalite</artifactId>
+      <version>${protobuf.version}</version>
+      <scope>compile</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${maven-compiler-plugin.version}</version>
+
+        <configuration>
+          <release>11</release>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${maven-surefire-plugin.version}</version>
+      </plugin>
+
+      <plugin>
+        <groupId>${plugin-group-id}</groupId>
+        <artifactId>${plugin-artifact-id}</artifactId>
+        <version>${plugin-version}</version>
+
+        <configuration>
+          <liteOnly>true</liteOnly>
+          <version>${protobuf.version}</version>
+        </configuration>
+
+        <executions>
+          <execution>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/lite-java-simple/src/main/protobuf/helloworld.proto
+++ b/src/it/lite-java-simple/src/main/protobuf/helloworld.proto
@@ -1,0 +1,27 @@
+//
+// Copyright (C) 2023, Ashley Scopes.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "org.example.helloworld";
+
+package org.example.helloworld;
+
+message GreetingRequest {
+  string name = 1;
+}
+

--- a/src/it/lite-java-simple/src/test/java/org/example/helloworld/ProtobufTest.java
+++ b/src/it/lite-java-simple/src/test/java/org/example/helloworld/ProtobufTest.java
@@ -20,12 +20,13 @@ import java.util.ArrayList;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ProtobufTest {
+
   @Test
-  void generatedProtobufSourcesAreFullMessages() throws Throwable {
+  void generatedProtobufSourcesAreLiteMessages() throws Throwable {
     // When
     var superClasses = new ArrayList<String>();
     Class<?> superClass = GreetingRequest.class;
@@ -36,7 +37,7 @@ class ProtobufTest {
     } while (superClass != null);
 
     // Then
-    assertTrue(superClasses.contains("com.google.protobuf.GeneratedMessageV3"));
+    assertFalse(superClasses.contains("com.google.protobuf.GeneratedMessageV3"));
   }
 
   @Test

--- a/src/it/lite-java-simple/test.groovy
+++ b/src/it/lite-java-simple/test.groovy
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2023, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import java.nio.file.Path
+import static org.assertj.core.api.Assertions.assertThat
+
+Path baseDirectory = basedir.toPath().toAbsolutePath()
+def generatedSourcesDir = baseDirectory.resolve("target/generated-sources/protobuf")
+def classesDir = baseDirectory.resolve("target/classes")
+def expectedGeneratedFiles = [
+    "org/example/helloworld/Helloworld",
+    "org/example/helloworld/GreetingRequest",
+    "org/example/helloworld/GreetingRequestOrBuilder",
+]
+
+assertThat(generatedSourcesDir).isDirectory()
+
+assertThat(classesDir).isDirectory()
+
+expectedGeneratedFiles.forEach {
+  assertThat(generatedSourcesDir.resolve("${it}.java"))
+      .exists()
+      .isNotEmptyFile()
+  assertThat(classesDir.resolve("${it}.class"))
+      .exists()
+      .isNotEmptyFile()
+
+}

--- a/src/it/lite-java-test-simple/invoker.properties
+++ b/src/it/lite-java-test-simple/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals = clean package
+invoker.quiet = false

--- a/src/it/lite-java-test-simple/pom.xml
+++ b/src/it/lite-java-test-simple/pom.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2023, Ashley Scopes.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.example</groupId>
+  <artifactId>example</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+
+  <properties>
+    <junit.version>5.10.1</junit.version>
+    <protobuf.version>3.25.0</protobuf.version>
+
+    <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
+    <maven-surefire-plugin.version>3.2.2</maven-surefire-plugin.version>
+
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-javalite</artifactId>
+      <version>${protobuf.version}</version>
+      <scope>compile</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${maven-compiler-plugin.version}</version>
+
+        <configuration>
+          <release>11</release>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${maven-surefire-plugin.version}</version>
+      </plugin>
+
+      <plugin>
+        <groupId>${plugin-group-id}</groupId>
+        <artifactId>${plugin-artifact-id}</artifactId>
+        <version>${plugin-version}</version>
+
+        <configuration>
+          <liteOnly>true</liteOnly>
+          <version>${protobuf.version}</version>
+        </configuration>
+
+        <executions>
+          <execution>
+            <phase>generate-test-sources</phase>
+            <goals>
+              <goal>generate-test</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/lite-java-test-simple/src/test/java/org/example/helloworld/ProtobufTest.java
+++ b/src/it/lite-java-test-simple/src/test/java/org/example/helloworld/ProtobufTest.java
@@ -20,12 +20,13 @@ import java.util.ArrayList;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ProtobufTest {
+
   @Test
-  void generatedProtobufSourcesAreFullMessages() throws Throwable {
+  void generatedProtobufSourcesAreLiteMessages() throws Throwable {
     // When
     var superClasses = new ArrayList<String>();
     Class<?> superClass = GreetingRequest.class;
@@ -36,7 +37,7 @@ class ProtobufTest {
     } while (superClass != null);
 
     // Then
-    assertTrue(superClasses.contains("com.google.protobuf.GeneratedMessageV3"));
+    assertFalse(superClasses.contains("com.google.protobuf.GeneratedMessageV3"));
   }
 
   @Test

--- a/src/it/lite-java-test-simple/src/test/protobuf/helloworld.proto
+++ b/src/it/lite-java-test-simple/src/test/protobuf/helloworld.proto
@@ -1,0 +1,27 @@
+//
+// Copyright (C) 2023, Ashley Scopes.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "org.example.helloworld";
+
+package org.example.helloworld;
+
+message GreetingRequest {
+  string name = 1;
+}
+

--- a/src/it/lite-java-test-simple/test.groovy
+++ b/src/it/lite-java-test-simple/test.groovy
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2023, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import java.nio.file.Path
+import static org.assertj.core.api.Assertions.assertThat
+
+Path baseDirectory = basedir.toPath().toAbsolutePath()
+def generatedSourcesDir = baseDirectory.resolve("target/generated-test-sources/protobuf")
+def classesDir = baseDirectory.resolve("target/test-classes")
+def expectedGeneratedFiles = [
+    "org/example/helloworld/Helloworld",
+    "org/example/helloworld/GreetingRequest",
+    "org/example/helloworld/GreetingRequestOrBuilder",
+]
+
+assertThat(generatedSourcesDir).isDirectory()
+
+assertThat(classesDir).isDirectory()
+
+expectedGeneratedFiles.forEach {
+  assertThat(generatedSourcesDir.resolve("${it}.java"))
+      .exists()
+      .isNotEmptyFile()
+  assertThat(classesDir.resolve("${it}.class"))
+      .exists()
+      .isNotEmptyFile()
+
+}

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/AbstractGenerateMojo.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/AbstractGenerateMojo.java
@@ -65,6 +65,7 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
   private Path outputDirectory;
   private Boolean fatalWarnings;
   private Boolean generateKotlinWrappers;
+  private Boolean liteOnly;
 
   /**
    * Initialise this Mojo.
@@ -77,6 +78,7 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
     outputDirectory = null;
     fatalWarnings = null;
     generateKotlinWrappers = null;
+    liteOnly = null;
   }
 
   /**
@@ -146,6 +148,21 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
   }
 
   /**
+   * Whether to only generate "lite" messages or not.
+   *
+   * <p>These are bare-bones sources that do not contain most of the metadata that regular
+   * Protobuf sources contain, and are designed for low-latency/low-overhead scenarios.
+   *
+   * <p>See the protobuf documentation for the pros and cons of this.
+   *
+   * @param liteOnly whether to only generate "lite" messages or not.
+   */
+  @Parameter(defaultValue = "false")
+  public final void setLiteOnly(boolean liteOnly) {
+    this.liteOnly = liteOnly;
+  }
+
+  /**
    * Execute this goal.
    *
    * @throws MojoExecutionException if a user/configuration error is encountered.
@@ -172,12 +189,12 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
       var compilerArgsBuilder = new ProtocArgumentBuilder(protocPath)
           .fatalWarnings(fatalWarnings)
           .includeDirectories(sourceDirectories)
-          .outputDirectory("java", outputDirectory);
+          .outputDirectory("java", outputDirectory, liteOnly);
 
       if (generateKotlinWrappers) {
         // Will emit stubs that wrap the generated Java code only.
         compilerArgsBuilder
-            .outputDirectory("kotlin", outputDirectory);
+            .outputDirectory("kotlin", outputDirectory, liteOnly);
       }
 
       var compilerArgs = compilerArgsBuilder.build(sources);

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/execute/ProtocArgumentBuilder.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/execute/ProtocArgumentBuilder.java
@@ -74,10 +74,23 @@ public final class ProtocArgumentBuilder {
    *
    * @param outputType      the output type, e.g. {@code java} or {@code kotlin}.
    * @param outputDirectory the directory to write outputs to.
+   * @param lite            whether to generate "lite" outputs or not for this output directory.
    * @return this builder.
    */
-  public ProtocArgumentBuilder outputDirectory(String outputType, Path outputDirectory) {
-    arguments.add("--" + outputType + "_out=" + outputDirectory);
+  public ProtocArgumentBuilder outputDirectory(
+      String outputType,
+      Path outputDirectory,
+      boolean lite
+  ) {
+    var arg = new StringBuilder("--").append(outputType).append("_out=");
+
+    if (lite) {
+      arg.append("lite:");
+    }
+
+    arg.append(outputDirectory);
+
+    arguments.add(arg.toString());
     return this;
   }
 

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -128,6 +128,33 @@ plugin configuration:
 
 Multiple source directories can be specified if required.
 
+Lightweight 'lite' sources
+--------------------------
+
+If you are in a situation where you need lightweight and fast protobuf generated sources, you
+can opt in to generating "lite" sources only. These will omit all the metadata usually included
+within generated protobuf sources, at the cost of flexibility.
+
+Refer to the protobuf documentation for more details on the pros and cons of doing this.
+
+To enable this in the plugin, set the `liteOnly` parameter to `true`. By default this is disabled
+as you usually do not need to worry about this.
+
+```xml
+<plugin>
+  <groupId>io.github.ascopes</groupId>
+  <artifactId>protobuf-maven-plugin</artifactId>
+  <version>...</version>
+
+  <configuration>
+    <liteOnly>true</liteOnly>
+    ...
+  </configuration>
+
+  ...
+</plugin>
+```
+
 Using `protoc` from the system path
 -----------------------------------
 


### PR DESCRIPTION
Enable generating "`lite`" sources for Java generated sources.

Closes GH-18.