### PR TITLE
Support disabling default Java code generation

### DIFF
--- a/src/main/java/io/github/ascopes/protobufmavenplugin/AbstractGenerateMojo.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/AbstractGenerateMojo.java
@@ -147,7 +147,20 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
   private boolean fatalWarnings;
 
   /**
+   * Whether to generate default Java source code.
+   *
+   * <p>Defaults to true, although some users may wish to disable this if using
+   * an alternative plugin instead.
+   *
+   * @since 0.1.1
+   */
+  @Parameter(defaultValue = "true")
+  private boolean javaEnabled;
+
+  /**
    * Whether to also generate Kotlin API wrapper code around the generated Java code.
+   *
+   * <p>Note that this requires {@code javaEnabled} to also be {@code true}, otherwise compilation may fail.
    *
    * @since 0.1.0
    */
@@ -183,6 +196,7 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
         .addAllAllowedDependencyScopes(allowedScopes())
         .addAllSourceRoots(actualSourceDirectories)
         .isFatalWarnings(fatalWarnings)
+        .isJavaEnabled(javaEnabled)
         .isKotlinEnabled(kotlinEnabled)
         .isLiteEnabled(liteOnly)
         .mavenSession(session)

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/generate/GenerationRequest.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/generate/GenerationRequest.java
@@ -47,6 +47,8 @@ public interface GenerationRequest {
 
   boolean isFatalWarnings();
 
+  boolean isJavaEnabled();
+
   boolean isKotlinEnabled();
 
   boolean isLiteEnabled();

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/generate/SourceCodeGenerator.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/generate/SourceCodeGenerator.java
@@ -78,8 +78,11 @@ public final class SourceCodeGenerator {
         .fatalWarnings(request.isFatalWarnings())
         .importPaths(importPaths)
         .importPaths(request.getSourceRoots())
-        .plugins(plugins, request.getOutputDirectory())
-        .javaOut(request.getOutputDirectory(), request.isLiteEnabled());
+        .plugins(plugins, request.getOutputDirectory());
+
+    if (request.isJavaEnabled()) {
+      argLineBuilder.javaOut(request.getOutputDirectory(), request.isLiteEnabled());
+    }
 
     if (request.isKotlinEnabled()) {
       argLineBuilder.kotlinOut(request.getOutputDirectory(), request.isLiteEnabled());


### PR DESCRIPTION
Add support for disabling the default Java outputs. This allows replacing Java generation with a different third party implementation if desired.