### PR TITLE
Rename additionalImportPaths parameter to importPaths

### DIFF
--- a/src/main/java/io/github/ascopes/protobufmavenplugin/AbstractGenerateMojo.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/AbstractGenerateMojo.java
@@ -109,12 +109,15 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    * <p>If you wish to depend on a JAR containing protobuf sources, add it as a dependency
    * with the {@code provided} or {@code test} scope instead.
    *
+   * <p>Prior to v1.2.0, this was called {@code additionalImportPaths}. This old name will
+   * be maintained as a valid alias until v2.0.0.
+   *
    * <p>This parameter is optional.
    *
    * @since 0.1.0
    */
-  @Parameter
-  private @Nullable List<File> additionalImportPaths;
+  @Parameter(alias = "additionalImportPaths")
+  private @Nullable List<File> importPaths;
 
   /**
    * Binary plugins to use with the protobuf compiler, sourced from a Maven repository.
@@ -392,15 +395,15 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
     }
 
     var request = ImmutableGenerationRequest.builder()
-        .additionalImportPaths(nonNullList(additionalImportPaths)
-            .stream()
-            .map(File::toPath)
-            .collect(Collectors.toList()))
         .allowedDependencyScopes(allowedScopes())
         .binaryMavenPlugins(nonNullList(binaryMavenPlugins))
         .binaryPathPlugins(nonNullList(binaryPathPlugins))
         .binaryUrlPlugins(nonNullList(binaryUrlPlugins))
         .jvmMavenPlugins(nonNullList(jvmMavenPlugins))
+        .importPaths(nonNullList(importPaths)
+            .stream()
+            .map(File::toPath)
+            .collect(Collectors.toList()))
         .isCppEnabled(cppEnabled)
         .isCsharpEnabled(csharpEnabled)
         .isFailOnMissingSources(failOnMissingSources)

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/generate/GenerationRequest.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/generate/GenerationRequest.java
@@ -32,13 +32,13 @@ import org.immutables.value.Value.Immutable;
 @Immutable
 public interface GenerationRequest {
 
-  Collection<Path> getAdditionalImportPaths();
-
   Collection<MavenArtifact> getBinaryMavenPlugins();
 
   Collection<String> getBinaryPathPlugins();
 
   Collection<URL> getBinaryUrlPlugins();
+
+  Collection<Path> getImportPaths();
 
   Collection<MavenArtifact> getJvmMavenPlugins();
 

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/generate/SourceCodeGenerator.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/generate/SourceCodeGenerator.java
@@ -181,7 +181,7 @@ public final class SourceCodeGenerator {
     // Always use all provided additional import paths, as we assume they are valid given the user
     // has explicitly included them in their configuration.
     var explicitDependencies = protoListingResolver
-        .createProtoFileListings(request.getAdditionalImportPaths());
+        .createProtoFileListings(request.getImportPaths());
 
     return concat(inheritedDependencies, explicitDependencies);
   }

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -216,7 +216,7 @@ just like you would expect when using Java code. This plugin considers any depen
 `provided`, or `system` scope (or additionally `test` if the `generate-test` goal is used).
 
 If there are additional paths on the file system that you wish to add to the import path, then
-you can specify these using the `additionalImportPaths` parameter. Note that these will not be
+you can specify these using the `importPaths` parameter. Note that these will not be
 compiled, only made visible to the protobuf compiler.
 
 ## Kotlin generation


### PR DESCRIPTION
The additionalImportPaths name will be retained as an alias for the parameter for backwards compatibility to prevent this being a breaking change. This will likely be removed in v2.0.0.