### PR TITLE
GH-135: Implement ability to only include direct dependencies

### DIFF
--- a/src/main/java/io/github/ascopes/protobufmavenplugin/AbstractGenerateMojo.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/AbstractGenerateMojo.java
@@ -19,7 +19,7 @@ package io.github.ascopes.protobufmavenplugin;
 import static java.util.Objects.requireNonNullElse;
 import static java.util.Objects.requireNonNullElseGet;
 
-import io.github.ascopes.protobufmavenplugin.dependency.DependencyResolutionScope;
+import io.github.ascopes.protobufmavenplugin.dependency.DependencyResolutionDepth;
 import io.github.ascopes.protobufmavenplugin.dependency.MavenArtifact;
 import io.github.ascopes.protobufmavenplugin.dependency.ResolutionException;
 import io.github.ascopes.protobufmavenplugin.generate.ImmutableGenerationRequest;
@@ -115,7 +115,7 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    * @since 1.2.0
    */
   @Parameter(defaultValue = "TRANSITIVE")
-  private DependencyResolutionScope dependencyResolutionScope;
+  private DependencyResolutionDepth dependencyResolutionDepth;
 
   /**
    * Specify additional paths to import protobuf sources from on the local file system.
@@ -415,7 +415,7 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
         .binaryMavenPlugins(nonNullList(binaryMavenPlugins))
         .binaryPathPlugins(nonNullList(binaryPathPlugins))
         .binaryUrlPlugins(nonNullList(binaryUrlPlugins))
-        .dependencyResolutionScope(dependencyResolutionScope)
+        .dependencyResolutionDepth(dependencyResolutionDepth)
         .jvmMavenPlugins(nonNullList(jvmMavenPlugins))
         .importPaths(nonNullList(importPaths)
             .stream()

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/AbstractGenerateMojo.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/AbstractGenerateMojo.java
@@ -19,6 +19,7 @@ package io.github.ascopes.protobufmavenplugin;
 import static java.util.Objects.requireNonNullElse;
 import static java.util.Objects.requireNonNullElseGet;
 
+import io.github.ascopes.protobufmavenplugin.dependency.DependencyResolutionScope;
 import io.github.ascopes.protobufmavenplugin.dependency.MavenArtifact;
 import io.github.ascopes.protobufmavenplugin.dependency.ResolutionException;
 import io.github.ascopes.protobufmavenplugin.generate.ImmutableGenerationRequest;
@@ -100,6 +101,21 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    */
   @Parameter
   private @Nullable List<File> sourceDirectories;
+
+  /**
+   * The scope to resolve dependencies with.
+   *
+   * <p>Supported values:
+   *
+   * <ul>
+   *   <li><code>TRANSITIVE</code> - resolve all dependencies.</li>
+   *   <li><code>DIRECT</code> - only resolve dependencies that were explicitly specified.</li>
+   * </ul>
+   *
+   * @since 1.2.0
+   */
+  @Parameter(defaultValue = "TRANSITIVE")
+  private DependencyResolutionScope dependencyResolutionScope;
 
   /**
    * Specify additional paths to import protobuf sources from on the local file system.
@@ -399,6 +415,7 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
         .binaryMavenPlugins(nonNullList(binaryMavenPlugins))
         .binaryPathPlugins(nonNullList(binaryPathPlugins))
         .binaryUrlPlugins(nonNullList(binaryUrlPlugins))
+        .dependencyResolutionScope(dependencyResolutionScope)
         .jvmMavenPlugins(nonNullList(jvmMavenPlugins))
         .importPaths(nonNullList(importPaths)
             .stream()

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/dependency/DependencyResolutionDepth.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/dependency/DependencyResolutionDepth.java
@@ -22,7 +22,7 @@ package io.github.ascopes.protobufmavenplugin.dependency;
  * @author Ashley Scopes
  * @since 1.2.0
  */
-public enum DependencyResolutionScope {
+public enum DependencyResolutionDepth {
 
   /**
    * Resolve all transitive dependencies.

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/dependency/DependencyResolutionScope.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/dependency/DependencyResolutionScope.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2023 - 2024, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.ascopes.protobufmavenplugin.dependency;
+
+/**
+ * User parameter to configure how to resolve dependencies.
+ *
+ * @author Ashley Scopes
+ * @since 1.2.0
+ */
+public enum DependencyResolutionScope {
+
+  /**
+   * Resolve all transitive dependencies.
+   */
+  TRANSITIVE,
+
+  /**
+   * Only resolve direct dependencies that were explicitly included.
+   */
+  DIRECT,
+}

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/dependency/JvmPluginResolver.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/dependency/JvmPluginResolver.java
@@ -101,7 +101,12 @@ public final class JvmPluginResolver {
 
     // Resolve dependencies first.
     var dependencyIterator = dependencyPathResolver
-        .resolveDependencyTreePaths(session, SCOPES, plugin)
+        .resolveDependencyTreePaths(
+            session,
+            SCOPES,
+            DependencyResolutionScope.TRANSITIVE,
+            plugin
+        )
         .iterator();
 
     // First dependency is always the thing we actually want to execute,

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/dependency/JvmPluginResolver.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/dependency/JvmPluginResolver.java
@@ -104,7 +104,7 @@ public final class JvmPluginResolver {
         .resolveDependencyTreePaths(
             session,
             SCOPES,
-            DependencyResolutionScope.TRANSITIVE,
+            DependencyResolutionDepth.TRANSITIVE,
             plugin
         )
         .iterator();

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/dependency/MavenDependencyPathResolver.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/dependency/MavenDependencyPathResolver.java
@@ -57,7 +57,7 @@ public final class MavenDependencyPathResolver {
   public Collection<Path> resolveProjectDependencyPaths(
       MavenSession session,
       Set<String> allowedScopes,
-      DependencyResolutionScope dependencyResolutionScope
+      DependencyResolutionDepth dependencyResolutionDepth
   ) throws ResolutionException {
     var paths = new ArrayList<Path>();
 
@@ -66,7 +66,7 @@ public final class MavenDependencyPathResolver {
       paths.addAll(resolveDependencyTreePaths(
           session,
           allowedScopes,
-          dependencyResolutionScope,
+          dependencyResolutionDepth,
           artifact
       ));
     }
@@ -77,7 +77,7 @@ public final class MavenDependencyPathResolver {
   public Collection<Path> resolveDependencyTreePaths(
       MavenSession session,
       Set<String> allowedScopes,
-      DependencyResolutionScope dependencyResolutionScope,
+      DependencyResolutionDepth dependencyResolutionDepth,
       MavenArtifact artifact
   ) throws ResolutionException {
     log.debug("Resolving dependency '{}'", artifact);
@@ -86,7 +86,7 @@ public final class MavenDependencyPathResolver {
     var artifactPath = resolveArtifact(session, artifact);
     allDependencyPaths.add(artifactPath);
 
-    if (dependencyResolutionScope == DependencyResolutionScope.DIRECT) {
+    if (dependencyResolutionDepth == DependencyResolutionDepth.DIRECT) {
       log.debug("Not resolving transitive dependencies of '{}'", artifact);
       return allDependencyPaths;
     }

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/dependency/MavenDependencyPathResolver.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/dependency/MavenDependencyPathResolver.java
@@ -56,16 +56,54 @@ public final class MavenDependencyPathResolver {
 
   public Collection<Path> resolveProjectDependencyPaths(
       MavenSession session,
-      Set<String> allowedScopes
+      Set<String> allowedScopes,
+      DependencyResolutionScope dependencyResolutionScope
   ) throws ResolutionException {
     var paths = new ArrayList<Path>();
 
     for (var dependency : session.getCurrentProject().getDependencies()) {
       var artifact = MavenArtifact.fromDependency(dependency);
-      paths.addAll(resolveDependencyTreePaths(session, allowedScopes, artifact));
+      paths.addAll(resolveDependencyTreePaths(
+          session,
+          allowedScopes,
+          dependencyResolutionScope,
+          artifact
+      ));
     }
 
     return paths;
+  }
+
+  public Collection<Path> resolveDependencyTreePaths(
+      MavenSession session,
+      Set<String> allowedScopes,
+      DependencyResolutionScope dependencyResolutionScope,
+      MavenArtifact artifact
+  ) throws ResolutionException {
+    log.debug("Resolving dependency '{}'", artifact);
+
+    var allDependencyPaths = new ArrayList<Path>();
+    var artifactPath = resolveArtifact(session, artifact);
+    allDependencyPaths.add(artifactPath);
+
+    if (dependencyResolutionScope == DependencyResolutionScope.DIRECT) {
+      log.debug("Not resolving transitive dependencies of '{}'", artifact);
+      return allDependencyPaths;
+    }
+
+    var request = new DefaultProjectBuildingRequest(session.getProjectBuildingRequest());
+    var scopes = ScopeFilter.including(allowedScopes);
+    var coordinate = artifact.toDependableCoordinate();
+
+    try {
+      for (var next : dependencyResolver.resolveDependencies(request, coordinate, scopes)) {
+        allDependencyPaths.add(next.getArtifact().getFile().toPath());
+      }
+    } catch (DependencyResolverException ex) {
+      throw new ResolutionException("Failed to resolve dependencies of '" + artifact + "'", ex);
+    }
+
+    return allDependencyPaths;
   }
 
   public Path resolveArtifact(
@@ -83,31 +121,5 @@ public final class MavenDependencyPathResolver {
     } catch (ArtifactResolverException ex) {
       throw new ResolutionException("Failed to resolve artifact '" + artifact + "'", ex);
     }
-  }
-
-  public Collection<Path> resolveDependencyTreePaths(
-      MavenSession session,
-      Set<String> allowedScopes,
-      MavenArtifact artifact
-  ) throws ResolutionException {
-    log.debug("Resolving dependency '{}'", artifact);
-
-    var allDependencyPaths = new ArrayList<Path>();
-    var artifactPath = resolveArtifact(session, artifact);
-    allDependencyPaths.add(artifactPath);
-
-    var request = new DefaultProjectBuildingRequest(session.getProjectBuildingRequest());
-    var scopes = ScopeFilter.including(allowedScopes);
-    var coordinate = artifact.toDependableCoordinate();
-
-    try {
-      for (var next : dependencyResolver.resolveDependencies(request, coordinate, scopes)) {
-        allDependencyPaths.add(next.getArtifact().getFile().toPath());
-      }
-    } catch (DependencyResolverException ex) {
-      throw new ResolutionException("Failed to resolve dependencies of '" + artifact + "'", ex);
-    }
-
-    return allDependencyPaths;
   }
 }

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/dependency/PlatformArtifactFactory.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/dependency/PlatformArtifactFactory.java
@@ -51,7 +51,7 @@ public final class PlatformArtifactFactory {
     artifact.setVersion(version);
     artifact.setType(requireNonNullElse(extension, "exe"));
     artifact.setClassifier(requireNonNullElseGet(
-        classifier, 
+        classifier,
         () -> getPlatformExecutableClassifier(artifactId)
     ));
     return artifact;

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/generate/GenerationRequest.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/generate/GenerationRequest.java
@@ -16,6 +16,7 @@
 
 package io.github.ascopes.protobufmavenplugin.generate;
 
+import io.github.ascopes.protobufmavenplugin.dependency.DependencyResolutionScope;
 import io.github.ascopes.protobufmavenplugin.dependency.MavenArtifact;
 import java.net.URL;
 import java.nio.file.Path;
@@ -37,6 +38,8 @@ public interface GenerationRequest {
   Collection<String> getBinaryPathPlugins();
 
   Collection<URL> getBinaryUrlPlugins();
+
+  DependencyResolutionScope getDependencyResolutionScope();
 
   Collection<Path> getImportPaths();
 

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/generate/GenerationRequest.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/generate/GenerationRequest.java
@@ -16,7 +16,7 @@
 
 package io.github.ascopes.protobufmavenplugin.generate;
 
-import io.github.ascopes.protobufmavenplugin.dependency.DependencyResolutionScope;
+import io.github.ascopes.protobufmavenplugin.dependency.DependencyResolutionDepth;
 import io.github.ascopes.protobufmavenplugin.dependency.MavenArtifact;
 import java.net.URL;
 import java.nio.file.Path;
@@ -39,7 +39,7 @@ public interface GenerationRequest {
 
   Collection<URL> getBinaryUrlPlugins();
 
-  DependencyResolutionScope getDependencyResolutionScope();
+  DependencyResolutionDepth getDependencyResolutionDepth();
 
   Collection<Path> getImportPaths();
 

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/generate/SourceCodeGenerator.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/generate/SourceCodeGenerator.java
@@ -17,6 +17,7 @@
 package io.github.ascopes.protobufmavenplugin.generate;
 
 import io.github.ascopes.protobufmavenplugin.dependency.BinaryPluginResolver;
+import io.github.ascopes.protobufmavenplugin.dependency.DependencyResolutionScope;
 import io.github.ascopes.protobufmavenplugin.dependency.JvmPluginResolver;
 import io.github.ascopes.protobufmavenplugin.dependency.MavenDependencyPathResolver;
 import io.github.ascopes.protobufmavenplugin.dependency.ProtocResolver;
@@ -171,9 +172,16 @@ public final class SourceCodeGenerator {
   ) throws IOException, ResolutionException {
     var session = request.getMavenSession();
 
-    log.debug("Finding importable protobuf sources from the classpath");
-    var dependencyPaths = mavenDependencyPathResolver
-        .resolveProjectDependencyPaths(session, request.getAllowedDependencyScopes());
+    log.debug(
+        "Finding importable protobuf sources from the classpath ({})",
+        request.getDependencyResolutionScope()
+    );
+
+    var dependencyPaths = mavenDependencyPathResolver.resolveProjectDependencyPaths(
+        session,
+        request.getAllowedDependencyScopes(),
+        request.getDependencyResolutionScope()
+    );
 
     var inheritedDependencies = protoListingResolver
         .createProtoFileListings(dependencyPaths);

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/generate/SourceCodeGenerator.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/generate/SourceCodeGenerator.java
@@ -17,7 +17,7 @@
 package io.github.ascopes.protobufmavenplugin.generate;
 
 import io.github.ascopes.protobufmavenplugin.dependency.BinaryPluginResolver;
-import io.github.ascopes.protobufmavenplugin.dependency.DependencyResolutionScope;
+import io.github.ascopes.protobufmavenplugin.dependency.DependencyResolutionDepth;
 import io.github.ascopes.protobufmavenplugin.dependency.JvmPluginResolver;
 import io.github.ascopes.protobufmavenplugin.dependency.MavenDependencyPathResolver;
 import io.github.ascopes.protobufmavenplugin.dependency.ProtocResolver;
@@ -174,13 +174,13 @@ public final class SourceCodeGenerator {
 
     log.debug(
         "Finding importable protobuf sources from the classpath ({})",
-        request.getDependencyResolutionScope()
+        request.getDependencyResolutionDepth()
     );
 
     var dependencyPaths = mavenDependencyPathResolver.resolveProjectDependencyPaths(
         session,
         request.getAllowedDependencyScopes(),
-        request.getDependencyResolutionScope()
+        request.getDependencyResolutionDepth()
     );
 
     var inheritedDependencies = protoListingResolver


### PR DESCRIPTION
A component that makes up a small part of the overall solution for GH-135, by providing the initial ability to not include transitive dependencies implicitly, only directly specified ones.

This is achieved via a new parameter `dependencyResolutionScope` (exact name to be confirmed) which will be set to `TRANSITIVE` by default to exhibit the current resolution behaviour. It can optionally be set to `DIRECT` instead to allow only adding explicitly included dependencies to the protopath.

The change will be complimented in a future set of PRs with the ability to add dependencies without making them visible to the Java compiler, and the ability to disable reading the Java classpath dependencies at all to enable more control over how the dependency mechanism works.