### PR TITLE
Add new job to run CI against prerequisite Maven version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    name: Build (Java ${{ matrix.java-version }} on ${{ matrix.os-name }})
+    name: Build (jdk-${{ matrix.java-version }}/${{ matrix.os-name }}/project-maven-version)
     runs-on: ${{ matrix.os-name }}
 
     strategy:
@@ -41,6 +41,38 @@ jobs:
           java-version: ${{ matrix.java-version }}
           distribution: 'temurin'
           cache: maven
+
+      - name: Build and test
+        shell: bash
+        run: ./mvnw -B verify
+
+      - name: Publish code coverage
+        uses: codecov/codecov-action@v3
+        continue-on-error: true
+        if: always()
+
+  build-oldest-maven:
+    name: Build (jdk-11/ubuntu-latest/prereq-maven-version)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
+        with:
+          java-version: 11
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Change Maven version to the prerequisite version
+        shell: bash
+        run: |-
+          version=$(./mvnw help:evaluate -q \
+              -Dexpression='project.prerequisites.maven' \
+              -DforceStdout)
+          ./mvnw wrapper:wrapper -Dmaven="${version}"
 
       - name: Build and test
         shell: bash

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
   <packaging>maven-plugin</packaging>
 
   <prerequisites>
-    <maven>3.8.0</maven>
+    <maven>3.8.1</maven>
   </prerequisites>
 
   <inceptionYear>2023</inceptionYear>

--- a/src/it/invoker.properties
+++ b/src/it/invoker.properties
@@ -2,5 +2,8 @@ invoker.mavenOpts = \
   -Dplugin-group-id=${project.groupId} \
   -Dplugin-artifact-id=${project.artifactId} \
   -Dplugin-version=${project.version} \
+  -Dmaven.compiler.release=11 \
+  -Dmaven.compiler.source=11 \
+  -Dmaven.compiler.target=11 \
   ${invoker.mavenOpts}
 invoker.quiet = false


### PR DESCRIPTION
This enables builds to verify that the prerequisite minimum Maven version is in fact compatible with the codebase.

I have also adjusted the minimum Maven version that is supported from 3.8.0 to
3.8.1, since 3.8.0 is not available at
https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/