### PR TITLE
GH-122: Bump to protoc 4.26.0 from 3.25.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,14 +29,16 @@ jobs:
         run: |-
           set -eux
           case "${{ matrix.os-name }}" in
-            macos-*) brew install protobuf ;;
+            # TODO: uncomment once protoc 4.26.0 is used globally.
+            #macos-*) brew install protobuf ;;
             ubuntu-*) sudo apt -q update && sudo apt -qy install protobuf-compiler ;;
-            windows-*) choco install protoc ;;
+            # TODO: uncomment once protoc 4.26.0 is used globally.
+            #windows-*) choco install protoc ;;
           esac
 
           java -version
           javac -version
-          protoc --version
+          protoc --version || true
 
       - name: Set up JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v4

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A simple and modern Maven plugin to generate source code from protobuf definitio
   <version>${protobuf-maven-plugin.version}</version>
 
   <configuration>
-    <protocVersion>3.25.3</protocVersion>
+    <protocVersion>4.26.0</protocVersion>
 
     <binaryMavenPlugins>
       <binaryMavenPlugin>

--- a/src/it/grpc-plugin/pom.xml
+++ b/src/it/grpc-plugin/pom.xml
@@ -29,7 +29,7 @@
     <grpc.version>1.61.1</grpc.version>
     <javax-annotation-api.version>1.3.2</javax-annotation-api.version>
     <junit.version>5.10.1</junit.version>
-    <protobuf.version>3.25.3</protobuf.version>
+    <protobuf.version>4.26.0</protobuf.version>
 
     <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
     <maven-surefire-plugin.version>3.2.2</maven-surefire-plugin.version>

--- a/src/it/java-main-empty/pom.xml
+++ b/src/it/java-main-empty/pom.xml
@@ -26,7 +26,7 @@
   <version>0.0.1-SNAPSHOT</version>
 
   <properties>
-    <protobuf.version>3.25.3</protobuf.version>
+    <protobuf.version>4.26.0</protobuf.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 

--- a/src/it/java-main-lite/pom.xml
+++ b/src/it/java-main-lite/pom.xml
@@ -27,7 +27,7 @@
 
   <properties>
     <junit.version>5.10.1</junit.version>
-    <protobuf.version>3.25.3</protobuf.version>
+    <protobuf.version>4.26.0</protobuf.version>
 
     <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
     <maven-surefire-plugin.version>3.2.2</maven-surefire-plugin.version>

--- a/src/it/java-main-lite/src/test/java/org/example/helloworld/ProtobufLiteTest.java
+++ b/src/it/java-main-lite/src/test/java/org/example/helloworld/ProtobufLiteTest.java
@@ -20,10 +20,10 @@ import java.util.ArrayList;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class ProtobufTest {
+class ProtobufLiteTest {
 
   @Test
   void generatedProtobufSourcesAreLiteMessages() throws Throwable {
@@ -37,7 +37,9 @@ class ProtobufTest {
     } while (superClass != null);
 
     // Then
-    assertFalse(superClasses.contains("com.google.protobuf.GeneratedMessageV3"));
+    // GeneratedMessageV3 for protobuf-java 3.25.3 and older.
+    // GeneratedMessageLite for protobuf-java 4.26.0 and newer.
+    assertTrue(superClasses.contains("com.google.protobuf.GeneratedMessageLite"));
   }
 
   @Test

--- a/src/it/java-main/pom.xml
+++ b/src/it/java-main/pom.xml
@@ -27,7 +27,7 @@
 
   <properties>
     <junit.version>5.10.1</junit.version>
-    <protobuf.version>3.25.3</protobuf.version>
+    <protobuf.version>4.26.0</protobuf.version>
 
     <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
     <maven-surefire-plugin.version>3.2.2</maven-surefire-plugin.version>

--- a/src/it/java-main/src/test/java/org/example/helloworld/ProtobufTest.java
+++ b/src/it/java-main/src/test/java/org/example/helloworld/ProtobufTest.java
@@ -36,7 +36,9 @@ class ProtobufTest {
     } while (superClass != null);
 
     // Then
-    assertTrue(superClasses.contains("com.google.protobuf.GeneratedMessageV3"));
+    // GeneratedMessageV3 for protobuf-java 3.25.3 and older.
+    // GeneratedMessage for protobuf-java 4.26.0 and newer.
+    assertTrue(superClasses.contains("com.google.protobuf.GeneratedMessage"));
   }
 
   @Test

--- a/src/it/java-test-empty/pom.xml
+++ b/src/it/java-test-empty/pom.xml
@@ -26,7 +26,7 @@
   <version>0.0.1-SNAPSHOT</version>
 
   <properties>
-    <protobuf.version>3.25.3</protobuf.version>
+    <protobuf.version>4.26.0</protobuf.version>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>

--- a/src/it/java-test-lite/pom.xml
+++ b/src/it/java-test-lite/pom.xml
@@ -27,7 +27,7 @@
 
   <properties>
     <junit.version>5.10.1</junit.version>
-    <protobuf.version>3.25.3</protobuf.version>
+    <protobuf.version>4.26.0</protobuf.version>
 
     <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
     <maven-surefire-plugin.version>3.2.2</maven-surefire-plugin.version>

--- a/src/it/java-test-lite/src/test/java/org/example/helloworld/ProtobufLiteTest.java
+++ b/src/it/java-test-lite/src/test/java/org/example/helloworld/ProtobufLiteTest.java
@@ -20,10 +20,10 @@ import java.util.ArrayList;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class ProtobufTest {
+class ProtobufLiteTest {
 
   @Test
   void generatedProtobufSourcesAreLiteMessages() throws Throwable {
@@ -37,7 +37,9 @@ class ProtobufTest {
     } while (superClass != null);
 
     // Then
-    assertFalse(superClasses.contains("com.google.protobuf.GeneratedMessageV3"));
+    // GeneratedMessageV3 for protobuf-java 3.25.3 and older.
+    // GeneratedMessageLite for protobuf-java 4.26.0 and newer.
+    assertTrue(superClasses.contains("com.google.protobuf.GeneratedMessageLite"));
   }
 
   @Test

--- a/src/it/java-test/pom.xml
+++ b/src/it/java-test/pom.xml
@@ -27,7 +27,7 @@
 
   <properties>
     <junit.version>5.10.1</junit.version>
-    <protobuf.version>3.25.3</protobuf.version>
+    <protobuf.version>4.26.0</protobuf.version>
 
     <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
     <maven-surefire-plugin.version>3.2.2</maven-surefire-plugin.version>

--- a/src/it/java-test/src/test/java/org/example/helloworld/ProtobufTest.java
+++ b/src/it/java-test/src/test/java/org/example/helloworld/ProtobufTest.java
@@ -37,7 +37,9 @@ class ProtobufTest {
     } while (superClass != null);
 
     // Then
-    assertTrue(superClasses.contains("com.google.protobuf.GeneratedMessageV3"));
+    // GeneratedMessageV3 for protobuf-java 3.25.3 and older.
+    // GeneratedMessage for protobuf-java 4.26.0 and newer.
+    assertTrue(superClasses.contains("com.google.protobuf.GeneratedMessage"));
   }
 
   @Test

--- a/src/it/kotlin-main/pom.xml
+++ b/src/it/kotlin-main/pom.xml
@@ -28,7 +28,7 @@
   <properties>
     <junit.version>5.10.1</junit.version>
     <kotlin.version>1.9.21</kotlin.version>
-    <protobuf.version>3.25.3</protobuf.version>
+    <protobuf.version>4.26.0</protobuf.version>
 
     <maven-surefire-plugin.version>3.2.2</maven-surefire-plugin.version>
 

--- a/src/it/kotlin-test/pom.xml
+++ b/src/it/kotlin-test/pom.xml
@@ -28,7 +28,7 @@
   <properties>
     <junit.version>5.10.1</junit.version>
     <kotlin.version>1.9.21</kotlin.version>
-    <protobuf.version>3.25.3</protobuf.version>
+    <protobuf.version>4.26.0</protobuf.version>
 
     <maven-surefire-plugin.version>3.2.2</maven-surefire-plugin.version>
 

--- a/src/it/path-protoc/pom.xml
+++ b/src/it/path-protoc/pom.xml
@@ -27,7 +27,7 @@
 
   <properties>
     <junit.version>5.10.2</junit.version>
-    <protobuf.version>3.25.3</protobuf.version>
+    <protobuf.version>4.26.0</protobuf.version>
 
     <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
     <maven-surefire-plugin.version>3.2.2</maven-surefire-plugin.version>

--- a/src/it/path-protoc/pom.xml
+++ b/src/it/path-protoc/pom.xml
@@ -27,7 +27,7 @@
 
   <properties>
     <junit.version>5.10.2</junit.version>
-    <protobuf.version>4.26.0</protobuf.version>
+    <protobuf.version>3.25.0</protobuf.version>
 
     <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
     <maven-surefire-plugin.version>3.2.2</maven-surefire-plugin.version>

--- a/src/it/reactor-grpc-binary-plugin/pom.xml
+++ b/src/it/reactor-grpc-binary-plugin/pom.xml
@@ -29,7 +29,7 @@
     <grpc.version>1.61.1</grpc.version>
     <javax-annotation-api.version>1.3.2</javax-annotation-api.version>
     <junit.version>5.10.1</junit.version>
-    <protobuf.version>3.25.3</protobuf.version>
+    <protobuf.version>4.26.0</protobuf.version>
     <reactor-core.version>3.6.3</reactor-core.version>
     <reactor-grpc.version>1.2.4</reactor-grpc.version>
 

--- a/src/it/reactor-grpc-jvm-plugin/pom.xml
+++ b/src/it/reactor-grpc-jvm-plugin/pom.xml
@@ -29,7 +29,7 @@
     <grpc.version>1.61.1</grpc.version>
     <javax-annotation-api.version>1.3.2</javax-annotation-api.version>
     <junit.version>5.10.1</junit.version>
-    <protobuf.version>3.25.3</protobuf.version>
+    <protobuf.version>4.26.0</protobuf.version>
     <reactor-core.version>3.6.3</reactor-core.version>
     <reactor-grpc.version>1.2.4</reactor-grpc.version>
 

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -51,7 +51,7 @@ do is provide the version of `protoc` to use.
   <version>${protobuf-maven-plugin.version}</version>
 
   <configuration>
-    <protocVersion>3.25.3</protocVersion>
+    <protocVersion>4.26.0</protocVersion>
   </configuration>
 
   <executions>
@@ -93,7 +93,7 @@ like Dependabot to keep the compiler version up-to-date automatically.
   ...
 
   <properties>
-    <protobuf.version>3.25.3</protobuf.version>
+    <protobuf.version>4.26.0</protobuf.version>
     <protobuf-maven-plugin.version>...</protobuf-maven-plugin.version>
   </properties>
 

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -201,6 +201,14 @@ Dependencies are listed as `groupId:artifactId` for brevity. Naming is not
   </tbody>
 </table>
 
+### v4.x versus v3.x
+
+The v4.x versions of the protobuf libraries have breaking changes compared to the v3.x
+versions. This means that using the `protoc` binary corresponding to v4.x will not be
+compatible with libraries using v3.x of the protobuf libraries.
+
+Ensure you are using the correct version for your project and requirements!
+
 ## Importing protobuf definitions from other places
 
 By default, this plugin will index all JARs that are dependencies for the current Maven project,


### PR DESCRIPTION
Protoc 4.26.0 has been released as a breaking change to 3.25.3 where deprecated functionality has been removed.

This fixes builds and updates all tests and examples.

Fixes GH-122.