### PR TITLE
GH-86: Fix exception causes being omitted from Maven output

### DIFF
--- a/src/main/java/io/github/ascopes/protobufmavenplugin/AbstractGenerateMojo.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/AbstractGenerateMojo.java
@@ -264,7 +264,9 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
         throw new MojoExecutionException("Protoc invocation failed");
       }
     } catch (ResolutionException | IOException ex) {
-      throw new MojoFailureException(this, ex.getMessage(), ex.getMessage());
+      var mojoFailureException = new MojoFailureException(this, ex.getMessage(), ex.getMessage());
+      mojoFailureException.initCause(ex);
+      throw mojoFailureException;
     }
   }
 

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/source/ProtoSourceResolver.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/source/ProtoSourceResolver.java
@@ -95,8 +95,10 @@ public final class ProtoSourceResolver implements AutoCloseable {
     }
 
     if (!exceptions.isEmpty()) {
+      var causeIterator = exceptions.iterator();
       var ex = new IOException("Failed to create listings asynchronously");
-      exceptions.forEach(ex::addSuppressed);
+      ex.initCause(causeIterator.next());
+      causeIterator.forEachRemaining(ex::addSuppressed);
       throw ex;
     }
 


### PR DESCRIPTION
Update exception handling to report causes correctly to Maven logs when running with `mvn -e`.

Fixes GH-86.