### PR TITLE
Configure unified artifact coordinate type.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>io.github.ascopes</groupId>
   <artifactId>protobuf-maven-plugin</artifactId>
-  <version>1.1.3-SNAPSHOT</version>
+  <version>1.2.0-SNAPSHOT</version>
 
   <name>Protobuf Maven Plugin</name>
   <description>Generates compilable sources from Protobuf definitions.</description>

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/AbstractGenerateMojo.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/AbstractGenerateMojo.java
@@ -19,6 +19,7 @@ package io.github.ascopes.protobufmavenplugin;
 import static java.util.Objects.requireNonNullElse;
 import static java.util.Objects.requireNonNullElseGet;
 
+import io.github.ascopes.protobufmavenplugin.dependency.MavenArtifact;
 import io.github.ascopes.protobufmavenplugin.dependency.ResolutionException;
 import io.github.ascopes.protobufmavenplugin.generate.ImmutableGenerationRequest;
 import io.github.ascopes.protobufmavenplugin.generate.SourceCodeGenerator;
@@ -39,8 +40,6 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Parameter;
-import org.apache.maven.shared.transfer.artifact.DefaultArtifactCoordinate;
-import org.apache.maven.shared.transfer.dependencies.DefaultDependableCoordinate;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -145,7 +144,7 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    * @since 0.3.0
    */
   @Parameter
-  private @Nullable List<DefaultArtifactCoordinate> binaryMavenPlugins;
+  private @Nullable List<MavenArtifact> binaryMavenPlugins;
 
   /**
    * Binary plugins to use with the protobuf compiler, sourced from the system {@code PATH}.
@@ -218,7 +217,7 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    * @since 0.3.0
    */
   @Parameter
-  private @Nullable List<DefaultDependableCoordinate> jvmMavenPlugins;
+  private @Nullable List<MavenArtifact> jvmMavenPlugins;
 
   /**
    * Override the directory to output generated code to.

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/dependency/MavenArtifact.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/dependency/MavenArtifact.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (C) 2023 - 2024, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.ascopes.protobufmavenplugin.dependency;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.shared.transfer.artifact.ArtifactCoordinate;
+import org.apache.maven.shared.transfer.artifact.DefaultArtifactCoordinate;
+import org.apache.maven.shared.transfer.dependencies.DefaultDependableCoordinate;
+import org.apache.maven.shared.transfer.dependencies.DependableCoordinate;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Implementation independent deacriptor for an artifact or dependency that
+ * can be used in a Maven Plugin parameter.
+ *
+ * @author Ashley Scopes
+ * @since 1.2.0
+ */
+public final class MavenArtifact {
+  private static final Logger log = LoggerFactory.getLogger(MavenArtifact.class);
+
+  private @Nullable String groupId;
+  private @Nullable String artifactId;
+  private @Nullable String version;
+  private @Nullable String classifier;
+  private @Nullable String type;
+
+  public Optional<String> getGroupId() {
+    return Optional.ofNullable(groupId);
+  }
+
+  public void setGroupId(@Nullable String groupId) {
+    this.groupId = groupId;
+  }
+
+  public Optional<String> getArtifactId() {
+    return Optional.ofNullable(artifactId);
+  }
+
+  public void setArtifactId(@Nullable String artifactId) {
+    this.artifactId = artifactId;
+  }
+
+  public Optional<String> getVersion() {
+    return Optional.ofNullable(version);
+  }
+
+  public void setVersion(@Nullable String version) {
+    this.version = version;
+  }
+
+  public Optional<String> getClassifier() {
+    return Optional.ofNullable(classifier);
+  }
+
+  public void setClassifier(@Nullable String classifier) {
+    this.classifier = classifier;
+  }
+
+  public Optional<String> getType() {
+    return Optional.ofNullable(type);
+  }
+
+  public void setType(@Nullable String type) {
+    this.type = type;
+  }
+
+  // Alias to enable compatibility with Dependency objects. This avoids a breaking
+  // change in v1.x.
+  // This should be totally removed in v2.0 to avoid ambiguity.
+  @Deprecated(forRemoval = true, since = "1.2.0")
+  public void setExtension(@Nullable String extension) {
+    log.warn("MavenArtifact.extension is deprecated for removal in v2.0.0. "
+        + "Please use MavenArtifact.type instead for future compatibility.");
+    this.type = extension;
+  }
+
+  @Override
+  public boolean equals(@Nullable Object other) {
+    if (!(other instanceof MavenArtifact)) {
+      return false;
+    }
+
+    var that = (MavenArtifact) other;
+
+    return Objects.equals(groupId, that.groupId)
+        && Objects.equals(artifactId, that.artifactId)
+        && Objects.equals(version, that.version)
+        && Objects.equals(classifier, that.classifier)
+        && Objects.equals(type, that.type);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(groupId, artifactId, version, classifier, type);
+  }
+
+  @Override
+  public String toString() {
+    return Stream.of(groupId, artifactId, version, classifier, type)
+        .map(attr -> Objects.requireNonNullElse(attr, ""))
+        .collect(Collectors.joining(":"));
+  }
+
+  public ArtifactCoordinate toArtifactCoordinate() {
+    var coordinate = new DefaultArtifactCoordinate();
+    coordinate.setGroupId(groupId);
+    coordinate.setArtifactId(artifactId);
+    coordinate.setVersion(version);
+    coordinate.setClassifier(classifier);
+    coordinate.setExtension(type);
+    return coordinate;
+  }
+
+  public DependableCoordinate toDependableCoordinate() {
+    var coordinate = new DefaultDependableCoordinate();
+    coordinate.setGroupId(groupId);
+    coordinate.setArtifactId(artifactId);
+    coordinate.setVersion(version);
+    coordinate.setClassifier(classifier);
+    coordinate.setType(type);
+    return coordinate;
+  }
+
+  public static MavenArtifact fromDependency(Dependency dependency) {
+    var mavenArtifact = new MavenArtifact();
+    mavenArtifact.setGroupId(dependency.getGroupId());
+    mavenArtifact.setArtifactId(dependency.getArtifactId());
+    mavenArtifact.setVersion(dependency.getVersion());
+    mavenArtifact.setClassifier(dependency.getClassifier());
+    mavenArtifact.setType(dependency.getType());
+    return mavenArtifact;
+  }
+}

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/dependency/MavenDependencyPathResolver.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/dependency/MavenDependencyPathResolver.java
@@ -25,12 +25,8 @@ import javax.inject.Named;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.project.DefaultProjectBuildingRequest;
 import org.apache.maven.shared.artifact.filter.resolve.ScopeFilter;
-import org.apache.maven.shared.transfer.artifact.ArtifactCoordinate;
-import org.apache.maven.shared.transfer.artifact.DefaultArtifactCoordinate;
 import org.apache.maven.shared.transfer.artifact.resolve.ArtifactResolver;
 import org.apache.maven.shared.transfer.artifact.resolve.ArtifactResolverException;
-import org.apache.maven.shared.transfer.dependencies.DefaultDependableCoordinate;
-import org.apache.maven.shared.transfer.dependencies.DependableCoordinate;
 import org.apache.maven.shared.transfer.dependencies.resolve.DependencyResolver;
 import org.apache.maven.shared.transfer.dependencies.resolve.DependencyResolverException;
 import org.slf4j.Logger;
@@ -65,13 +61,8 @@ public final class MavenDependencyPathResolver {
     var paths = new ArrayList<Path>();
 
     for (var dependency : session.getCurrentProject().getDependencies()) {
-      var coordinate = new DefaultDependableCoordinate();
-      coordinate.setGroupId(dependency.getGroupId());
-      coordinate.setArtifactId(dependency.getArtifactId());
-      coordinate.setVersion(dependency.getVersion());
-      coordinate.setType(dependency.getType());
-      coordinate.setClassifier(dependency.getClassifier());
-      paths.addAll(resolveDependencyTreePaths(session, allowedScopes, coordinate));
+      var artifact = MavenArtifact.fromDependency(dependency);
+      paths.addAll(resolveDependencyTreePaths(session, allowedScopes, artifact));
     }
 
     return paths;
@@ -79,12 +70,16 @@ public final class MavenDependencyPathResolver {
 
   public Path resolveArtifact(
       MavenSession session,
-      ArtifactCoordinate artifact
+      MavenArtifact artifact
   ) throws ResolutionException {
     var request = new DefaultProjectBuildingRequest(session.getProjectBuildingRequest());
 
     try {
-      return artifactResolver.resolveArtifact(request, artifact).getArtifact().getFile().toPath();
+      var artifactCoordinate = artifact.toArtifactCoordinate();
+      return artifactResolver.resolveArtifact(request, artifactCoordinate)
+          .getArtifact()
+          .getFile()
+          .toPath();
     } catch (ArtifactResolverException ex) {
       throw new ResolutionException("Failed to resolve artifact '" + artifact + "'", ex);
     }
@@ -93,30 +88,24 @@ public final class MavenDependencyPathResolver {
   public Collection<Path> resolveDependencyTreePaths(
       MavenSession session,
       Set<String> allowedScopes,
-      DependableCoordinate dependency
+      MavenArtifact artifact
   ) throws ResolutionException {
-    log.debug("Resolving dependency '{}'", dependency);
-
-    var artifactCoordinate = new DefaultArtifactCoordinate();
-    artifactCoordinate.setGroupId(dependency.getGroupId());
-    artifactCoordinate.setArtifactId(dependency.getArtifactId());
-    artifactCoordinate.setVersion(dependency.getVersion());
-    artifactCoordinate.setExtension(dependency.getType());
-    artifactCoordinate.setClassifier(dependency.getClassifier());
+    log.debug("Resolving dependency '{}'", artifact);
 
     var allDependencyPaths = new ArrayList<Path>();
-    var artifactPath = resolveArtifact(session, artifactCoordinate);
+    var artifactPath = resolveArtifact(session, artifact);
     allDependencyPaths.add(artifactPath);
 
     var request = new DefaultProjectBuildingRequest(session.getProjectBuildingRequest());
     var scopes = ScopeFilter.including(allowedScopes);
+    var coordinate = artifact.toDependableCoordinate();
 
     try {
-      for (var next : dependencyResolver.resolveDependencies(request, dependency, scopes)) {
+      for (var next : dependencyResolver.resolveDependencies(request, coordinate, scopes)) {
         allDependencyPaths.add(next.getArtifact().getFile().toPath());
       }
     } catch (DependencyResolverException ex) {
-      throw new ResolutionException("Failed to resolve dependencies of '" + dependency + "'", ex);
+      throw new ResolutionException("Failed to resolve dependencies of '" + artifact + "'", ex);
     }
 
     return allDependencyPaths;

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/dependency/PlatformArtifactFactory.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/dependency/PlatformArtifactFactory.java
@@ -22,8 +22,6 @@ import static java.util.Objects.requireNonNullElseGet;
 import io.github.ascopes.protobufmavenplugin.platform.HostSystem;
 import javax.inject.Inject;
 import javax.inject.Named;
-import org.apache.maven.shared.transfer.artifact.ArtifactCoordinate;
-import org.apache.maven.shared.transfer.artifact.DefaultArtifactCoordinate;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -40,23 +38,23 @@ public final class PlatformArtifactFactory {
     this.hostSystem = hostSystem;
   }
 
-  public ArtifactCoordinate createArtifact(
+  public MavenArtifact createArtifact(
       String groupId,
       String artifactId,
       String version,
       @Nullable String extension,
       @Nullable String classifier
   ) {
-    var dependency = new DefaultArtifactCoordinate();
-    dependency.setGroupId(groupId);
-    dependency.setArtifactId(artifactId);
-    dependency.setVersion(version);
-    dependency.setExtension(requireNonNullElse(extension, "exe"));
-    dependency.setClassifier(requireNonNullElseGet(
+    var artifact = new MavenArtifact();
+    artifact.setGroupId(groupId);
+    artifact.setArtifactId(artifactId);
+    artifact.setVersion(version);
+    artifact.setType(requireNonNullElse(extension, "exe"));
+    artifact.setClassifier(requireNonNullElseGet(
         classifier, 
         () -> getPlatformExecutableClassifier(artifactId)
     ));
-    return dependency;
+    return artifact;
   }
 
   private String getPlatformExecutableClassifier(String artifactId) {

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/dependency/ProtocResolver.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/dependency/ProtocResolver.java
@@ -106,7 +106,7 @@ public final class ProtocResolver {
       );
     }
 
-    var coordinate = platformArtifactFactory.createArtifact(
+    var artifact = platformArtifactFactory.createArtifact(
         GROUP_ID,
         ARTIFACT_ID,
         version,
@@ -114,6 +114,6 @@ public final class ProtocResolver {
         null
     );
 
-    return mavenDependencyPathResolver.resolveArtifact(session, coordinate);
+    return mavenDependencyPathResolver.resolveArtifact(session, artifact);
   }
 }

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/generate/GenerationRequest.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/generate/GenerationRequest.java
@@ -16,13 +16,12 @@
 
 package io.github.ascopes.protobufmavenplugin.generate;
 
+import io.github.ascopes.protobufmavenplugin.dependency.MavenArtifact;
 import java.net.URL;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Set;
 import org.apache.maven.execution.MavenSession;
-import org.apache.maven.shared.transfer.artifact.ArtifactCoordinate;
-import org.apache.maven.shared.transfer.dependencies.DependableCoordinate;
 import org.immutables.value.Value.Immutable;
 
 /**
@@ -35,13 +34,13 @@ public interface GenerationRequest {
 
   Collection<Path> getAdditionalImportPaths();
 
-  Collection<? extends ArtifactCoordinate> getBinaryMavenPlugins();
+  Collection<MavenArtifact> getBinaryMavenPlugins();
 
   Collection<String> getBinaryPathPlugins();
 
   Collection<URL> getBinaryUrlPlugins();
 
-  Collection<? extends DependableCoordinate> getJvmMavenPlugins();
+  Collection<MavenArtifact> getJvmMavenPlugins();
 
   Set<String> getAllowedDependencyScopes();
 

--- a/src/test/java/io/github/ascopes/protobufmavenplugin/dependency/PlatformArtifactFactoryTest.java
+++ b/src/test/java/io/github/ascopes/protobufmavenplugin/dependency/PlatformArtifactFactoryTest.java
@@ -64,30 +64,30 @@ class PlatformArtifactFactoryTest {
     var factory = new PlatformArtifactFactory(hostSystem);
 
     // When
-    var dependency = factory.createArtifact(
-        groupId, 
-        artifactId, 
-        version, 
-        givenExtension, 
+    var artifact = factory.createArtifact(
+        groupId,
+        artifactId,
+        version,
+        givenExtension,
         givenClassifier
     );
 
     // Then
     assertSoftly(softly -> {
-      softly.assertThat(dependency.getGroupId())
+      softly.assertThat(artifact.getGroupId().orElse(null))
           .as("groupId")
           .isEqualTo(groupId);
-      softly.assertThat(dependency.getArtifactId())
+      softly.assertThat(artifact.getArtifactId().orElse(null))
           .as("artifactId")
           .isEqualTo(artifactId);
-      softly.assertThat(dependency.getVersion())
+      softly.assertThat(artifact.getVersion().orElse(null))
           .as("version")
           .isEqualTo(version);
-      softly.assertThat(dependency.getExtension())
-          .as("extension")
-          .isEqualTo(expectedExtension);
-      softly.assertThat(dependency.getClassifier())
+      softly.assertThat(artifact.getType().orElse(null))
           .as("type")
+          .isEqualTo(expectedExtension);
+      softly.assertThat(artifact.getClassifier().orElse(null))
+          .as("classifier")
           .isEqualTo(expectedClassifier);
     });
   }


### PR DESCRIPTION
This replaces the use of DependableCoordinate and ArtifactCoordinate outside a couple of locations that depend on the artifact resolver API as implementation detail. This will allow for adjusting the internal implementation later much more easily going forwards.

The use of .setExtension on the artifact/dependency types used for parameters is now deprecated and should be replaced with .setType instead. This will be removed in v2.0.0.

While this is technically a breaking change in the code itself, the new parameter type remains fully compatible with the current parameter type, so this is not a major version bump. Users should not see any difference in the API signature when using Maven XML to configure it.