### PR TITLE
Add ability to detect Termux and warn if detected

### DIFF
--- a/src/main/java/io/github/ascopes/protobufmavenplugin/system/HostSystem.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/system/HostSystem.java
@@ -94,6 +94,11 @@ public final class HostSystem {
     return operatingSystem.toLowerCase(Locale.ROOT).startsWith("windows");
   }
 
+  public boolean isProbablyAndroidTermux() {
+    return isProbablyLinux()
+        && getWorkingDirectory().toString().startsWith("/data/data/com.termux/");
+  }
+
   public Path getWorkingDirectory() {
     return workingDirectory;
   }


### PR DESCRIPTION
Enables emitting a warning if building on Android Termux platforms as the protoc binaries on Maven Central may not work correctly on some devices such as my own.

This warning advises users on how to work around this problem.

Closes GH-65.