### PR TITLE
GH-38: Import .proto files from maven dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 
   <groupId>io.github.ascopes</groupId>
   <artifactId>protobuf-maven-plugin</artifactId>
-  <version>0.0.2-SNAPSHOT</version>
+  <version>0.1.0</version>
 
   <name>Protobuf Maven Plugin</name>
   <description>Maven Plugin that generates source code from protobuf source files.</description>

--- a/src/it/java-import-from-jar/invoker.properties
+++ b/src/it/java-import-from-jar/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = clean package

--- a/src/it/java-import-from-jar/pom.xml
+++ b/src/it/java-import-from-jar/pom.xml
@@ -83,9 +83,7 @@
         <version>${plugin-version}</version>
 
         <configuration>
-          <additionalImports>
-            mvn:com.google.api.grpc:proto-google-common-protos:${proto-google-common-protos.version}
-          </additionalImports>
+          <additionalImports>mvn:com.google.api.grpc:proto-google-common-protos:${proto-google-common-protos.version}</additionalImports>
           <protocVersion>${protobuf.version}</protocVersion>
         </configuration>
 

--- a/src/it/java-import-from-jar/pom.xml
+++ b/src/it/java-import-from-jar/pom.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2023, Ashley Scopes.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.example</groupId>
+  <artifactId>example</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+
+  <properties>
+    <junit.version>5.10.1</junit.version>
+    <protobuf.version>3.25.0</protobuf.version>
+    <proto-google-common-protos.version>2.29.0</proto-google-common-protos.version>
+
+    <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
+    <maven-surefire-plugin.version>3.2.2</maven-surefire-plugin.version>
+
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>${protobuf.version}</version>
+      <scope>compile</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.api.grpc</groupId>
+      <artifactId>proto-google-common-protos</artifactId>
+      <version>${proto-google-common-protos.version}</version>
+      <scope>compile</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${maven-compiler-plugin.version}</version>
+
+        <configuration>
+          <release>11</release>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${maven-surefire-plugin.version}</version>
+      </plugin>
+
+      <plugin>
+        <groupId>${plugin-group-id}</groupId>
+        <artifactId>${plugin-artifact-id}</artifactId>
+        <version>${plugin-version}</version>
+
+        <configuration>
+          <additionalImports>
+            mvn:com.google.api.grpc:proto-google-common-protos:${proto-google-common-protos.version}
+          </additionalImports>
+          <protocVersion>${protobuf.version}</protocVersion>
+        </configuration>
+
+        <executions>
+          <execution>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/java-import-from-jar/src/main/protobuf/car.proto
+++ b/src/it/java-import-from-jar/src/main/protobuf/car.proto
@@ -1,0 +1,28 @@
+//
+// Copyright (C) 2023, Ashley Scopes.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "org.example";
+
+import "google/type/color.proto";
+
+message Car {
+  google.type.Color color = 1;
+  int32 doors = 2;
+}
+

--- a/src/it/java-import-from-jar/test.groovy
+++ b/src/it/java-import-from-jar/test.groovy
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) 2023, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/ArchiveExtractor.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/ArchiveExtractor.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2023, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.ascopes.protobufmavenplugin.dependencies;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.spi.FileSystemProvider;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Helpers for extracting archives to the root file system.
+ *
+ * @author Ashley Scopes
+ */
+public final class ArchiveExtractor {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ArchiveExtractor.class);
+
+  private ArchiveExtractor() {
+    // Static-only class.
+  }
+
+  /**
+   * Extract the contents of multiple archives to a given base directory.
+   *
+   * @param archives  the archives to extract.
+   * @param targetDir the target directory to write outputs to.
+   * @return the created path on the root file system to use with {@code protoc}.
+   * @throws IOException if an error occurs performing IO.
+   */
+  public static Collection<Path> extractArchives(
+      Collection<Path> archives,
+      Path targetDir
+  ) throws IOException {
+    var jarFsProvider = FileSystemProvider
+        .installedProviders()
+        .stream()
+        .filter(provider -> provider.getScheme().equals("jar"))
+        .findFirst()
+        .orElseThrow();
+
+    var resolved = new ArrayList<Path>();
+
+    for (var archive : archives) {
+      var friendlyDirName = archive.getFileName().toString();
+      var fileExtensionIndex = friendlyDirName.lastIndexOf('.');
+      friendlyDirName = fileExtensionIndex == -1
+          ? friendlyDirName
+          : friendlyDirName.substring(0, fileExtensionIndex);
+      var outputDir = targetDir.resolve(friendlyDirName);
+      LOGGER.info("Extracting contents of '{}' to {}", archive, outputDir);
+
+      // We could support "releaseVersion" and "multi-release" attributes in the future.
+      var env = Map.<String, String>of();
+      try (var fs = jarFsProvider.newFileSystem(archive, env)) {
+        var archiveRoot = fs.getRootDirectories().iterator().next();
+
+        Files.walkFileTree(archiveRoot, new SimpleFileVisitor<>() {
+          @Override
+          public FileVisitResult visitFile(
+              Path sourceFile,
+              BasicFileAttributes attrs
+          ) throws IOException {
+            var relativeFile = archiveRoot.relativize(sourceFile);
+            var targetFile = resolveCrossFileSystem(outputDir, relativeFile);
+            Files.createDirectories(targetFile.getParent());
+            Files.copy(
+                sourceFile,
+                targetFile,
+                StandardCopyOption.REPLACE_EXISTING,
+                StandardCopyOption.COPY_ATTRIBUTES
+            );
+
+            return FileVisitResult.CONTINUE;
+          }
+        });
+
+        resolved.add(outputDir);
+      }
+    }
+
+    return Collections.unmodifiableList(resolved);
+  }
+
+  private static Path resolveCrossFileSystem(Path root, Path toResolve) {
+    for (var path : toResolve) {
+      root = root.resolve(path.getFileName().toString());
+    }
+    return root;
+  }
+}

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/BasicMavenCoordinate.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/BasicMavenCoordinate.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright (C) 2023, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.ascopes.protobufmavenplugin.dependencies;
+
+import java.util.Objects;
+import java.util.regex.Pattern;
+import org.apache.maven.shared.transfer.artifact.ArtifactCoordinate;
+import org.apache.maven.shared.transfer.dependencies.DependableCoordinate;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Maven coordinate that is compatible with artifact and dependency resolution.
+ *
+ * @author Ashley Scopes
+ */
+public final class BasicMavenCoordinate implements ArtifactCoordinate, DependableCoordinate {
+
+  private static final Pattern COORDINATE_PATTERN = Pattern.compile(
+      "mvn:(?<groupId>[^:]+)"
+          + ":(?<artifactId>[^:]+)"
+          + ":(?<version>[^:]+)"
+          + "(?::(?<type>.*))?"
+          + "(?::(?<classifier>.*))?"
+  );
+
+  private final String groupId;
+  private final String artifactId;
+  private final String version;
+  private final String type;
+  private final @Nullable String classifier;
+
+  /**
+   * Initialise this coordinate.
+   *
+   * @param groupId the group ID.
+   * @param artifactId the artifact ID.
+   * @param version the version.
+   * @param type the artifact type, or {@code null} to use the default.
+   * @param classifier the classifier, or {@code null} if not applicable.
+   */
+  public BasicMavenCoordinate(
+      String groupId,
+      String artifactId,
+      String version,
+      @Nullable String type,
+      @Nullable String classifier
+  ) {
+    this.groupId = groupId;
+    this.artifactId = artifactId;
+    this.version = version;
+    this.type = Objects.requireNonNullElse(type, "jar");
+    this.classifier = classifier;
+  }
+
+  /**
+   * Get the group ID.
+   *
+   * @return the group ID.
+   */
+  @Override
+  public String getGroupId() {
+    return groupId;
+  }
+
+  /**
+   * Get the artifact ID.
+   *
+   * @return the artifact ID.
+   */
+  @Override
+  public String getArtifactId() {
+    return artifactId;
+  }
+
+  /**
+   * Get the version.
+   *
+   * @return the version.
+   */
+  @Override
+  public String getVersion() {
+    return version;
+  }
+
+  /**
+   * Get the artifact type.
+   *
+   * @return the artifact type.
+   */
+  @Override
+  public String getType() {
+    return type;
+  }
+
+  /**
+   * Get the artifact extension.
+   *
+   * @return the artifact extension.
+   */
+  @Override
+  public String getExtension() {
+    return type;
+  }
+
+  /**
+   * Get the classifier.
+   *
+   * @return the classifier, or {@code null} if not specified.
+   */
+  @Nullable
+  @Override
+  public String getClassifier() {
+    return classifier;
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * @return the string representation.
+   */
+  @Override
+  public String toString() {
+    var sb = new StringBuilder();
+    sb.append("mvn:")
+        .append(groupId)
+        .append(":")
+        .append(artifactId)
+        .append(":")
+        .append(version)
+        .append(":")
+        .append(type);
+
+    if (classifier != null) {
+      sb.append(":").append(classifier);
+    }
+
+    return sb.toString();
+  }
+
+  /**
+   * Parse a Maven classifier ID into an artifact coordinate.
+   *
+   * @param id the ID to parse.
+   * @return the coordinate.
+   * @throws DependencyResolutionException if the coordinate could not be parsed due to a syntax
+   *                                       error.
+   */
+  public static BasicMavenCoordinate parse(String id) throws DependencyResolutionException {
+    var matcher = COORDINATE_PATTERN.matcher(id);
+    if (!matcher.matches()) {
+      throw new DependencyResolutionException("Failed to parse artifact coordinate '" + id + "'");
+    }
+
+    return new BasicMavenCoordinate(
+        matcher.group("groupId"),
+        matcher.group("artifactId"),
+        matcher.group("version"),
+        matcher.group("type"),
+        matcher.group("classifier")
+    );
+  }
+}

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/Executable.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/Executable.java
@@ -17,8 +17,6 @@
 package io.github.ascopes.protobufmavenplugin.dependencies;
 
 import io.github.ascopes.protobufmavenplugin.platform.HostEnvironment;
-import org.apache.maven.shared.transfer.artifact.ArtifactCoordinate;
-import org.apache.maven.shared.transfer.artifact.DefaultArtifactCoordinate;
 
 /**
  * Representation of an executable that can be resolved from the
@@ -78,14 +76,14 @@ public final class Executable {
    * @throws DependencyResolutionException if the coordinate cannot be
    *     resolved for the current platform.
    */
-  public ArtifactCoordinate getMavenArtifactCoordinate(String version) throws DependencyResolutionException {
-    var coordinate = new DefaultArtifactCoordinate();
-    coordinate.setGroupId(groupId);
-    coordinate.setArtifactId(artifactId);
-    coordinate.setVersion(version);
-    coordinate.setClassifier(getMavenClassifier());
-    coordinate.setExtension("exe");
-    return coordinate;
+  public BasicMavenCoordinate getMavenArtifactCoordinate(String version) throws DependencyResolutionException {
+    return new BasicMavenCoordinate(
+        groupId,
+        artifactId,
+        version,
+        "exe",
+        getMavenClassifier()
+    );
   }
 
   private String getMavenClassifier() throws DependencyResolutionException {

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/Executable.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/Executable.java
@@ -76,8 +76,8 @@ public final class Executable {
    * @throws DependencyResolutionException if the coordinate cannot be
    *     resolved for the current platform.
    */
-  public BasicMavenCoordinate getMavenArtifactCoordinate(String version) throws DependencyResolutionException {
-    return new BasicMavenCoordinate(
+  public MavenCoordinate getMavenArtifactCoordinate(String version) throws DependencyResolutionException {
+    return new MavenCoordinate(
         groupId,
         artifactId,
         version,

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/MavenArtifactResolver.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/MavenArtifactResolver.java
@@ -62,7 +62,7 @@ public final class MavenArtifactResolver {
    * @throws DependencyResolutionException if resolution fails for any reason.
    */
   public Path resolveArtifact(
-      BasicMavenCoordinate coordinate
+      MavenCoordinate coordinate
   ) throws DependencyResolutionException {
     try {
       LOGGER.info("Resolving {} from Maven repositories", coordinate);
@@ -89,7 +89,7 @@ public final class MavenArtifactResolver {
    * @throws DependencyResolutionException if resolution fails.
    */
   public Set<Path> resolveDependencies(
-      BasicMavenCoordinate coordinate,
+      MavenCoordinate coordinate,
       Collection<String> scopes
   ) throws DependencyResolutionException {
     try {

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/MavenArtifactResolver.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/MavenArtifactResolver.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2023, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.ascopes.protobufmavenplugin.dependencies;
+
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.project.DefaultProjectBuildingRequest;
+import org.apache.maven.shared.artifact.filter.resolve.ScopeFilter;
+import org.apache.maven.shared.transfer.artifact.resolve.ArtifactResolver;
+import org.apache.maven.shared.transfer.artifact.resolve.ArtifactResolverException;
+import org.apache.maven.shared.transfer.dependencies.resolve.DependencyResolver;
+import org.apache.maven.shared.transfer.dependencies.resolve.DependencyResolverException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class MavenArtifactResolver {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(MavenExecutableResolver.class);
+
+  private final ArtifactResolver artifactResolver;
+  private final DependencyResolver dependencyResolver;
+  private final MavenSession mavenSession;
+
+  /**
+   * Initialise the resolver.
+   *
+   * @param artifactResolver the artifact resolver to use.
+   * @param mavenSession     the Maven session to use.
+   */
+  public MavenArtifactResolver(
+      ArtifactResolver artifactResolver,
+      DependencyResolver dependencyResolver,
+      MavenSession mavenSession
+  ) {
+    this.artifactResolver = artifactResolver;
+    this.dependencyResolver = dependencyResolver;
+    this.mavenSession = mavenSession;
+  }
+
+  /**
+   * Determine the path to the artifact.
+   *
+   * @param coordinate the artifact coordinate.
+   * @return the path to the artifact.
+   * @throws DependencyResolutionException if resolution fails for any reason.
+   */
+  public Path resolveArtifact(
+      BasicMavenCoordinate coordinate
+  ) throws DependencyResolutionException {
+    try {
+      LOGGER.info("Resolving {} from Maven repositories", coordinate);
+
+      var request = new DefaultProjectBuildingRequest(mavenSession.getProjectBuildingRequest());
+      var result = artifactResolver.resolveArtifact(request, coordinate);
+      return result.getArtifact().getFile().toPath();
+
+    } catch (ArtifactResolverException ex) {
+      throw new DependencyResolutionException(
+          "Failed to resolve " + coordinate + " from Maven repositories",
+          ex
+      );
+    }
+  }
+
+  /**
+   * Resolve the given dependency coordinate recursively, fetching all dependencies as well.
+   *
+   * @param coordinate the coordinate to pull.
+   * @param scopes     the scopes of dependencies to allow (e.g. {@code "compile"},
+   *                   {@code "provided"}).
+   * @return the set of paths to all discovered dependencies.
+   * @throws DependencyResolutionException if resolution fails.
+   */
+  public Set<Path> resolveDependencies(
+      BasicMavenCoordinate coordinate,
+      Collection<String> scopes
+  ) throws DependencyResolutionException {
+    try {
+      var results = new HashSet<Path>();
+      results.add(resolveArtifact(coordinate));
+
+      LOGGER.info("Resolving dependencies of {} from Maven repositories", coordinate);
+
+      var request = new DefaultProjectBuildingRequest(mavenSession.getProjectBuildingRequest());
+      var scopeFilter = new ScopeFilter(scopes, null);
+
+      for (var result : dependencyResolver.resolveDependencies(request, coordinate, scopeFilter)) {
+        var path = result.getArtifact().getFile().toPath();
+        LOGGER.trace("Resolved '{}' to '{}'", result.getArtifact(), path);
+        results.add(path);
+      }
+
+      return Collections.unmodifiableSet(results);
+    } catch (DependencyResolverException ex) {
+      throw new DependencyResolutionException(
+          "Failed to resolve " + coordinate + " and dependencies from Maven repositories",
+          ex
+      );
+    }
+  }
+}

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/MavenCoordinate.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/MavenCoordinate.java
@@ -26,7 +26,7 @@ import org.jspecify.annotations.Nullable;
  *
  * @author Ashley Scopes
  */
-public final class BasicMavenCoordinate implements ArtifactCoordinate, DependableCoordinate {
+public final class MavenCoordinate implements ArtifactCoordinate, DependableCoordinate {
 
   private static final Pattern COORDINATE_PATTERN = Pattern.compile(
       "mvn:(?<groupId>[^:]+)"
@@ -51,7 +51,7 @@ public final class BasicMavenCoordinate implements ArtifactCoordinate, Dependabl
    * @param type the artifact type, or {@code null} to use the default.
    * @param classifier the classifier, or {@code null} if not applicable.
    */
-  public BasicMavenCoordinate(
+  public MavenCoordinate(
       String groupId,
       String artifactId,
       String version,
@@ -158,13 +158,13 @@ public final class BasicMavenCoordinate implements ArtifactCoordinate, Dependabl
    * @throws DependencyResolutionException if the coordinate could not be parsed due to a syntax
    *                                       error.
    */
-  public static BasicMavenCoordinate parse(String id) throws DependencyResolutionException {
+  public static MavenCoordinate parse(String id) throws DependencyResolutionException {
     var matcher = COORDINATE_PATTERN.matcher(id);
     if (!matcher.matches()) {
       throw new DependencyResolutionException("Failed to parse artifact coordinate '" + id + "'");
     }
 
-    return new BasicMavenCoordinate(
+    return new MavenCoordinate(
         matcher.group("groupId"),
         matcher.group("artifactId"),
         matcher.group("version"),

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/MavenExecutableResolver.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/MavenExecutableResolver.java
@@ -21,10 +21,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.HashSet;
-import org.apache.maven.execution.MavenSession;
-import org.apache.maven.project.DefaultProjectBuildingRequest;
-import org.apache.maven.shared.transfer.artifact.resolve.ArtifactResolver;
-import org.apache.maven.shared.transfer.artifact.resolve.ArtifactResolverException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,18 +33,15 @@ public final class MavenExecutableResolver {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(MavenExecutableResolver.class);
 
-  private final ArtifactResolver artifactResolver;
-  private final MavenSession mavenSession;
+  private final MavenArtifactResolver artifactResolver;
 
   /**
    * Initialise the resolver.
    *
    * @param artifactResolver  the artifact resolver to use.
-   * @param mavenSession      the Maven session to use.
    */
-  public MavenExecutableResolver(ArtifactResolver artifactResolver, MavenSession mavenSession) {
+  public MavenExecutableResolver(MavenArtifactResolver artifactResolver) {
     this.artifactResolver = artifactResolver;
-    this.mavenSession = mavenSession;
   }
 
   /**
@@ -60,24 +53,8 @@ public final class MavenExecutableResolver {
    * @throws DependencyResolutionException if resolution fails for any reason.
    */
   public Path resolve(Executable executable, String version) throws DependencyResolutionException {
-    Path path;
-
     var coordinate = executable.getMavenArtifactCoordinate(version);
-
-    try {
-      var request = new DefaultProjectBuildingRequest(mavenSession.getProjectBuildingRequest());
-
-      LOGGER.info("Resolving {} from Maven repositories", coordinate);
-
-      var result = artifactResolver.resolveArtifact(request, coordinate);
-      path = result.getArtifact().getFile().toPath();
-
-    } catch (ArtifactResolverException ex) {
-      throw new DependencyResolutionException(
-          "Failed to resolve " + coordinate + " from Maven repositories",
-          ex
-      );
-    }
+    var path = artifactResolver.resolveArtifact(coordinate);
 
     LOGGER.info("Resolved {} to local path '{}'", coordinate, path);
 

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/ProtoSourceResolver.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/ProtoSourceResolver.java
@@ -74,7 +74,7 @@ public final class ProtoSourceResolver {
     if (!Files.isRegularFile(file)) {
       return false;
     }
-    
+
     var fileName = file.getFileName().toString();
     var periodIndex = fileName.lastIndexOf('.');
 

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/execute/ProtocArgumentBuilder.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/execute/ProtocArgumentBuilder.java
@@ -61,7 +61,7 @@ public final class ProtocArgumentBuilder {
    * @param directories the directories to include.
    * @return this builder.
    */
-  public ProtocArgumentBuilder includeDirectories(Collection<Path> directories) {
+  public ProtocArgumentBuilder protoPaths(Collection<Path> directories) {
     for (var directory : directories) {
       arguments.add("--proto_path=" + directory);
     }

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/generate/SourceGenerator.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/generate/SourceGenerator.java
@@ -19,7 +19,7 @@ import static java.util.Objects.requireNonNull;
 import static java.util.Optional.ofNullable;
 
 import io.github.ascopes.protobufmavenplugin.dependencies.ArchiveExtractor;
-import io.github.ascopes.protobufmavenplugin.dependencies.BasicMavenCoordinate;
+import io.github.ascopes.protobufmavenplugin.dependencies.MavenCoordinate;
 import io.github.ascopes.protobufmavenplugin.dependencies.DependencyResolutionException;
 import io.github.ascopes.protobufmavenplugin.dependencies.Executable;
 import io.github.ascopes.protobufmavenplugin.dependencies.MavenArtifactResolver;
@@ -169,7 +169,7 @@ public final class SourceGenerator {
 
       for (var additionalImport : additionalImports) {
         if (additionalImport.startsWith("mvn:")) {
-          var coordinate = BasicMavenCoordinate.parse(additionalImport);
+          var coordinate = MavenCoordinate.parse(additionalImport);
           additionalImportPaths.addAll(resolveAdditionalImport(coordinate));
         } else {
           additionalImportPaths.add(Path.of(additionalImport));
@@ -184,7 +184,7 @@ public final class SourceGenerator {
   }
 
   private Collection<Path> resolveAdditionalImport(
-      BasicMavenCoordinate coordinate
+      MavenCoordinate coordinate
   ) throws DependencyResolutionException, IOException {
     var processingDirectory = createProcessingDirectory("imports");
 

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/generate/SourceGeneratorBuilder.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/generate/SourceGeneratorBuilder.java
@@ -20,6 +20,7 @@ import java.nio.file.Path;
 import java.util.Set;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.shared.transfer.artifact.resolve.ArtifactResolver;
+import org.apache.maven.shared.transfer.dependencies.resolve.DependencyResolver;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -35,10 +36,12 @@ import org.jspecify.annotations.Nullable;
 public final class SourceGeneratorBuilder {
 
   @Nullable ArtifactResolver artifactResolver;
+  @Nullable DependencyResolver dependencyResolver;
   @Nullable MavenSession mavenSession;
   @Nullable String protocVersion;
   @Nullable String grpcPluginVersion;
   @Nullable Set<Path> sourceDirectories;
+  @Nullable Set<String> additionalImports;
   @Nullable Path protobufOutputDirectory;
   @Nullable Path grpcOutputDirectory;
   @Nullable Boolean fatalWarnings;
@@ -61,6 +64,17 @@ public final class SourceGeneratorBuilder {
    */
   public SourceGeneratorBuilder artifactResolver(ArtifactResolver artifactResolver) {
     this.artifactResolver = artifactResolver;
+    return this;
+  }
+
+  /**
+   * Set the dependency resolver.
+   *
+   * @param dependencyResolver the dependency resolver.
+   * @return this builder.
+   */
+  public SourceGeneratorBuilder dependencyResolver(DependencyResolver dependencyResolver) {
+    this.dependencyResolver = dependencyResolver;
     return this;
   }
 
@@ -105,6 +119,20 @@ public final class SourceGeneratorBuilder {
    */
   public SourceGeneratorBuilder sourceDirectories(Set<Path> sourceDirectories) {
     this.sourceDirectories = sourceDirectories;
+    return this;
+  }
+
+  /**
+   * Set the imports to include.
+   *
+   * <p>These should be paths or Maven GAVs ({@code mvn:groupId:artifactId:version[:classifier]}
+   * that point to JAR artifacts.
+   *
+   * @param additionalImports the imports to include.
+   * @return this builder.
+   */
+  public SourceGeneratorBuilder additionalImports(Set<String> additionalImports) {
+    this.additionalImports = additionalImports;
     return this;
   }
 


### PR DESCRIPTION
New features to add the ability to "import" protobuf sources from other locations, including other JARs and other directories, without including them for compilation.

This allows referencing dependencies in a similar way to how Java manages this, and provides the ability to recursively pull in these imports. This has been done because, as an example, depending on `com.google.api.grpc:proto-google-common-protos` requires protoc to be able to see the protobuf stubs in `com.google.protobuf:protobuf-java` as well.

<details>
  <summary>Example configuration and output</summary>

  ```xml
  <plugin>
    <groupId>${plugin-group-id}</groupId>
    <artifactId>${plugin-artifact-id}</artifactId>
    <version>${plugin-version}</version>
  
    <configuration>
      <additionalImports>
        <additionalImport>mvn:com.google.api.grpc:proto-google-common-protos:2.29.0</additionalImport>
      </additionalImport>
      <protocVersion>${protobuf.version}</protocVersion>
    </configuration>

    <executions>
      <execution>
        <phase>generate-sources</phase>
        <goals>
          <goal>generate</goal>
        </goals>
      </execution>
    </executions>
  </plugin>
  ```
  
  ```log
  [INFO] --- protobuf:0.0.2-SNAPSHOT:generate (default) @ example ---
  [INFO] Resolving mvn:com.google.protobuf:protoc:3.25.0:exe:linux-x86_64 from Maven repositories
  [INFO] Resolved mvn:com.google.protobuf:protoc:3.25.0:exe:linux-x86_64 to local path '/.../protoc-3.25.0-linux-x86_64.exe'
  [INFO] Resolving mvn:com.google.api.grpc:proto-google-common-protos:2.29.0:jar from Maven repositories
  [INFO] Resolving dependencies of mvn:com.google.api.grpc:proto-google-common-protos:2.29.0:jar from Maven repositories
  [INFO] Extracting contents of '/.../protobuf-java-3.25.1.jar' to /.../target/protobuf-extracted/protobuf-java-3.25.1
  [INFO] Extracting contents of '/.../proto-google-common-protos-2.29.0.jar' to /.../target/protobuf-extracted/proto-google-common-protos-2.29.0
  [INFO] Discovering protobuf sources in /.../src/main/protobuf
  [INFO] Discovered a total of 1 protobuf source(s) to compile
  [INFO] Invoking [/.../protoc-3.25.0-linux-x86_64.exe, --version]
  [INFO] >>> libprotoc 25.0
  [INFO] Protoc completed after 7ms with exit code 0
  [INFO] Invoking [/.../protoc-3.25.0-linux-x86_64.exe, --proto_path=/.../target/protobuf-extracted/protobuf-java-3.25.1, --proto_path=/.../target/protobuf-extracted/proto-google-common-protos-2.29.0, --proto_path=/.../src/main/protobuf, --java_out=/.../target/generated-sources/protobuf, /.../src/main/protobuf/car.proto]
  [INFO] Protoc completed after 3ms with exit code 0
  ```
</details>

This implementation is a work in progress and may not yet be fully functional for certain cases.