### PR TITLE
GH-19: Disallow output directories with .jar extensions

### DIFF
--- a/src/main/java/io/github/ascopes/protobufmavenplugin/AbstractGenerateMojo.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/AbstractGenerateMojo.java
@@ -311,6 +311,14 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    * @throws InvalidArgumentException if any parameters are invalid.
    */
   protected void validate() {
+    if (protocVersion.equalsIgnoreCase("latest")) {
+      throw new IllegalArgumentException(
+         "Cannot use LATEST for the protoc version. "
+             + "Google has not released linear versions in the past, meaning that "
+             + "using LATEST will have unexpected behaviour."
+      );
+    }
+
     if (binaryPlugins != null) {
       binaryPlugins.forEach(Plugin::validate);
     }

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/AbstractGenerateMojo.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/AbstractGenerateMojo.java
@@ -311,7 +311,9 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    * @throws InvalidArgumentException if any parameters are invalid.
    */
   protected void validate() {
-    binaryPlugins.forEach(Plugin::validate);
+    if (binaryPlugins != null) {
+      binaryPlugins.forEach(Plugin::validate);
+    }
 
     // Having .jar on the output directory makes protoc generate a JAR with a
     // Manifest. This will break our logic because generated sources will be

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/Plugin.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/Plugin.java
@@ -63,4 +63,25 @@ public final class Plugin {
   public Optional<String> getExecutableName() {
     return Optional.ofNullable(executableName);
   }
+
+  /**
+   * Ensure the model is valid.
+   *
+   * @throws IllegalArgumentException if the model is invalid.
+   */
+  public void validate() {
+    if (artifact == null && executableName == null) {
+      throw new IllegalArgumentException(
+          "You must provide one of `artifact' or `executableName' in a "
+              + "binary plugin declaration."
+      );
+    }
+
+    if (artifact != null && executableName != null) {
+      throw new IllegalArgumentException(
+          "You must not provide both `artifact' and `executableName' in "
+              + " a binary plugin declaration."
+      );
+    }
+  }
 }

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/dependency/BinaryPluginResolver.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/dependency/BinaryPluginResolver.java
@@ -89,14 +89,12 @@ public final class BinaryPluginResolver {
       }
     }
 
-    if (pluginBean.getExecutableName().isPresent()) {
-      var executableName = pluginBean.getExecutableName().get();
-      return systemPathResolver.resolve(executableName)
+    // At this point, we know this will be present, since we validated this
+    // earlier. Use orElseThrow to avoid a useless compiler warning.
+    var executableName = pluginBean.getExecutableName().orElseThrow();
+    return systemPathResolver.resolve(executableName)
           .orElseThrow(() -> new ResolutionException("No executable '"
               + executableName + "' was found on the system path"));
-    }
-
-    throw new ResolutionException("Invalid protoc plugin definition");
   }
 
   private ArtifactCoordinate enrich(ArtifactCoordinate coordinate) {
@@ -104,12 +102,14 @@ public final class BinaryPluginResolver {
     // annoying and the opposite of what we actually want to happen. If we pass a JAR
     // here, then explicitly swap it out with null as this is *never* what we want to
     // happen here.
-    var extension = coordinate.getExtension().equals("jar") ? null : coordinate.getExtension();
+    var extension = coordinate.getExtension().equals("jar")
+        ? null
+        : coordinate.getExtension();
 
     return platformDependencyFactory.createArtifact(
         coordinate.getGroupId(),
         coordinate.getArtifactId(),
-        coordinate.getVersion(),        
+        coordinate.getVersion(),
         extension,
         coordinate.getClassifier()
     );

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/generate/SourceCodeGenerator.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/generate/SourceCodeGenerator.java
@@ -85,7 +85,7 @@ public final class SourceCodeGenerator {
       log.info("No protobuf sources found; nothing to do!");
       return true;
     }
-    
+
     createOutputDirectories(request);
 
     var argLineBuilder = new ArgLineBuilder(protocPath)


### PR DESCRIPTION
Provides a better validation mechanism and allows rejection of configurations that would make protoc emit a JAR directly and break the build assumptions.

Also validates plugins correctly and validates protocVersion is not LATEST which will have confusing behaviour.

Fixes GH-19.