### PR TITLE
GH-79: Handle special characters in shell scripts better

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -17,6 +17,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master
+        with:
+          check_together: 'yes'
+          scandir: './scripts'
+
       - name: Validate codecov.yml
         shell: bash
         run: curl -vvv --fail --data-binary @- https://codecov.io/validate < codecov.yml

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/platform/Shlex.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/platform/Shlex.java
@@ -46,6 +46,7 @@ public final class Shlex {
     var iter = args.iterator();
 
     if (!iter.hasNext()) {
+      // Probably won't ever happen.
       return "";
     }
 
@@ -102,7 +103,6 @@ public final class Shlex {
         case '%':
           sb.append("%%");
           break;
-
         case '\\':
         case '"':
         case '\'':
@@ -114,8 +114,8 @@ public final class Shlex {
         case '<':
         case '>':
         case '|':
-          sb.append('^');
-          // Fall through...
+          sb.append('^').append(c);
+          break;
         default:
           sb.append(c);
           break;

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/platform/Shlex.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/platform/Shlex.java
@@ -22,6 +22,10 @@ import java.util.function.BiConsumer;
  *
  * <p>Losely based on Python's {@code shlex} module.
  *
+ * <p>This is far from perfect but should work in the majority of use cases
+ * to ensure scripts do not interpret special characters in paths in strange
+ * and unexpected ways.
+ *
  * @author Ashley Scopes
  */
 public final class Shlex {
@@ -65,10 +69,22 @@ public final class Shlex {
     sb.append('\'');
     for (var i = 0; i < arg.length(); ++i) {
       var c = arg.charAt(i);
-      if (c == '\'') {
-        sb.append("'\"'\"'");
-      } else {
-        sb.append(c);
+      switch (c) {
+        case '\'':
+          sb.append("'\"'\"'");
+          break;
+        case '\n':
+          sb.append("'$'\\n''");
+          break;
+        case '\r':
+          sb.append("'$'\\r''");
+          break;
+        case '\t':
+          sb.append("'$'\\t''");
+          break;
+        default:
+          sb.append(c);
+          break;
       }
     }
     sb.append('\'');
@@ -83,6 +99,10 @@ public final class Shlex {
     for (var i = 0; i < arg.length(); ++i) {
       var c = arg.charAt(i);
       switch (c) {
+        case '%':
+          sb.append("%%");
+          break;
+
         case '\\':
         case '"':
         case '\'':
@@ -95,9 +115,11 @@ public final class Shlex {
         case '>':
         case '|':
           sb.append('^');
+          // Fall through...
+        default:
+          sb.append(c);
+          break;
       }
-
-      sb.append(c);
     }
   }
 

--- a/src/test/java/io/github/ascopes/protobufmavenplugin/platform/ShlexTest.java
+++ b/src/test/java/io/github/ascopes/protobufmavenplugin/platform/ShlexTest.java
@@ -81,7 +81,10 @@ class ShlexTest {
         arguments(list("\\"), "'\\'"),
         arguments(list("\""), "'\"'"),
         arguments(list("po'tato"), "'po'\"'\"'tato'"),
-        arguments(list("'potato'"), "''\"'\"'potato'\"'\"''")
+        arguments(list("'potato'"), "''\"'\"'potato'\"'\"''"),
+        arguments(list("foo\nbar", "baz"), "'foo'$'\\n''bar' baz"),
+        arguments(list("foo\rbar", "baz"), "'foo'$'\\r''bar' baz"),
+        arguments(list("foo\tbar", "baz"), "'foo'$'\\t''bar' baz")
     );
   }
 
@@ -110,7 +113,8 @@ class ShlexTest {
         arguments(list("&"), "^&"),
         arguments(list("<"), "^<"),
         arguments(list(">"), "^>"),
-        arguments(list("|"), "^|")
+        arguments(list("|"), "^|"),
+        arguments(list("100% complete", "0% incomplete"), "100%%^ complete 0%%^ incomplete")
     );
   }
 


### PR DESCRIPTION
- Handle \r \n and \t in shell scripts.
- Handle % in batch scripts.

Fixes GH-79.