### PR TITLE
Add the ability to skip registration as a compiler source root

### DIFF
--- a/src/main/java/io/github/ascopes/protobufmavenplugin/AbstractGenerateMojo.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/AbstractGenerateMojo.java
@@ -263,6 +263,19 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
   private boolean liteOnly;
 
   /**
+   * Whether to register the output directories as compilation roots with
+   * Maven.
+   *
+   * <p>Generally, you want to do this, but there may be edge cases where you
+   * wish to control this behaviour manually instead. In this case, set this
+   * parameter to be {@code false}.
+   *
+   * @since 0.5.0
+   */
+  @Parameter(defaultValue = "true")
+  private boolean registerAsCompilationRoot;
+
+  /**
    * Execute the plugin and generate sources.
    *
    * @throws MojoExecutionException if execution fails.
@@ -287,6 +300,7 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
         .isJavaEnabled(javaEnabled)
         .isKotlinEnabled(kotlinEnabled)
         .isLiteEnabled(liteOnly)
+        .isRegisterAsCompilationRoot(registerAsCompilationRoot)
         .mavenSession(session)
         .outputDirectory(requireNonNullElseGet(
             outputDirectory, () -> defaultOutputDirectory(session)

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/generate/GenerationRequest.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/generate/GenerationRequest.java
@@ -61,4 +61,6 @@ public interface GenerationRequest {
   boolean isKotlinEnabled();
 
   boolean isLiteEnabled();
+
+  boolean isRegisterAsCompilationRoot();
 }

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/generate/SourceCodeGenerator.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/generate/SourceCodeGenerator.java
@@ -178,12 +178,16 @@ public final class SourceCodeGenerator {
 
   private void createOutputDirectories(GenerationRequest request) throws IOException {
     var directory = request.getOutputDirectory();
-    var registrar = request.getSourceRootRegistrar();
-
-    log.info("Creating {} and registering as a {} root", directory, registrar);
-
+    log.debug("Creating {}", directory);
     Files.createDirectories(directory);
-    registrar.registerSourceRoot(request.getMavenSession(), directory);
+
+    if (request.isRegisterAsCompilationRoot()) {
+      var registrar = request.getSourceRootRegistrar();
+      log.debug("Registering {} as {} compilation root", directory, registrar);
+      registrar.registerSourceRoot(request.getMavenSession(), directory);
+    } else {
+      log.debug("Not registering {} as a compilation root", directory);
+    }
   }
 
   @SafeVarargs


### PR DESCRIPTION
Allow users to disable the registration of output directories as compiler source roots, should special edge cases come along that require this.