### PR TITLE
Add support for additional languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ A simple and modern Maven plugin to generate source code from protobuf definitio
 - Importing of `*.proto` sources from classpath dependencies.
 - Ready to implement Maven 4 support once Maven 4 is stable, meaning your projects will not be blocked by unmaintained plugins using
   unsupported Maven 2.x APIs.
+- Additional support for generating sources targeting C++, C#, Objective C, Python (with and without static typechecking stubs),
+  PHP, Ruby, and Rust.
 
 ## Usage
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>io.github.ascopes</groupId>
   <artifactId>protobuf-maven-plugin</artifactId>
-  <version>1.0.1-SNAPSHOT</version>
+  <version>1.1.0-SNAPSHOT</version>
 
   <name>Protobuf Maven Plugin</name>
   <description>Generates compilable sources from Protobuf definitions.</description>

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/AbstractGenerateMojo.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/AbstractGenerateMojo.java
@@ -242,7 +242,7 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
   private boolean fatalWarnings;
 
   /**
-   * Specify whether to generate default Java sources from the protobuf sources.
+   * Enable generating Java sources from the protobuf sources.
    *
    * <p>Defaults to {@code true}, although some users may wish to disable this
    * if using an alternative plugin that covers generating the code for models instead.
@@ -253,15 +253,87 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
   private boolean javaEnabled;
 
   /**
-   * Whether to also generate Kotlin API wrapper code around the generated Java code.
+   * Enable generating Kotlin API wrapper code around the generated Java code.
    *
-   * <p>Note that this may require {@code javaEnabled} to also be {@code true}, otherwise compilation
+   * <p>This may require {@code javaEnabled} to also be {@code true}, otherwise compilation
    * may fail unless other sources are generated to replace the expected Java ones.
    *
    * @since 0.1.0
    */
   @Parameter(defaultValue = "false")
   private boolean kotlinEnabled;
+
+  /**
+   * Enable generating Python sources from the protobuf sources.
+   *
+   * <p>If you enable this, you probably will also want to enable Python stubs
+   * to enable generating {@code *.pyi} files for static type checkers.
+   *
+   * @since 1.1.0
+   */
+  @Parameter(defaultValue = "false")
+  private boolean pythonEnabled;
+
+  /**
+   * Enable generating Python stubs ({@code *.pyi} files) for static typechecking
+   * from the protobuf sources.
+   *
+   * <p>If you enable this, you probably will also want to enable Python itself
+   * to get actual source code
+   * to accompany the stubs.
+   *
+   * @since 1.1.0
+   */
+  @Parameter(defaultValue = "false")
+  private boolean pythonStubsEnabled;
+
+  /**
+   * Enable generating Ruby sources from the protobuf sources.
+   *
+   * @since 1.1.0
+   */
+  @Parameter(defaultValue = "false")
+  private boolean rubyEnabled;
+
+  /**
+   * Enable generating C++ sources from the protobuf sources.
+   *
+   * @since 1.1.0
+   */
+  @Parameter(defaultValue = "false")
+  private boolean cppEnabled;
+
+  /**
+   * Enable generating C# sources from the protobuf sources.
+   *
+   * @since 1.1.0
+   */
+  @Parameter(defaultValue = "false")
+  private boolean csharpEnabled;
+
+  /**
+   * Enable generating Rust sources from the protobuf sources.
+   *
+   * @since 1.1.0
+   */
+  @Parameter(defaultValue = "false")
+  private boolean rustEnabled;
+
+  /**
+   * Enable generating Objective C sources from the protobuf sources.
+   *
+   * @since 1.1.0
+   */
+  @Parameter(defaultValue = "false")
+  private boolean objcEnabled;
+
+  /**
+   * Enable generating PHP sources from the protobuf sources.
+   *
+   * @since 1.1.0
+   */
+  @Parameter(defaultValue = "false")
+  private boolean phpEnabled;
 
   /**
    * Whether to only generate "lite" messages or not.
@@ -310,12 +382,20 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
         .binaryPathPlugins(nonNullList(binaryPathPlugins))
         .binaryUrlPlugins(nonNullList(binaryUrlPlugins))
         .jvmMavenPlugins(nonNullList(jvmMavenPlugins))
+        .isCppEnabled(cppEnabled)
+        .isCsharpEnabled(csharpEnabled)
         .isFailOnMissingSources(failOnMissingSources)
         .isFatalWarnings(fatalWarnings)
         .isJavaEnabled(javaEnabled)
         .isKotlinEnabled(kotlinEnabled)
         .isLiteEnabled(liteOnly)
+        .isObjcEnabled(objcEnabled)
+        .isPhpEnabled(phpEnabled)
+        .isPythonEnabled(pythonEnabled)
+        .isPythonStubsEnabled(pythonStubsEnabled)
         .isRegisterAsCompilationRoot(registerAsCompilationRoot)
+        .isRubyEnabled(rubyEnabled)
+        .isRustEnabled(rustEnabled)
         .mavenSession(session)
         .outputDirectory(requireNonNullElseGet(
             outputDirectory, () -> defaultOutputDirectory(session)

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/execute/ArgLineBuilder.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/execute/ArgLineBuilder.java
@@ -37,6 +37,14 @@ public final class ArgLineBuilder {
     outputTargetCount = 0;
   }
 
+  public ArgLineBuilder cppOut(Path outputPath, boolean lite) {
+    return langOut("cpp", outputPath, lite);
+  }
+
+  public ArgLineBuilder csharpOut(Path outputPath, boolean lite) {
+    return langOut("csharp", outputPath, lite);
+  }
+
   public List<String> compile(Collection<Path> sourcesToCompile) {
     if (outputTargetCount == 0) {
       throw new IllegalStateException("No output targets were provided");
@@ -73,6 +81,14 @@ public final class ArgLineBuilder {
     return langOut("kotlin", outputPath, lite);
   }
 
+  public ArgLineBuilder objcOut(Path outputPath, boolean lite) {
+    return langOut("objc", outputPath, lite);
+  }
+
+  public ArgLineBuilder phpOut(Path outputPath, boolean lite) {
+    return langOut("php", outputPath, lite);
+  }
+
   public ArgLineBuilder plugins(Collection<ResolvedPlugin> plugins, Path outputPath) {
     for (var plugin : plugins) {
       // protoc always maps a flag `--xxx_out` to a plugin named `protoc-gen-xxx`, so we have
@@ -82,6 +98,22 @@ public final class ArgLineBuilder {
       args.add("--" + plugin.getId() + "_out=" + outputPath);
     }
     return this;
+  }
+
+  public ArgLineBuilder pyiOut(Path outputPath, boolean lite) {
+    return langOut("pyi", outputPath, lite);
+  }
+
+  public ArgLineBuilder pythonOut(Path outputPath, boolean lite) {
+    return langOut("python", outputPath, lite);
+  }
+
+  public ArgLineBuilder rubyOut(Path outputPath, boolean lite) {
+    return langOut("ruby", outputPath, lite);
+  }
+
+  public ArgLineBuilder rustOut(Path outputPath, boolean lite) {
+    return langOut("rust", outputPath, lite);
   }
 
   public List<String> version() {

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/generate/GenerationRequest.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/generate/GenerationRequest.java
@@ -54,6 +54,10 @@ public interface GenerationRequest {
 
   SourceRootRegistrar getSourceRootRegistrar();
 
+  boolean isCppEnabled();
+
+  boolean isCsharpEnabled();
+
   boolean isFailOnMissingSources();
 
   boolean isFatalWarnings();
@@ -64,5 +68,17 @@ public interface GenerationRequest {
 
   boolean isLiteEnabled();
 
+  boolean isObjcEnabled();
+
+  boolean isPhpEnabled();
+
+  boolean isPythonEnabled();
+
+  boolean isPythonStubsEnabled();
+
   boolean isRegisterAsCompilationRoot();
+
+  boolean isRubyEnabled();
+
+  boolean isRustEnabled();
 }


### PR DESCRIPTION
This PR adds support for generating C++, Python, pyi, and Ruby sources.

By default, this is not enabled, as most users will not need this.

The functionality has been added to enable working with the GraalVM polyglot platform which allows working with C++, Python, and Ruby as common targets.

Support for PHP, C#, Objective C, and Rust has also been included to provide full coverage across the targets supported by protoc at the time of writing.