### PR TITLE
Simplify project dependency resolution

### DIFF
--- a/src/main/java/io/github/ascopes/protobufmavenplugin/AbstractGenerateMojo.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/AbstractGenerateMojo.java
@@ -33,7 +33,6 @@ import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
@@ -255,10 +254,9 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    * Whether to fail on missing sources.
    *
    * <p>If no sources are detected, it is usually a sign that this plugin
-   * is misconfigured, or that you are including this plugin in a project
-   * that does not need it. For this reason, the plugin defaults this setting
-   * to being enabled. If you wish to not fail, you can explicitly set this
-   * to false instead.
+   * is misconfigured, or that you are including this plugin in a project that does not need it. For
+   * this reason, the plugin defaults this setting to being enabled. If you wish to not fail, you
+   * can explicitly set this to false instead.
    *
    * @since 0.5.0
    */
@@ -310,12 +308,11 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
   private boolean pythonEnabled;
 
   /**
-   * Enable generating Python stubs ({@code *.pyi} files) for static typechecking
-   * from the protobuf sources.
+   * Enable generating Python stubs ({@code *.pyi} files) for static typechecking from the protobuf
+   * sources.
    *
    * <p>If you enable this, you probably will also want to enable Python itself
-   * to get actual source code
-   * to accompany the stubs.
+   * to get actual source code to accompany the stubs.
    *
    * @since 1.1.0
    */
@@ -384,12 +381,11 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
   private boolean liteOnly;
 
   /**
-   * Whether to register the output directories as compilation roots with
-   * Maven.
+   * Whether to register the output directories as compilation roots with Maven.
    *
    * <p>Generally, you want to do this, but there may be edge cases where you
-   * wish to control this behaviour manually instead. In this case, set this
-   * parameter to be {@code false}.
+   * wish to control this behaviour manually instead. In this case, set this parameter to be
+   * {@code false}.
    *
    * @since 0.5.0
    */
@@ -410,8 +406,8 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
       throw new MojoExecutionException(ex.getMessage(), ex);
     }
 
+    //noinspection DataFlowIssue
     var request = ImmutableGenerationRequest.builder()
-        .allowedDependencyScopes(allowedScopes())
         .binaryMavenPlugins(nonNullList(binaryMavenPlugins))
         .binaryPathPlugins(nonNullList(binaryPathPlugins))
         .binaryUrlPlugins(nonNullList(binaryUrlPlugins))
@@ -498,16 +494,6 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    * @return the path to the directory.
    */
   protected abstract Path defaultOutputDirectory(MavenSession session);
-
-  /**
-   * Provides the scopes allowed for dependencies.
-   *
-   * <p>Dependencies matching one of these scopes will be indexed and made visible
-   * to the protoc compiler if proto files are discovered.
-   *
-   * @return a set of the scopes.
-   */
-  protected abstract Set<String> allowedScopes();
 
   /**
    * Validate this Mojo's parameters.

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/MainGenerateMojo.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/MainGenerateMojo.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.ResolutionScope;
 
 /**
  * Generate source code from protobuf files.
@@ -42,6 +43,8 @@ import org.apache.maven.plugins.annotations.Mojo;
 @Mojo(
     name = "generate",
     defaultPhase = LifecyclePhase.GENERATE_SOURCES,
+    requiresDependencyCollection = ResolutionScope.COMPILE_PLUS_RUNTIME,
+    requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME,
     threadSafe = true
 )
 public final class MainGenerateMojo extends AbstractGenerateMojo {
@@ -49,11 +52,6 @@ public final class MainGenerateMojo extends AbstractGenerateMojo {
   @Override
   protected SourceRootRegistrar sourceRootRegistrar() {
     return SourceRootRegistrar.MAIN;
-  }
-
-  @Override
-  protected Set<String> allowedScopes() {
-    return Set.of("compile", "provided", "system");
   }
 
   @Override

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/TestGenerateMojo.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/TestGenerateMojo.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.ResolutionScope;
 
 /**
  * Generate source code from protobuf files for use in tests.
@@ -47,6 +48,8 @@ import org.apache.maven.plugins.annotations.Mojo;
 @Mojo(
     name = "generate-test",
     defaultPhase = LifecyclePhase.GENERATE_TEST_SOURCES,
+    requiresDependencyCollection = ResolutionScope.TEST,
+    requiresDependencyResolution = ResolutionScope.TEST,
     threadSafe = true
 )
 public final class TestGenerateMojo extends AbstractGenerateMojo {
@@ -54,11 +57,6 @@ public final class TestGenerateMojo extends AbstractGenerateMojo {
   @Override
   protected SourceRootRegistrar sourceRootRegistrar() {
     return SourceRootRegistrar.TEST;
-  }
-
-  @Override
-  protected Set<String> allowedScopes() {
-    return Set.of("compile", "provided", "system", "test");
   }
 
   @Override

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/dependency/JvmPluginResolver.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/dependency/JvmPluginResolver.java
@@ -46,8 +46,6 @@ import org.apache.maven.execution.MavenSession;
 @Named
 public final class JvmPluginResolver {
 
-  private static final Set<String> SCOPES = Set.of("compile", "runtime", "system");
-
   private final HostSystem hostSystem;
   private final MavenDependencyPathResolver dependencyPathResolver;
   private final TemporarySpace temporarySpace;
@@ -104,7 +102,6 @@ public final class JvmPluginResolver {
     var dependencyIterator = dependencyPathResolver
         .resolveDependencyTreePaths(
             session,
-            SCOPES,
             DependencyResolutionDepth.TRANSITIVE,
             plugin
         )

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/dependency/MavenDependencyPathResolver.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/dependency/MavenDependencyPathResolver.java
@@ -19,12 +19,10 @@ package io.github.ascopes.protobufmavenplugin.dependency;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Set;
 import javax.inject.Inject;
 import javax.inject.Named;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.project.DefaultProjectBuildingRequest;
-import org.apache.maven.shared.artifact.filter.resolve.ScopeFilter;
 import org.apache.maven.shared.transfer.artifact.resolve.ArtifactResolver;
 import org.apache.maven.shared.transfer.artifact.resolve.ArtifactResolverException;
 import org.apache.maven.shared.transfer.dependencies.resolve.DependencyResolver;
@@ -56,7 +54,6 @@ public final class MavenDependencyPathResolver {
 
   public Collection<Path> resolveProjectDependencyPaths(
       MavenSession session,
-      Set<String> allowedScopes,
       DependencyResolutionDepth dependencyResolutionDepth
   ) throws ResolutionException {
     var paths = new ArrayList<Path>();
@@ -65,7 +62,6 @@ public final class MavenDependencyPathResolver {
       var artifact = MavenArtifact.fromDependency(dependency);
       paths.addAll(resolveDependencyTreePaths(
           session,
-          allowedScopes,
           dependencyResolutionDepth,
           artifact
       ));
@@ -76,7 +72,6 @@ public final class MavenDependencyPathResolver {
 
   public Collection<Path> resolveDependencyTreePaths(
       MavenSession session,
-      Set<String> allowedScopes,
       DependencyResolutionDepth dependencyResolutionDepth,
       MavenArtifact artifact
   ) throws ResolutionException {
@@ -92,11 +87,10 @@ public final class MavenDependencyPathResolver {
     }
 
     var request = new DefaultProjectBuildingRequest(session.getProjectBuildingRequest());
-    var scopes = ScopeFilter.including(allowedScopes);
     var coordinate = artifact.toDependableCoordinate();
 
     try {
-      for (var next : dependencyResolver.resolveDependencies(request, coordinate, scopes)) {
+      for (var next : dependencyResolver.resolveDependencies(request, coordinate, null)) {
         allDependencyPaths.add(next.getArtifact().getFile().toPath());
       }
     } catch (DependencyResolverException ex) {

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/generate/GenerationRequest.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/generate/GenerationRequest.java
@@ -21,7 +21,6 @@ import io.github.ascopes.protobufmavenplugin.dependency.MavenArtifact;
 import java.net.URL;
 import java.nio.file.Path;
 import java.util.Collection;
-import java.util.Set;
 import org.apache.maven.execution.MavenSession;
 import org.immutables.value.Value.Immutable;
 
@@ -44,8 +43,6 @@ public interface GenerationRequest {
   Collection<Path> getImportPaths();
 
   Collection<MavenArtifact> getJvmMavenPlugins();
-
-  Set<String> getAllowedDependencyScopes();
 
   MavenSession getMavenSession();
 

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/generate/SourceCodeGenerator.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/generate/SourceCodeGenerator.java
@@ -17,7 +17,6 @@
 package io.github.ascopes.protobufmavenplugin.generate;
 
 import io.github.ascopes.protobufmavenplugin.dependency.BinaryPluginResolver;
-import io.github.ascopes.protobufmavenplugin.dependency.DependencyResolutionDepth;
 import io.github.ascopes.protobufmavenplugin.dependency.JvmPluginResolver;
 import io.github.ascopes.protobufmavenplugin.dependency.MavenDependencyPathResolver;
 import io.github.ascopes.protobufmavenplugin.dependency.ProtocResolver;
@@ -179,7 +178,6 @@ public final class SourceCodeGenerator {
 
     var dependencyPaths = mavenDependencyPathResolver.resolveProjectDependencyPaths(
         session,
-        request.getAllowedDependencyScopes(),
         request.getDependencyResolutionDepth()
     );
 


### PR DESCRIPTION
Remove the `allowedScopes` mechanism and then default to querying the already-known resolved dependencies from the Maven project itself unless direct resolution is requested.

This removes some overhead and boilerplate and simplifies the logic ready for GH-101.