### PR TITLE
Default to failing on missing sources.

### DIFF
--- a/src/it/java-main-empty/pom.xml
+++ b/src/it/java-main-empty/pom.xml
@@ -38,6 +38,7 @@
         <version>@project.version@</version>
 
         <configuration>
+          <failOnMissingSources>false</failOnMissingSources>
           <protocVersion>${protobuf.version}</protocVersion>
         </configuration>
 

--- a/src/it/java-test-empty/pom.xml
+++ b/src/it/java-test-empty/pom.xml
@@ -39,6 +39,7 @@
         <version>@project.version@</version>
 
         <configuration>
+          <failOnMissingSources>false</failOnMissingSources>
           <protocVersion>${protobuf.version}</protocVersion>
         </configuration>
 

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/AbstractGenerateMojo.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/AbstractGenerateMojo.java
@@ -217,6 +217,20 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
   private @Nullable Path outputDirectory;
 
   /**
+   * Whether to fail on missing sources.
+   *
+   * <p>If no sources are detected, it is usually a sign that this plugin
+   * is misconfigured, or that you are including this plugin in a project
+   * that does not need it. For this reason, the plugin defaults this setting
+   * to being enabled. If you wish to not fail, you can explicitly set this
+   * to false instead.
+   *
+   * @since 0.5.0
+   */
+  @Parameter(defaultValue = "true")
+  private boolean failOnMissingSources;
+
+  /**
    * Specify that any warnings emitted by {@code protoc} should be treated as errors and fail the
    * build.
    *
@@ -291,11 +305,12 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
 
     var request = ImmutableGenerationRequest.builder()
         .additionalImportPaths(nonNullList(additionalImportPaths))
+        .allowedDependencyScopes(allowedScopes())
         .binaryMavenPlugins(nonNullList(binaryMavenPlugins))
         .binaryPathPlugins(nonNullList(binaryPathPlugins))
         .binaryUrlPlugins(nonNullList(binaryUrlPlugins))
         .jvmMavenPlugins(nonNullList(jvmMavenPlugins))
-        .allowedDependencyScopes(allowedScopes())
+        .isFailOnMissingSources(failOnMissingSources)
         .isFatalWarnings(fatalWarnings)
         .isJavaEnabled(javaEnabled)
         .isKotlinEnabled(kotlinEnabled)

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/generate/GenerationRequest.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/generate/GenerationRequest.java
@@ -54,6 +54,8 @@ public interface GenerationRequest {
 
   SourceRootRegistrar getSourceRootRegistrar();
 
+  boolean isFailOnMissingSources();
+
   boolean isFatalWarnings();
 
   boolean isJavaEnabled();

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/generate/SourceCodeGenerator.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/generate/SourceCodeGenerator.java
@@ -83,11 +83,14 @@ public final class SourceCodeGenerator {
     var sourcePaths = discoverCompilableSources(request);
 
     if (sourcePaths.isEmpty()) {
-      // We might want to add the ability to throw an error here in the future.
-      // For now, let's just avoid doing additional work. This also prevents protobuf
-      // failing because we provided no sources to it.
-      log.info("No protobuf sources found; nothing to do!");
-      return true;
+      if (request.isFailOnMissingSources()) {
+        log.error("No protobuf sources found. If this is unexpected, check your "
+            + "configuration and try again.");
+        return false;
+      } else {
+        log.info("No protobuf sources found; nothing to do!");
+        return true;
+      }
     }
 
     createOutputDirectories(request);


### PR DESCRIPTION
Set the default behaviour to fail the build if no sources are found to compile by protoc. This enables detecting faulty plugin configuration.

Added a new parameter to allow reverting this behaviour.