### PR TITLE
Allow overriding protoc.version via the commandline properly

### DIFF
--- a/src/main/java/io/github/ascopes/protobufmavenplugin/AbstractGenerateMojo.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/AbstractGenerateMojo.java
@@ -250,7 +250,7 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
         .isLiteEnabled(liteOnly)
         .mavenSession(session)
         .outputDirectory(actualOutputDirectory)
-        .protocVersion(protocVersion)
+        .protocVersion(protocVersion())
         .sourceRootRegistrar(sourceRootRegistrar())
         .build();
 
@@ -336,6 +336,16 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
               "The output directory cannot be a path with a JAR file extension"
           );
         });
+  }
+
+  private String protocVersion() {
+    // Give precedence to overriding the protoc version via the command line
+    // in case the Maven binaries are incompatible with the current system.
+    var overriddenVersion = System.getProperty("protoc.version");
+    if (overriddenVersion != null) {
+      return overriddenVersion;
+    }
+    return protocVersion;
   }
 
   private Collection<Path> parsePaths(@Nullable Collection<String> paths) {

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -57,6 +57,13 @@ and will be output to `target/generated-sources/protobuf`
 (or `target/generated-test-sources/protobuf` for tests). This can be overridden
 in the `configuration` block if needed.
 
+The `protoc` version itself can be set via the `<protocVersion>` configuration parameter
+as shown above, or can be set via the `protoc.version` property in your POM. It may
+optionally be totally overridden on the command line by passing `-Dprotoc.version=xxx`,
+in which case the `<protocVersion>` and `protoc.version` will be ignored. This is done
+to allow users who may have an incompatible system to be able to request a build using
+the `$PATH`-based `protoc` binary on their system (documented later in this page).
+
 ## Dependencies
 
 It is worth noting that you will need to include the `protobuf-java` dependency


### PR DESCRIPTION
Allow overriding protoc.version via the commandline with higher precedence than <protocVersion>.