### PR TITLE
Handle irregular path cases better

### DIFF
--- a/src/main/java/io/github/ascopes/protobufmavenplugin/platform/HostEnvironment.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/platform/HostEnvironment.java
@@ -94,8 +94,9 @@ public final class HostEnvironment {
       return scanner
           .tokens()
           .filter(not(String::isBlank))
-          .distinct()
+          .map(String::trim)
           .map(HostEnvironment::parsePath)
+          .distinct()
           .collect(toUnmodifiableList());
     }
   }
@@ -112,6 +113,7 @@ public final class HostEnvironment {
       return scanner
           .tokens()
           .filter(not(String::isBlank))
+          .map(String::trim)
           .collect(collectingAndThen(
               toCollection(() -> new TreeSet<>(String::compareToIgnoreCase)),
               Collections::unmodifiableSortedSet


### PR DESCRIPTION
- Only apply distinction reduction once paths are parsed and normalized so we don't let mixed absolute and relative paths get detected as being distinct despite looking at the same file.
- Discard any trailing and leading whitespace in paths (all platforms) and path extensions (windows only).