### PR TITLE
GH-85: Do not crash if source roots are missing

### DIFF
--- a/src/it/test-java-main-empty/invoker.properties
+++ b/src/it/test-java-main-empty/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = clean package

--- a/src/it/test-java-main-empty/pom.xml
+++ b/src/it/test-java-main-empty/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2023 - 2024, Ashley Scopes.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.example</groupId>
+  <artifactId>example</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+
+  <properties>
+    <protobuf.version>3.25.1</protobuf.version>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>${plugin-group-id}</groupId>
+        <artifactId>${plugin-artifact-id}</artifactId>
+        <version>${plugin-version}</version>
+
+        <configuration>
+          <protocVersion>${protobuf.version}</protocVersion>
+        </configuration>
+
+        <executions>
+          <execution>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/test-java-test-empty/invoker.properties
+++ b/src/it/test-java-test-empty/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = clean package

--- a/src/it/test-java-test-empty/pom.xml
+++ b/src/it/test-java-test-empty/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2023 - 2024, Ashley Scopes.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.example</groupId>
+  <artifactId>example</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+
+  <properties>
+    <protobuf.version>3.25.1</protobuf.version>
+
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>${plugin-group-id}</groupId>
+        <artifactId>${plugin-artifact-id}</artifactId>
+        <version>${plugin-version}</version>
+
+        <configuration>
+          <protocVersion>${protobuf.version}</protocVersion>
+        </configuration>
+
+        <executions>
+          <execution>
+            <goals>
+              <goal>generate-test</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/source/ProtoSourceResolver.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/source/ProtoSourceResolver.java
@@ -106,6 +106,11 @@ public final class ProtoSourceResolver implements AutoCloseable {
   }
 
   public Optional<ProtoFileListing> createProtoFileListing(Path path) throws IOException {
+    if (!Files.exists(path)) {
+      log.debug("Skipping lookup in path {} as it does not exist", path);
+      return Optional.empty();
+    }
+
     if (Files.isRegularFile(path)) {
       return protoArchiveExtractor.extractProtoFiles(path);
     }


### PR DESCRIPTION
Fixes a bug where the plugin would crash if the directory for protobuf source roots did not exist. 

The plugin will now emit a message saying that no sources are found, and then exit successfully.

This prevents build failures if the plugin is accidentally inherited from a parent POM into a project that lacks any source roots.

Fixes GH-85.