### PR TITLE
GH-101: Use Aether artifact resolver directly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,10 +98,10 @@
     <immutables.version>2.10.1</immutables.version>
     <jspecify.version>0.3.0</jspecify.version>
     <junit.version>5.10.2</junit.version>
-    <maven-artifact-transfer.version>0.13.1</maven-artifact-transfer.version>
     <maven-core.version>3.9.6</maven-core.version>
     <maven-plugin-annotations.version>3.11.0</maven-plugin-annotations.version>
     <maven-plugin-api.version>3.9.6</maven-plugin-api.version>
+    <maven-resolver-api.version>1.9.18</maven-resolver-api.version>
     <memoryfilesystem.version>2.8.0</memoryfilesystem.version>
     <mockito.version>5.11.0</mockito.version>
     <slf4j.version>2.0.12</slf4j.version>
@@ -175,32 +175,19 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-core</artifactId>
-      <version>${maven-core.version}</version>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-api</artifactId>
+      <version>${maven-resolver-api.version}</version>
       <!-- Provided by Maven at runtime -->
       <scope>provided</scope>
     </dependency>
 
     <dependency>
-      <groupId>org.apache.maven.shared</groupId>
-      <artifactId>maven-artifact-transfer</artifactId>
-      <version>${maven-artifact-transfer.version}</version>
-      <scope>compile</scope>
-
-      <exclusions>
-        <!-- These are pulled in with provided scope by other dependencies,
-            so do not depend on them with compile scope as this will raise
-            build warnings. -->
-        <exclusion>
-          <groupId>org.apache.maven</groupId>
-          <artifactId>maven-artifact</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.maven</groupId>
-          <artifactId>maven-model</artifactId>
-        </exclusion>
-      </exclusions>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-core</artifactId>
+      <version>${maven-core.version}</version>
+      <!-- Provided by Maven at runtime -->
+      <scope>provided</scope>
     </dependency>
 
     <dependency>

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/dependency/BinaryPluginResolver.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/dependency/BinaryPluginResolver.java
@@ -35,19 +35,19 @@ import org.apache.maven.execution.MavenSession;
 @Named
 public final class BinaryPluginResolver {
 
-  private final MavenDependencyPathResolver mavenDependencyPathResolver;
+  private final MavenDependencyPathResolver dependencyResolver;
   private final PlatformArtifactFactory platformDependencyFactory;
   private final SystemPathBinaryResolver systemPathResolver;
   private final UrlResourceFetcher urlResourceFetcher;
 
   @Inject
   public BinaryPluginResolver(
-      MavenDependencyPathResolver mavenDependencyPathResolver,
+      MavenDependencyPathResolver dependencyResolver,
       PlatformArtifactFactory platformDependencyFactory,
       SystemPathBinaryResolver systemPathResolver,
       UrlResourceFetcher urlResourceFetcher
   ) {
-    this.mavenDependencyPathResolver = mavenDependencyPathResolver;
+    this.dependencyResolver = dependencyResolver;
     this.platformDependencyFactory = platformDependencyFactory;
     this.systemPathResolver = systemPathResolver;
     this.urlResourceFetcher = urlResourceFetcher;
@@ -84,7 +84,10 @@ public final class BinaryPluginResolver {
         plugin.getClassifier().orElse(null)
     );
 
-    var path = mavenDependencyPathResolver.resolveArtifact(session, plugin);
+    // Only one dependency should ever be returned here.
+    var path = dependencyResolver.resolveOne(session, plugin, DependencyResolutionDepth.DIRECT)
+        .iterator()
+        .next();
     makeExecutable(path);
     return createResolvedPlugin(path);
   }

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/dependency/JvmPluginResolver.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/dependency/JvmPluginResolver.java
@@ -29,7 +29,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Set;
 import javax.inject.Inject;
 import javax.inject.Named;
 import org.apache.maven.execution.MavenSession;
@@ -47,17 +46,17 @@ import org.apache.maven.execution.MavenSession;
 public final class JvmPluginResolver {
 
   private final HostSystem hostSystem;
-  private final MavenDependencyPathResolver dependencyPathResolver;
+  private final MavenDependencyPathResolver dependencyResolver;
   private final TemporarySpace temporarySpace;
 
   @Inject
   public JvmPluginResolver(
       HostSystem hostSystem,
-      MavenDependencyPathResolver dependencyPathResolver,
+      MavenDependencyPathResolver dependencyResolver,
       TemporarySpace temporarySpace
   ) {
     this.hostSystem = hostSystem;
-    this.dependencyPathResolver = dependencyPathResolver;
+    this.dependencyResolver = dependencyResolver;
     this.temporarySpace = temporarySpace;
   }
 
@@ -99,12 +98,8 @@ public final class JvmPluginResolver {
   ) throws ResolutionException {
 
     // Resolve dependencies first.
-    var dependencyIterator = dependencyPathResolver
-        .resolveDependencyTreePaths(
-            session,
-            DependencyResolutionDepth.TRANSITIVE,
-            plugin
-        )
+    var dependencyIterator = dependencyResolver
+        .resolveOne(session, plugin, DependencyResolutionDepth.TRANSITIVE)
         .iterator();
 
     // First dependency is always the thing we actually want to execute,

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/dependency/MavenArtifact.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/dependency/MavenArtifact.java
@@ -20,24 +20,20 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.apache.maven.model.Dependency;
-import org.apache.maven.shared.transfer.artifact.ArtifactCoordinate;
-import org.apache.maven.shared.transfer.artifact.DefaultArtifactCoordinate;
-import org.apache.maven.shared.transfer.dependencies.DefaultDependableCoordinate;
-import org.apache.maven.shared.transfer.dependencies.DependableCoordinate;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
 /**
- * Implementation independent deacriptor for an artifact or dependency that
- * can be used in a Maven Plugin parameter.
+ * Implementation independent descriptor for an artifact or dependency that can be used in a Maven
+ * Plugin parameter.
  *
  * @author Ashley Scopes
  * @since 1.2.0
  */
 public final class MavenArtifact {
+
   private static final Logger log = LoggerFactory.getLogger(MavenArtifact.class);
 
   private @Nullable String groupId;
@@ -93,7 +89,7 @@ public final class MavenArtifact {
   public void setExtension(@Nullable String extension) {
     log.warn("MavenArtifact.extension is deprecated for removal in v2.0.0. "
         + "Please use MavenArtifact.type instead for future compatibility.");
-    this.type = extension;
+    type = extension;
   }
 
   @Override
@@ -121,35 +117,5 @@ public final class MavenArtifact {
     return Stream.of(groupId, artifactId, version, classifier, type)
         .map(attr -> Objects.requireNonNullElse(attr, ""))
         .collect(Collectors.joining(":"));
-  }
-
-  public ArtifactCoordinate toArtifactCoordinate() {
-    var coordinate = new DefaultArtifactCoordinate();
-    coordinate.setGroupId(groupId);
-    coordinate.setArtifactId(artifactId);
-    coordinate.setVersion(version);
-    coordinate.setClassifier(classifier);
-    coordinate.setExtension(type);
-    return coordinate;
-  }
-
-  public DependableCoordinate toDependableCoordinate() {
-    var coordinate = new DefaultDependableCoordinate();
-    coordinate.setGroupId(groupId);
-    coordinate.setArtifactId(artifactId);
-    coordinate.setVersion(version);
-    coordinate.setClassifier(classifier);
-    coordinate.setType(type);
-    return coordinate;
-  }
-
-  public static MavenArtifact fromDependency(Dependency dependency) {
-    var mavenArtifact = new MavenArtifact();
-    mavenArtifact.setGroupId(dependency.getGroupId());
-    mavenArtifact.setArtifactId(dependency.getArtifactId());
-    mavenArtifact.setVersion(dependency.getVersion());
-    mavenArtifact.setClassifier(dependency.getClassifier());
-    mavenArtifact.setType(dependency.getType());
-    return mavenArtifact;
   }
 }

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/dependency/MavenProjectDependencyPathResolver.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/dependency/MavenProjectDependencyPathResolver.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2023 - 2024, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.ascopes.protobufmavenplugin.dependency;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
+import javax.inject.Named;
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.execution.MavenSession;
+
+/**
+ * Component that fetches paths for known project dependencies.
+ *
+ * @author Ashley Scopes
+ * @since 1.2.0
+ */
+@Named
+public final class MavenProjectDependencyPathResolver {
+
+  // Important note: we use the org.apache.maven.artifact.Artifact type here. For actual
+  // dependency resolution elsewhere, we use the org.eclipse.aether APIs instead which are
+  // almost identical but incompatible with these calls. I have separated this concern
+  // out to avoid confusion.
+
+  @Inject
+  public MavenProjectDependencyPathResolver() {
+    // Nothing to do.
+  }
+
+  public Collection<Path> resolveProjectDependencies(
+      MavenSession session,
+      DependencyResolutionDepth dependencyResolutionDepth
+  ) {
+    // This assumes the mojo executing this request has specified the correct
+    // requiresDependencyCollection and requiresDependencyResolution scopes in
+    // the @Mojo annotation. This is far more efficient than what we used to do,
+    // which is re-resolve everything from scratch in a more error-prone way.
+    //
+    // This also avoids needing to call the resolver again directly.
+    return session.getCurrentProject().getArtifacts()
+        .stream()
+        .filter(dependencyResolutionDepth == DependencyResolutionDepth.DIRECT
+            ? artifactIsDirectDependency(session)
+            : always())
+        .map(Artifact::getFile)
+        .map(File::toPath)
+        .distinct()
+        .collect(Collectors.toList());
+  }
+
+  private Predicate<Artifact> always() {
+    return anything -> true;
+  }
+
+  private Predicate<Artifact> artifactIsDirectDependency(
+      MavenSession session
+  ) {
+    var dependencies = session.getCurrentProject().getDependencies();
+    return artifact -> dependencies.stream()
+        .anyMatch(dependency -> Objects.equals(dependency.getGroupId(), artifact.getGroupId())
+            && Objects.equals(dependency.getArtifactId(), artifact.getArtifactId())
+            && Objects.equals(dependency.getVersion(), artifact.getVersion())
+            && Objects.equals(dependency.getClassifier(), artifact.getClassifier())
+            && Objects.equals(dependency.getType(), artifact.getType())
+            && Objects.equals(dependency.getScope(), artifact.getScope()));
+  }
+}

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/dependency/ProtocResolver.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/dependency/ProtocResolver.java
@@ -42,7 +42,7 @@ public final class ProtocResolver {
   private static final Logger log = LoggerFactory.getLogger(ProtocResolver.class);
 
   private final HostSystem hostSystem;
-  private final MavenDependencyPathResolver mavenDependencyPathResolver;
+  private final MavenDependencyPathResolver dependencyResolver;
   private final PlatformArtifactFactory platformArtifactFactory;
   private final SystemPathBinaryResolver systemPathResolver;
   private final UrlResourceFetcher urlResourceFetcher;
@@ -50,13 +50,13 @@ public final class ProtocResolver {
   @Inject
   public ProtocResolver(
       HostSystem hostSystem,
-      MavenDependencyPathResolver mavenDependencyPathResolver,
+      MavenDependencyPathResolver dependencyResolver,
       PlatformArtifactFactory platformArtifactFactory,
       SystemPathBinaryResolver systemPathResolver,
       UrlResourceFetcher urlResourceFetcher
   ) {
     this.hostSystem = hostSystem;
-    this.mavenDependencyPathResolver = mavenDependencyPathResolver;
+    this.dependencyResolver = dependencyResolver;
     this.platformArtifactFactory = platformArtifactFactory;
     this.systemPathResolver = systemPathResolver;
     this.urlResourceFetcher = urlResourceFetcher;
@@ -114,6 +114,8 @@ public final class ProtocResolver {
         null
     );
 
-    return mavenDependencyPathResolver.resolveArtifact(session, artifact);
+    return dependencyResolver.resolveOne(session, artifact, DependencyResolutionDepth.DIRECT)
+        .iterator()
+        .next();
   }
 }

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/generate/SourceCodeGenerator.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/generate/SourceCodeGenerator.java
@@ -18,7 +18,7 @@ package io.github.ascopes.protobufmavenplugin.generate;
 
 import io.github.ascopes.protobufmavenplugin.dependency.BinaryPluginResolver;
 import io.github.ascopes.protobufmavenplugin.dependency.JvmPluginResolver;
-import io.github.ascopes.protobufmavenplugin.dependency.MavenDependencyPathResolver;
+import io.github.ascopes.protobufmavenplugin.dependency.MavenProjectDependencyPathResolver;
 import io.github.ascopes.protobufmavenplugin.dependency.ProtocResolver;
 import io.github.ascopes.protobufmavenplugin.dependency.ResolutionException;
 import io.github.ascopes.protobufmavenplugin.dependency.ResolvedPlugin;
@@ -54,7 +54,7 @@ public final class SourceCodeGenerator {
 
   private static final Logger log = LoggerFactory.getLogger(SourceCodeGenerator.class);
 
-  private final MavenDependencyPathResolver mavenDependencyPathResolver;
+  private final MavenProjectDependencyPathResolver mavenProjectDependencyPathResolver;
   private final ProtocResolver protocResolver;
   private final BinaryPluginResolver binaryPluginResolver;
   private final JvmPluginResolver jvmPluginResolver;
@@ -63,14 +63,14 @@ public final class SourceCodeGenerator {
 
   @Inject
   public SourceCodeGenerator(
-      MavenDependencyPathResolver mavenDependencyPathResolver,
+      MavenProjectDependencyPathResolver mavenProjectDependencyPathResolver,
       ProtocResolver protocResolver,
       BinaryPluginResolver binaryPluginResolver,
       JvmPluginResolver jvmPluginResolver,
       ProtoSourceResolver protoListingResolver,
       CommandLineExecutor commandLineExecutor
   ) {
-    this.mavenDependencyPathResolver = mavenDependencyPathResolver;
+    this.mavenProjectDependencyPathResolver = mavenProjectDependencyPathResolver;
     this.protocResolver = protocResolver;
     this.binaryPluginResolver = binaryPluginResolver;
     this.jvmPluginResolver = jvmPluginResolver;
@@ -176,7 +176,7 @@ public final class SourceCodeGenerator {
         request.getDependencyResolutionDepth()
     );
 
-    var dependencyPaths = mavenDependencyPathResolver.resolveProjectDependencyPaths(
+    var dependencyPaths = mavenProjectDependencyPathResolver.resolveProjectDependencies(
         session,
         request.getDependencyResolutionDepth()
     );


### PR DESCRIPTION
This removes the Maven Artifact Transfer dependency entirely and integrates with the Maven Dependency Resolver API directly instead. This helps make this more compatible with the future Maven 4.x API that will expect this usage and this removes a set of dependencies that we do not actually need to be using.

As a small side effect, the project dependency resolution is now even more optimised, as we no longer need to scan project dependencies again to re-resolve them when the direct resolution mode is in use. This should slightly improve build speeds in some more complicated edge cases and configurations.

Closes GH-101.