### PR TITLE
Do not attempt to walk across source directories that are not directories

### DIFF
--- a/src/main/java/io/github/ascopes/protobufmavenplugin/resolve/ProtoSourceResolver.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/resolve/ProtoSourceResolver.java
@@ -51,7 +51,7 @@ public final class ProtoSourceResolver {
     var protoSources = new ArrayList<Path>();
 
     for (var sourceDir : sourceDirs) {
-      if (!Files.exists(sourceDir)) {
+      if (!Files.isDirectory(sourceDir)) {
         LOGGER.info("Source directory {} does not exist", sourceDir);
         continue;
       }


### PR DESCRIPTION
Fix an issue that may cause confusing behaviour if the user attempts to specify a file as a source directory.

Rather than crashing or checking if that file is valid, the plugin will now emit a message and ignore the entry entirely.