### PR TITLE
GH-24: Add ability to generate gRPC stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 A simple and modern Maven plugin to generate Java/Kotlin sources from Protobuf definitions.
 
-## Aims
+## Features
 
 - Support for downloading a specified version of `protoc` from Maven repositories.
   - Ability to resolve any desired version
@@ -15,7 +15,9 @@ A simple and modern Maven plugin to generate Java/Kotlin sources from Protobuf d
 - Support for invoking `protoc` from the `$PATH` if you have an obscure system that does not provide
   an official `protoc` binary release from Google.
 - Java 11+ support.
-- Support for generating Java and Kotlin sources.
+- Ability to generate sources for Protobuf message payloads.
+- Ability to optionally generate source stubs for GRPC services.
+- Option to also generate Kotlin stubs that wrap the Java sources.
 
 ## Usage
 
@@ -30,7 +32,7 @@ The proposed usage at the time of writing will be something along the lines of:
   <configuration>
     <!-- Version of protoc to use, as defined at
          https://mvnrepository.com/artifact/com.google.protobuf/protoc -->
-    <version>3.25.0</version>
+    <protocVersion>3.25.0</protocVersion>
     <!-- Fail if protoc raises any warnings -->
     <fatalWarnings>true</fatalWarnings>
   </configuration>

--- a/src/it/java-grpc-simple/invoker.properties
+++ b/src/it/java-grpc-simple/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals = clean package
+invoker.quiet = false

--- a/src/it/java-grpc-simple/pom.xml
+++ b/src/it/java-grpc-simple/pom.xml
@@ -26,10 +26,12 @@
   <version>0.0.1-SNAPSHOT</version>
 
   <properties>
+    <grpc.version>1.59.0</grpc.version>
+    <javax-annotation-api.version>1.3.2</javax-annotation-api.version>
     <junit.version>5.10.1</junit.version>
-    <kotlin.version>1.9.21</kotlin.version>
     <protobuf.version>3.25.0</protobuf.version>
 
+    <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
     <maven-surefire-plugin.version>3.2.2</maven-surefire-plugin.version>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -38,15 +40,35 @@
   <dependencies>
     <dependency>
       <groupId>com.google.protobuf</groupId>
-      <artifactId>protobuf-kotlin</artifactId>
+      <artifactId>protobuf-java</artifactId>
       <version>${protobuf.version}</version>
       <scope>compile</scope>
     </dependency>
 
     <dependency>
-      <groupId>org.jetbrains.kotlin</groupId>
-      <artifactId>kotlin-stdlib</artifactId>
-      <version>${kotlin.version}</version>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-protobuf</artifactId>
+      <version>${grpc.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-netty</artifactId>
+      <version>${grpc.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-stub</artifactId>
+      <version>${grpc.version}</version>
+      <scope>compile</scope>
+    </dependency>
+
+    <!-- See https://github.com/grpc/grpc-java/issues/9179 -->
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+      <version>${javax-annotation-api.version}</version>
     </dependency>
 
     <dependency>
@@ -58,35 +80,21 @@
   </dependencies>
 
   <build>
-    <testSourceDirectory>${project.basedir}/src/test/kotlin</testSourceDirectory>
-
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${maven-compiler-plugin.version}</version>
+
+        <configuration>
+          <release>11</release>
+        </configuration>
+      </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>${maven-surefire-plugin.version}</version>
-      </plugin>
-
-      <plugin>
-        <groupId>org.jetbrains.kotlin</groupId>
-        <artifactId>kotlin-maven-plugin</artifactId>
-        <version>${kotlin.version}</version>
-
-        <executions>
-          <execution>
-            <id>compile</id>
-            <goals>
-              <goal>compile</goal>
-            </goals>
-          </execution>
-
-          <execution>
-            <id>test-compile</id>
-            <goals>
-              <goal>test-compile</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
 
       <plugin>
@@ -95,7 +103,7 @@
         <version>${plugin-version}</version>
 
         <configuration>
-          <generateKotlinWrappers>true</generateKotlinWrappers>
+          <grpcPluginVersion>${grpc.version}</grpcPluginVersion>
           <protocVersion>${protobuf.version}</protocVersion>
         </configuration>
 

--- a/src/it/java-grpc-simple/src/main/java/org/example/helloworld/GreetingServiceImpl.java
+++ b/src/it/java-grpc-simple/src/main/java/org/example/helloworld/GreetingServiceImpl.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2023, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.example.helloworld;
+
+import io.grpc.stub.StreamObserver;
+
+public class GreetingServiceImpl extends GreetingServiceGrpc.GreetingServiceImplBase {
+  @Override
+  public void greet(GreetingRequest request, StreamObserver<GreetingResponse> responseObserver) {
+    var response = GreetingResponse.newBuilder()
+        .setText("Hello, " + request.getName() + "!")
+        .build();
+
+    responseObserver.onNext(response);
+    responseObserver.onCompleted();
+  }
+}

--- a/src/it/java-grpc-simple/src/main/protobuf/helloworld.proto
+++ b/src/it/java-grpc-simple/src/main/protobuf/helloworld.proto
@@ -1,0 +1,35 @@
+//
+// Copyright (C) 2023, Ashley Scopes.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "org.example.helloworld";
+
+package org.example.helloworld;
+
+message GreetingRequest {
+  string name = 1;
+}
+
+message GreetingResponse {
+  string text = 1;
+}
+
+service GreetingService {
+  rpc Greet(GreetingRequest) returns (GreetingResponse);
+}
+

--- a/src/it/java-grpc-simple/src/test/java/org/example/helloworld/GreetingServiceImplTest.java
+++ b/src/it/java-grpc-simple/src/test/java/org/example/helloworld/GreetingServiceImplTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2023, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.example.helloworld;
+
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.ServerBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class GreetingServiceImplTest {
+  @Test
+  void greetingServiceWorksAsExpected() throws Throwable {
+    // Given
+    var service = new GreetingServiceImpl();
+    var server = ServerBuilder
+        .forPort(8080)
+        .addService(service)
+        .build();
+    var channel = ManagedChannelBuilder.forAddress("localhost", 8080)
+        .usePlaintext()
+        .build();
+    var stub = GreetingServiceGrpc.newBlockingStub(channel);
+
+    try {
+      server.start();
+
+      // When
+      var request = GreetingRequest
+          .newBuilder()
+          .setName("Ashley")
+          .build();
+      var response = stub.greet(request);
+
+      // Then
+      assertEquals("Hello, Ashley!", response.getText());
+    } finally {
+      server.shutdown();
+      server.awaitTermination();
+    }
+  }
+}

--- a/src/it/java-grpc-simple/test.groovy
+++ b/src/it/java-grpc-simple/test.groovy
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2023, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.nio.file.Path
+
+import static org.assertj.core.api.Assertions.assertThat
+
+Path baseDirectory = basedir.toPath().toAbsolutePath()
+def generatedSourcesDir = baseDirectory.resolve("target/generated-sources/protobuf")
+def classesDir = baseDirectory.resolve("target/classes")
+def expectedGeneratedFiles = [
+    "org/example/helloworld/Helloworld",
+    "org/example/helloworld/GreetingRequest",
+    "org/example/helloworld/GreetingRequestOrBuilder",
+]
+
+assertThat(generatedSourcesDir).isDirectory()
+
+assertThat(classesDir).isDirectory()
+
+expectedGeneratedFiles.forEach {
+  assertThat(generatedSourcesDir.resolve("${it}.java"))
+      .exists()
+      .isNotEmptyFile()
+  assertThat(classesDir.resolve("${it}.class"))
+      .exists()
+      .isNotEmptyFile()
+
+}

--- a/src/it/java-simple/pom.xml
+++ b/src/it/java-simple/pom.xml
@@ -75,7 +75,7 @@
         <version>${plugin-version}</version>
 
         <configuration>
-          <version>${protobuf.version}</version>
+          <protocVersion>${protobuf.version}</protocVersion>
         </configuration>
 
         <executions>

--- a/src/it/java-test-simple/pom.xml
+++ b/src/it/java-test-simple/pom.xml
@@ -75,7 +75,7 @@
         <version>${plugin-version}</version>
 
         <configuration>
-          <version>${protobuf.version}</version>
+          <protocVersion>${protobuf.version}</protocVersion>
         </configuration>
 
         <executions>

--- a/src/it/kotlin-test-simple/pom.xml
+++ b/src/it/kotlin-test-simple/pom.xml
@@ -89,7 +89,7 @@
 
         <configuration>
           <generateKotlinWrappers>true</generateKotlinWrappers>
-          <version>${protobuf.version}</version>
+          <protocVersion>${protobuf.version}</protocVersion>
         </configuration>
 
         <executions>

--- a/src/it/lite-java-simple/pom.xml
+++ b/src/it/lite-java-simple/pom.xml
@@ -76,7 +76,7 @@
 
         <configuration>
           <liteOnly>true</liteOnly>
-          <version>${protobuf.version}</version>
+          <protocVersion>${protobuf.version}</protocVersion>
         </configuration>
 
         <executions>

--- a/src/it/lite-java-test-simple/pom.xml
+++ b/src/it/lite-java-test-simple/pom.xml
@@ -76,7 +76,7 @@
 
         <configuration>
           <liteOnly>true</liteOnly>
-          <version>${protobuf.version}</version>
+          <protocVersion>${protobuf.version}</protocVersion>
         </configuration>
 
         <executions>

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/GenerateProtobufMojo.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/GenerateProtobufMojo.java
@@ -21,38 +21,42 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 
 /**
- * Mojo to generate test source code from Protobuf sources.
+ * Mojo to generate source code from protobuf sources.
  *
  * @author Ashley Scopes
  */
 @Mojo(
-    name = "generate-test",
-    defaultPhase = LifecyclePhase.GENERATE_TEST_SOURCES,
+    name = "generate",
+    defaultPhase = LifecyclePhase.GENERATE_SOURCES,
     requiresOnline = true,
     threadSafe = true
 )
-public final class GenerateTestMojo extends AbstractGenerateMojo {
+public final class GenerateProtobufMojo extends AbstractGenerateMojo {
 
   /**
    * Initialise this Mojo.
    */
-  public GenerateTestMojo() {
+  public GenerateProtobufMojo() {
     // Nothing to do.
   }
 
-
   @Override
   protected Path getDefaultSourceDirectory(Path baseDir) {
-    return baseDir.resolve("src").resolve("test").resolve("protobuf");
+    return baseDir.resolve("src").resolve("main").resolve("protobuf");
   }
 
   @Override
-  protected Path getDefaultOutputDirectory(Path targetDir) {
-    return targetDir.resolve("generated-test-sources").resolve("protobuf");
+  protected Path getDefaultProtobufOutputDirectory(Path targetDir) {
+    return targetDir.resolve("generated-sources").resolve("protobuf");
+  }
+
+  @Override
+  protected Path getDefaultGrpcOutputDirectory(Path targetDir) {
+    return targetDir.resolve("generated-sources").resolve("grpc");
   }
 
   @Override
   protected SourceRootRegistrar getSourceRootRegistrar() {
-    return SourceRootRegistrar.TEST;
+    return SourceRootRegistrar.MAIN;
   }
 }

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/GenerateProtobufTestMojo.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/GenerateProtobufTestMojo.java
@@ -21,37 +21,42 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 
 /**
- * Mojo to generate source code from protobuf sources.
+ * Mojo to generate test source code from Protobuf sources.
  *
  * @author Ashley Scopes
  */
 @Mojo(
-    name = "generate",
-    defaultPhase = LifecyclePhase.GENERATE_SOURCES,
+    name = "generate-test",
+    defaultPhase = LifecyclePhase.GENERATE_TEST_SOURCES,
     requiresOnline = true,
     threadSafe = true
 )
-public final class GenerateMojo extends AbstractGenerateMojo {
+public final class GenerateProtobufTestMojo extends AbstractGenerateMojo {
 
   /**
    * Initialise this Mojo.
    */
-  public GenerateMojo() {
+  public GenerateProtobufTestMojo() {
     // Nothing to do.
   }
 
   @Override
   protected Path getDefaultSourceDirectory(Path baseDir) {
-    return baseDir.resolve("src").resolve("main").resolve("protobuf");
+    return baseDir.resolve("src").resolve("test").resolve("protobuf");
   }
 
   @Override
-  protected Path getDefaultOutputDirectory(Path targetDir) {
-    return targetDir.resolve("generated-sources").resolve("protobuf");
+  protected Path getDefaultProtobufOutputDirectory(Path targetDir) {
+    return targetDir.resolve("generated-test-sources").resolve("protobuf");
+  }
+
+  @Override
+  protected Path getDefaultGrpcOutputDirectory(Path targetDir) {
+    return targetDir.resolve("generated-test-sources").resolve("grpc");
   }
 
   @Override
   protected SourceRootRegistrar getSourceRootRegistrar() {
-    return SourceRootRegistrar.MAIN;
+    return SourceRootRegistrar.TEST;
   }
 }

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/execute/ProtocArgumentBuilder.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/execute/ProtocArgumentBuilder.java
@@ -18,7 +18,6 @@ package io.github.ascopes.protobufmavenplugin.execute;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -34,7 +33,6 @@ public final class ProtocArgumentBuilder {
   // See the following source code for all supported flags:
   // https://github.com/protocolbuffers/protobuf/blob/7f94235e552599141950d7a4a3eaf93bc87d1b22/src/google/protobuf/compiler/command_line_interface.cc#L2438
 
-  private final Path executablePath;
   private final List<String> arguments;
 
   /**
@@ -43,8 +41,8 @@ public final class ProtocArgumentBuilder {
    * @param executablePath the path to the {@code protoc} executable.
    */
   public ProtocArgumentBuilder(Path executablePath) {
-    this.executablePath = executablePath;
     arguments = new ArrayList<>();
+    arguments.add(executablePath.toString());
   }
 
   /**
@@ -53,7 +51,8 @@ public final class ProtocArgumentBuilder {
    * @return the arguments.
    */
   public List<String> version() {
-    return List.of(executablePath.toString(), "--version");
+    arguments.add("--version");
+    return List.copyOf(arguments);
   }
 
   /**
@@ -66,6 +65,19 @@ public final class ProtocArgumentBuilder {
     for (var directory : directories) {
       arguments.add("--proto_path=" + directory);
     }
+    return this;
+  }
+
+  /**
+   * Add a plugin.
+   *
+   * @param pluginName the plugin name to use.
+   * @param pluginPath the plugin path to use.
+   * @return this builder.
+   */
+  public ProtocArgumentBuilder plugin(String pluginName, Path pluginPath) {
+    var arg = "--plugin=" + pluginName + "=" + pluginPath;
+    arguments.add(arg);
     return this;
   }
 
@@ -118,12 +130,9 @@ public final class ProtocArgumentBuilder {
    * @return the arguments.
    */
   public List<String> build(Collection<Path> protoFiles) {
-    var finalArguments = new ArrayList<String>(1 + arguments.size() + protoFiles.size());
-    finalArguments.add(executablePath.toString());
-    finalArguments.addAll(arguments);
     for (var protoFile : protoFiles) {
-      finalArguments.add(protoFile.toString());
+      arguments.add(protoFile.toString());
     }
-    return Collections.unmodifiableList(finalArguments);
+    return List.copyOf(arguments);
   }
 }

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/generate/SourceGenerator.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/generate/SourceGenerator.java
@@ -22,12 +22,17 @@ import io.github.ascopes.protobufmavenplugin.execute.ProtocArgumentBuilder;
 import io.github.ascopes.protobufmavenplugin.execute.ProtocExecutionException;
 import io.github.ascopes.protobufmavenplugin.execute.ProtocExecutor;
 import io.github.ascopes.protobufmavenplugin.resolve.ExecutableResolutionException;
+import io.github.ascopes.protobufmavenplugin.resolve.grpc.MavenGrpcJavaPluginResolver;
+import io.github.ascopes.protobufmavenplugin.resolve.grpc.MavenGrpcKotlinPluginResolver;
+import io.github.ascopes.protobufmavenplugin.resolve.grpc.PathGrpcJavaPluginResolver;
+import io.github.ascopes.protobufmavenplugin.resolve.grpc.PathGrpcKotlinPluginResolver;
 import io.github.ascopes.protobufmavenplugin.resolve.protoc.MavenProtocResolver;
 import io.github.ascopes.protobufmavenplugin.resolve.protoc.PathProtocResolver;
 import io.github.ascopes.protobufmavenplugin.resolve.source.ProtoSourceResolver;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -35,6 +40,9 @@ import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.shared.transfer.artifact.resolve.ArtifactResolver;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Main code generator.
@@ -46,11 +54,15 @@ import org.apache.maven.shared.transfer.artifact.resolve.ArtifactResolver;
  */
 public final class SourceGenerator {
 
+  private static final Logger LOGGER = LoggerFactory.getLogger(SourceGenerator.class);
+
   private final ArtifactResolver artifactResolver;
   private final MavenSession mavenSession;
   private final String protocVersion;
+  private final @Nullable String grpcPluginVersion;
   private final Set<Path> sourceDirectories;
-  private final Path outputDirectory;
+  private final Path protobufOutputDirectory;
+  private final Path grpcOutputDirectory;
   private final boolean fatalWarnings;
   private final boolean generateKotlinWrappers;
   private final boolean liteOnly;
@@ -60,8 +72,10 @@ public final class SourceGenerator {
     artifactResolver = requireNonNull(builder.artifactResolver);
     mavenSession = requireNonNull(builder.mavenSession);
     protocVersion = requireNonNull(builder.protocVersion);
+    grpcPluginVersion = builder.grpcPluginVersion;
     sourceDirectories = requireNonNull(builder.sourceDirectories);
-    outputDirectory = requireNonNull(builder.outputDirectory);
+    protobufOutputDirectory = requireNonNull(builder.protobufOutputDirectory);
+    grpcOutputDirectory = requireNonNull(builder.grpcOutputDirectory);
     fatalWarnings = requireNonNull(builder.fatalWarnings);
     generateKotlinWrappers = requireNonNull(builder.generateKotlinWrappers);
     liteOnly = requireNonNull(builder.liteOnly);
@@ -72,19 +86,24 @@ public final class SourceGenerator {
    * Generate the sources.
    *
    * @throws MojoExecutionException if a user error occurs.
-   * @throws MojoFailureException if a plugin error occurs.
+   * @throws MojoFailureException   if a plugin error occurs.
    */
   public void generate() throws MojoExecutionException, MojoFailureException {
+    LOGGER.debug("Beginning generation pass");
+
     // Step 1. Resolve everything we need to compile correctly.
     var protocPath = resolveProtocPath();
+    var pluginPaths = resolvePlugins();
     var sources = resolveProtoSources();
 
     // Step 2. Prepare the output environment.
     registerSourceOutputRoots();
 
-    // Step 3. Compile.
+    // Step 3. Log the protoc version being used for reference.
     dumpProtocVersion(protocPath);
-    compileProtobufSources(protocPath, sources);
+
+    // Step 4. Perform the compilation.
+    generateSources(protocPath, pluginPaths, sources);
   }
 
   Path resolveProtocPath() throws MojoFailureException {
@@ -99,6 +118,40 @@ public final class SourceGenerator {
     }
   }
 
+  Collection<Plugin> resolvePlugins() throws MojoFailureException {
+    if (grpcPluginVersion == null) {
+      return List.of();
+    }
+
+    var usePath = grpcPluginVersion.trim().equalsIgnoreCase("PATH");
+    var resolvedPluginPaths = new ArrayList<Plugin>();
+
+    try {
+      var javaResolver = usePath
+          ? new PathGrpcJavaPluginResolver()
+          : new MavenGrpcJavaPluginResolver(grpcPluginVersion, artifactResolver, mavenSession);
+
+      resolvedPluginPaths.add(new Plugin("protoc-gen-grpc-java", javaResolver.resolve()));
+    } catch (ExecutableResolutionException ex) {
+      throw failure("Failed to resolve Java GRPC plugin executable", ex);
+    }
+
+    if (generateKotlinWrappers) {
+      try {
+        var kotlinResolver = usePath
+            ? new PathGrpcKotlinPluginResolver()
+            : new MavenGrpcKotlinPluginResolver(grpcPluginVersion, artifactResolver,
+                mavenSession);
+
+        resolvedPluginPaths.add(new Plugin("protoc-gen-grpc-kotlin", kotlinResolver.resolve()));
+      } catch (ExecutableResolutionException ex) {
+        throw failure("Failed to resolve Kotlin GRPC plugin executables", ex);
+      }
+    }
+
+    return resolvedPluginPaths;
+  }
+
   private List<Path> resolveProtoSources() throws MojoFailureException {
     try {
       return ProtoSourceResolver.resolve(sourceDirectories);
@@ -108,35 +161,57 @@ public final class SourceGenerator {
   }
 
   void registerSourceOutputRoots() throws MojoFailureException {
-    // Create the root first if it does not yet exist.
     try {
-      Files.createDirectories(outputDirectory);
-      sourceRootRegistrar.register(mavenSession.getCurrentProject(), outputDirectory);
+      // Create the root first if it does not yet exist.
+      Files.createDirectories(protobufOutputDirectory);
+      sourceRootRegistrar.register(mavenSession.getCurrentProject(), protobufOutputDirectory);
     } catch (IOException ex) {
-      throw failure("Failed to register source output root", ex);
+      throw failure("Failed to register protobuf output root", ex);
+    }
+
+    if (grpcPluginVersion != null) {
+      try {
+        // Create the root first if it does not yet exist.
+        Files.createDirectories(grpcOutputDirectory);
+        sourceRootRegistrar.register(mavenSession.getCurrentProject(), grpcOutputDirectory);
+      } catch (IOException ex) {
+        throw failure("Failed to register GRPC output root", ex);
+      }
     }
   }
 
   void dumpProtocVersion(Path protocPath) throws MojoFailureException {
     try {
-      var args = new ProtocArgumentBuilder(protocPath).version();
-      ProtocExecutor.invoke(args);
+      ProtocExecutor.invoke(new ProtocArgumentBuilder(protocPath).version());
     } catch (ProtocExecutionException ex) {
       throw failure("Failed to determine protoc version", ex);
     }
   }
 
-  void compileProtobufSources(
+  void generateSources(
       Path protocPath,
+      Collection<Plugin> plugins,
       Collection<Path> sources
   ) throws MojoExecutionException {
     var argBuilder = new ProtocArgumentBuilder(protocPath)
         .includeDirectories(sourceDirectories)
         .fatalWarnings(fatalWarnings)
-        .outputDirectory("java", outputDirectory, liteOnly);
+        .outputDirectory("java", protobufOutputDirectory, liteOnly);
+
+    for (var plugin : plugins) {
+      argBuilder.plugin(plugin.name, plugin.path);
+    }
+
+    if (grpcPluginVersion != null) {
+      argBuilder.outputDirectory("grpc-java", grpcOutputDirectory, false);
+    }
 
     if (generateKotlinWrappers) {
-      argBuilder.outputDirectory("kotlin", outputDirectory, liteOnly);
+      argBuilder.outputDirectory("kotlin", protobufOutputDirectory, liteOnly);
+
+      if (grpcPluginVersion != null) {
+        argBuilder.outputDirectory("grpc-kotlin", grpcOutputDirectory, false);
+      }
     }
 
     try {
@@ -163,5 +238,15 @@ public final class SourceGenerator {
     return ofNullable(ex)
         .map(Exception::getMessage)
         .orElse(shortMessage);
+  }
+
+  private static final class Plugin {
+    private final String name;
+    private final Path path;
+
+    private Plugin(String name, Path path) {
+      this.name = name;
+      this.path = path;
+    }
   }
 }

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/generate/SourceGeneratorBuilder.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/generate/SourceGeneratorBuilder.java
@@ -37,8 +37,10 @@ public final class SourceGeneratorBuilder {
   @Nullable ArtifactResolver artifactResolver;
   @Nullable MavenSession mavenSession;
   @Nullable String protocVersion;
+  @Nullable String grpcPluginVersion;
   @Nullable Set<Path> sourceDirectories;
-  @Nullable Path outputDirectory;
+  @Nullable Path protobufOutputDirectory;
+  @Nullable Path grpcOutputDirectory;
   @Nullable Boolean fatalWarnings;
   @Nullable Boolean generateKotlinWrappers;
   @Nullable Boolean liteOnly;
@@ -85,6 +87,17 @@ public final class SourceGeneratorBuilder {
   }
 
   /**
+   * Set the GRPC plugin version.
+   *
+   * @param grpcPluginVersion the GRPC plugin version, or {@code null} to disable.
+   * @return this builder.
+   */
+  public SourceGeneratorBuilder grpcPluginVersion(@Nullable String grpcPluginVersion) {
+    this.grpcPluginVersion = grpcPluginVersion;
+    return this;
+  }
+
+  /**
    * Set the source directories to compile from.
    *
    * @param sourceDirectories the source directories to compile.
@@ -96,13 +109,24 @@ public final class SourceGeneratorBuilder {
   }
 
   /**
-   * Set the directory to output generated sources to.
+   * Set the directory to output generated protobuf message sources to.
    *
-   * @param outputDirectory the directory to output generated sources to.
+   * @param protobufOutputDirectory the directory to output generated protobuf message sources to.
    * @return this builder.
    */
-  public SourceGeneratorBuilder outputDirectory(Path outputDirectory) {
-    this.outputDirectory = outputDirectory;
+  public SourceGeneratorBuilder protobufOutputDirectory(Path protobufOutputDirectory) {
+    this.protobufOutputDirectory = protobufOutputDirectory;
+    return this;
+  }
+
+  /**
+   * Set the directory to output generated GRPC service sources to.
+   *
+   * @param grpcOutputDirectory the directory to output generated GRPC service sources to.
+   * @return this builder.
+   */
+  public SourceGeneratorBuilder grpcOutputDirectory(Path grpcOutputDirectory) {
+    this.grpcOutputDirectory = grpcOutputDirectory;
     return this;
   }
 

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/resolve/AbstractMavenCoordinateFactory.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/resolve/AbstractMavenCoordinateFactory.java
@@ -48,6 +48,12 @@ public abstract class AbstractMavenCoordinateFactory {
    */
   protected abstract String name();
 
+  /**
+   * Determine the correct classifier for the current system.
+   *
+   * @return the classifier string.
+   * @throws ExecutableResolutionException if the classifier could not be resolved.
+   */
   protected final String determineClassifier() throws ExecutableResolutionException {
     String classifier;
 

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/resolve/grpc/MavenGrpcJavaPluginCoordinateFactory.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/resolve/grpc/MavenGrpcJavaPluginCoordinateFactory.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2023, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.ascopes.protobufmavenplugin.resolve.grpc;
+
+import io.github.ascopes.protobufmavenplugin.resolve.AbstractMavenCoordinateFactory;
+import io.github.ascopes.protobufmavenplugin.resolve.ExecutableResolutionException;
+import org.apache.maven.shared.transfer.artifact.ArtifactCoordinate;
+import org.apache.maven.shared.transfer.artifact.DefaultArtifactCoordinate;
+
+/**
+ * Coordinate factory for determining the correct coordinate for the GRPC Java generator to download
+ * from Maven central.
+ *
+ * @author Ashley Scopes
+ */
+public final class MavenGrpcJavaPluginCoordinateFactory extends AbstractMavenCoordinateFactory {
+
+  private static final String GROUP_ID = "io.grpc";
+  private static final String ARTIFACT_ID = "protoc-gen-grpc-java";
+  private static final String EXTENSION = "exe";
+
+  /**
+   * Create the artifact coordinate for the current system.
+   *
+   * @param versionRange the version or version range of the artifact to use.
+   * @return the artifact to resolve.
+   * @throws ExecutableResolutionException if the system is not supported.
+   */
+  public ArtifactCoordinate create(String versionRange) throws ExecutableResolutionException {
+    var coordinate = new DefaultArtifactCoordinate();
+    coordinate.setGroupId(GROUP_ID);
+    coordinate.setArtifactId(ARTIFACT_ID);
+    coordinate.setVersion(versionRange);
+    coordinate.setClassifier(determineClassifier());
+    coordinate.setExtension(EXTENSION);
+    return coordinate;
+  }
+
+  @Override
+  protected String name() {
+    return ARTIFACT_ID;
+  }
+}

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/resolve/grpc/MavenGrpcJavaPluginResolver.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/resolve/grpc/MavenGrpcJavaPluginResolver.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2023, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.ascopes.protobufmavenplugin.resolve.grpc;
+
+import io.github.ascopes.protobufmavenplugin.resolve.AbstractMavenResolver;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.shared.transfer.artifact.resolve.ArtifactResolver;
+
+/**
+ * Resolver for the Java GRPC plugin for {@code protoc} which queries Maven Central.
+ *
+ * @author Ashley Scopes
+ */
+public final class MavenGrpcJavaPluginResolver extends AbstractMavenResolver {
+
+  /**
+   * Initialise this resolver.
+   *
+   * @param version          the version/version range to resolve.
+   * @param artifactResolver the Maven artifact resolver to use.
+   * @param session          the current Maven session.
+   */
+  public MavenGrpcJavaPluginResolver(
+      String version,
+      ArtifactResolver artifactResolver,
+      MavenSession session
+  ) {
+    super(version, artifactResolver, session, new MavenGrpcJavaPluginCoordinateFactory());
+  }
+}

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/resolve/grpc/MavenGrpcKotlinPluginCoordinateFactory.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/resolve/grpc/MavenGrpcKotlinPluginCoordinateFactory.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2023, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.ascopes.protobufmavenplugin.resolve.grpc;
+
+import io.github.ascopes.protobufmavenplugin.resolve.AbstractMavenCoordinateFactory;
+import io.github.ascopes.protobufmavenplugin.resolve.ExecutableResolutionException;
+import org.apache.maven.shared.transfer.artifact.ArtifactCoordinate;
+import org.apache.maven.shared.transfer.artifact.DefaultArtifactCoordinate;
+
+/**
+ * Coordinate factory for determining the correct coordinate for the GRPC Kotlin generator to
+ * download from Maven central.
+ *
+ * @author Ashley Scopes
+ */
+public final class MavenGrpcKotlinPluginCoordinateFactory extends AbstractMavenCoordinateFactory {
+
+  private static final String GROUP_ID = "io.grpc";
+  private static final String ARTIFACT_ID = "protoc-gen-grpc-kotlin";
+  private static final String EXTENSION = "exe";
+
+  /**
+   * Create the artifact coordinate for the current system.
+   *
+   * @param versionRange the version or version range of the artifact to use.
+   * @return the artifact to resolve.
+   * @throws ExecutableResolutionException if the system is not supported.
+   */
+  public ArtifactCoordinate create(String versionRange) throws ExecutableResolutionException {
+    var coordinate = new DefaultArtifactCoordinate();
+    coordinate.setGroupId(GROUP_ID);
+    coordinate.setArtifactId(ARTIFACT_ID);
+    coordinate.setVersion(versionRange);
+    coordinate.setClassifier(determineClassifier());
+    coordinate.setExtension(EXTENSION);
+    return coordinate;
+  }
+
+  @Override
+  protected String name() {
+    return ARTIFACT_ID;
+  }
+}

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/resolve/grpc/MavenGrpcKotlinPluginResolver.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/resolve/grpc/MavenGrpcKotlinPluginResolver.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2023, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.ascopes.protobufmavenplugin.resolve.grpc;
+
+import io.github.ascopes.protobufmavenplugin.resolve.AbstractMavenResolver;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.shared.transfer.artifact.resolve.ArtifactResolver;
+
+/**
+ * Resolver for the Kotlin GRPC plugin for {@code protoc} which queries Maven Central.
+ *
+ * @author Ashley Scopes
+ */
+public final class MavenGrpcKotlinPluginResolver extends AbstractMavenResolver {
+
+  /**
+   * Initialise this resolver.
+   *
+   * @param version          the version/version range to resolve.
+   * @param artifactResolver the Maven artifact resolver to use.
+   * @param session          the current Maven session.
+   */
+  public MavenGrpcKotlinPluginResolver(
+      String version,
+      ArtifactResolver artifactResolver,
+      MavenSession session
+  ) {
+    super(version, artifactResolver, session, new MavenGrpcKotlinPluginCoordinateFactory());
+  }
+}

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/resolve/grpc/PathGrpcJavaPluginResolver.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/resolve/grpc/PathGrpcJavaPluginResolver.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2023, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.ascopes.protobufmavenplugin.resolve.grpc;
+
+import io.github.ascopes.protobufmavenplugin.resolve.AbstractPathResolver;
+
+/**
+ * Resolver for the Java {@code protoc} GRPC plugin that searches the system path.
+ *
+ * @author Ashley Scopes
+ */
+public final class PathGrpcJavaPluginResolver extends AbstractPathResolver {
+
+  /**
+   * Initialise this resolver.
+   */
+  public PathGrpcJavaPluginResolver() {
+    // Nothing to do.
+  }
+
+  @Override
+  protected String binaryName() {
+    return "protoc-gen-grpc-java";
+  }
+}

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/resolve/grpc/PathGrpcKotlinPluginResolver.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/resolve/grpc/PathGrpcKotlinPluginResolver.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2023, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.ascopes.protobufmavenplugin.resolve.grpc;
+
+import io.github.ascopes.protobufmavenplugin.resolve.AbstractPathResolver;
+
+/**
+ * Resolver for the Kotlin {@code protoc} GRPC plugin that searches the system path.
+ *
+ * @author Ashley Scopes
+ */
+public final class PathGrpcKotlinPluginResolver extends AbstractPathResolver {
+
+  /**
+   * Initialise this resolver.
+   */
+  public PathGrpcKotlinPluginResolver() {
+    // Nothing to do.
+  }
+
+  @Override
+  protected String binaryName() {
+    return "protoc-gen-grpc-kotlin";
+  }
+}

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -1,5 +1,4 @@
-Introduction
-============
+# Introduction
 
 The Protobuf Maven Plugin is a modern Maven plugin that attempts to reduce the hassle needed to
 integrate Protobuf compilation into your build process.
@@ -11,21 +10,23 @@ the version of this plugin to be able to pull in a newer version of `protoc` whe
 If your system is not directly supported by Google in the `protoc` releases they supply, you can
 instruct the plugin to instead invoke `protoc` from your system path directly.
 
-In addition to generating Java sources, this plugin supports generating Kotlin sources as well!
+For users who are writing GRPC services, this plugin can also support generating the GRPC stubs
+for you automatically.
 
-Bugs and feature requests
-=========================
+In addition to generating Java sources, this plugin can also generate Kotlin sources.
+
+# Bugs and feature requests
 
 Please raise any bugs or feature requests on 
 [the GitHub project for this plugin](https://github.com/ascopes/protobuf-maven-plugin/issues).
 
-Usage
-=====
+# Usage
 
 Detailed usage can be found on the [plugin info (goals) page](plugin-info.html).
 
-Basic Configuration
--------------------
+## Generating Protobuf Sources
+
+### Basic configuration
 
 A simple project that makes use of this plugin to generate Java sources would place their
 `*.proto` protobuf sources in `src/main/protobuf`, and use the following structure:
@@ -54,7 +55,7 @@ A simple project that makes use of this plugin to generate Java sources would pl
         <version>...</version>
 
         <configuration>
-          <version>${protobuf.version}</version>
+          <protocVersion>${protobuf.version}</protocVersion>
         </configuration>
 
         <executions>
@@ -77,8 +78,7 @@ Test sources can be generated with the `generate-test` goal. Test sources will b
 the `target/generated-test-sources/protobuf` directory, and will be read from
 `src/test/protobuf` by default.
 
-Kotlin
-------
+### Kotlin generation
 
 Protoc support for Kotlin currently takes the shape of producing additional Kotlin API wrapper
 calls that can decorate the existing generated Java code.
@@ -103,8 +103,7 @@ To opt in to also generating these sources, set the `generateKotlinWrappers` plu
 
 Sources will be emitted in the same location as the Java sources.
 
-Overriding the input directories
---------------------------------
+### Changing the input directories
 
 If you do not want to use the default directory for your sources, you can override it in the
 plugin configuration:
@@ -119,7 +118,7 @@ plugin configuration:
     <sourceDirectories>
       <sourceDirectory>path/to/your/directory</sourceDirectory>
     </sourceDirectories>
-    <version>${protobuf.version}</version>
+    ...
   </configuration>
   
   ...
@@ -128,8 +127,7 @@ plugin configuration:
 
 Multiple source directories can be specified if required.
 
-Lightweight 'lite' sources
---------------------------
+### Generating lightweight sources
 
 If you are in a situation where you need lightweight and fast protobuf generated sources, you
 can opt in to generating "lite" sources only. These will omit all the metadata usually included
@@ -137,7 +135,7 @@ within generated protobuf sources, at the cost of flexibility.
 
 Refer to the protobuf documentation for more details on the pros and cons of doing this.
 
-To enable this in the plugin, set the `liteOnly` parameter to `true`. By default this is disabled
+To enable this in the plugin, set the `liteOnly` parameter to `true`. By default, this is disabled
 as you usually do not need to worry about this.
 
 ```xml
@@ -155,8 +153,7 @@ as you usually do not need to worry about this.
 </plugin>
 ```
 
-Using `protoc` from the system path
------------------------------------
+### Using protoc from your system path
 
 If you need to use the version of `protoc` that is installed on your system, specify the version
 as `PATH`.
@@ -168,9 +165,99 @@ as `PATH`.
   <version>...</version>
 
   <configuration>
-    <version>PATH</version>
+    <protocVersion>PATH</protocVersion>
   </configuration>
 
   ...
 </plugin>
 ```
+
+## GRPC
+
+This plugin supports generating Kotlin and Java GRPC service definitions to accompany the generated
+protobuf sources.
+
+To enable this, specify a version for the `grpcPluginVersion` parameter in the configuration block:
+
+```xml
+<project>
+  ...
+  
+  <properties>
+    <grpc.version>1.59.0</grpc.version>
+    <javax-annotation-api.version>1.3.2</javax-annotation-api.version>
+    <junit.version>5.10.1</junit.version>
+    <protobuf.version>3.25.0</protobuf.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>${protobuf.version}</version>
+      <scope>compile</scope>
+    </dependency>
+  
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-protobuf</artifactId>
+      <version>${grpc.version}</version>
+    </dependency>
+  
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-netty</artifactId>
+      <version>${grpc.version}</version>
+    </dependency>
+  
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-stub</artifactId>
+      <version>${grpc.version}</version>
+      <scope>compile</scope>
+    </dependency>
+  
+    <!-- See https://github.com/grpc/grpc-java/issues/9179 -->
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+      <version>${javax-annotation-api.version}</version>
+    </dependency>
+  </dependencies>
+  
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.github.ascopes</groupId>
+        <artifactId>protobuf-maven-plugin</artifactId>
+        <version>...</version>
+
+        <configuration>
+          <grpcPluginVersion>${grpc.version}</grpcPluginVersion>
+          <protocVersion>${protobuf.version}</protocVersion>
+        </configuration>
+
+        <executions>
+          <execution>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>
+```
+
+GRPC stub sources will be output at `target/generated-sources/grpc`, or  
+`target/generated-test-sources/grpc` by default unless overridden.
+
+Like the `protoc` version, you can request that the system path is used to discover the plugins
+instead by setting the version to the string: "`PATH`". This will expect an executable named 
+`protoc-gen-grpc-java` (and `protoc-gen-grpc-kotlin` if Kotlin wrappers are enabled) to be on 
+the `$PATH`.
+
+Sources are kept separate to allow users to have custom logic that separates the two generated
+sources if they wish.


### PR DESCRIPTION
Adds ability to generate gRPC stubs for Java and optionally Kotlin by resolving the binaries from Maven central.

The plugin structure has been moved around to enable reusing components more easily.

Closes GH-24.