### PR TITLE
Move MavenArtifact class to base package since it is part of the public API

### DIFF
--- a/src/main/java/io/github/ascopes/protobufmavenplugin/AbstractGenerateMojo.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/AbstractGenerateMojo.java
@@ -20,7 +20,6 @@ import static java.util.Objects.requireNonNullElse;
 import static java.util.Objects.requireNonNullElseGet;
 
 import io.github.ascopes.protobufmavenplugin.dependency.DependencyResolutionDepth;
-import io.github.ascopes.protobufmavenplugin.dependency.MavenArtifact;
 import io.github.ascopes.protobufmavenplugin.dependency.ResolutionException;
 import io.github.ascopes.protobufmavenplugin.generate.ImmutableGenerationRequest;
 import io.github.ascopes.protobufmavenplugin.generate.SourceCodeGenerator;

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/MainGenerateMojo.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/MainGenerateMojo.java
@@ -18,7 +18,6 @@ package io.github.ascopes.protobufmavenplugin;
 
 import io.github.ascopes.protobufmavenplugin.generate.SourceRootRegistrar;
 import java.nio.file.Path;
-import java.util.Set;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/MavenArtifact.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/MavenArtifact.java
@@ -14,15 +14,14 @@
  * limitations under the License.
  */
 
-package io.github.ascopes.protobufmavenplugin.dependency;
+package io.github.ascopes.protobufmavenplugin;
 
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.jspecify.annotations.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /**
@@ -33,8 +32,6 @@ import org.slf4j.LoggerFactory;
  * @since 1.2.0
  */
 public final class MavenArtifact {
-
-  private static final Logger log = LoggerFactory.getLogger(MavenArtifact.class);
 
   private @Nullable String groupId;
   private @Nullable String artifactId;
@@ -78,18 +75,9 @@ public final class MavenArtifact {
     return Optional.ofNullable(type);
   }
 
+  @Parameter(alias = "extension")
   public void setType(@Nullable String type) {
     this.type = type;
-  }
-
-  // Alias to enable compatibility with Dependency objects. This avoids a breaking
-  // change in v1.x.
-  // This should be totally removed in v2.0 to avoid ambiguity.
-  @Deprecated(forRemoval = true, since = "1.2.0")
-  public void setExtension(@Nullable String extension) {
-    log.warn("MavenArtifact.extension is deprecated for removal in v2.0.0. "
-        + "Please use MavenArtifact.type instead for future compatibility.");
-    type = extension;
   }
 
   @Override

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/TestGenerateMojo.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/TestGenerateMojo.java
@@ -18,7 +18,6 @@ package io.github.ascopes.protobufmavenplugin;
 
 import io.github.ascopes.protobufmavenplugin.generate.SourceRootRegistrar;
 import java.nio.file.Path;
-import java.util.Set;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/dependency/BinaryPluginResolver.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/dependency/BinaryPluginResolver.java
@@ -16,6 +16,7 @@
 
 package io.github.ascopes.protobufmavenplugin.dependency;
 
+import io.github.ascopes.protobufmavenplugin.MavenArtifact;
 import io.github.ascopes.protobufmavenplugin.platform.Digests;
 import io.github.ascopes.protobufmavenplugin.platform.FileUtils;
 import java.io.IOException;

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/dependency/JvmPluginResolver.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/dependency/JvmPluginResolver.java
@@ -16,6 +16,7 @@
 
 package io.github.ascopes.protobufmavenplugin.dependency;
 
+import io.github.ascopes.protobufmavenplugin.MavenArtifact;
 import io.github.ascopes.protobufmavenplugin.generate.TemporarySpace;
 import io.github.ascopes.protobufmavenplugin.platform.Digests;
 import io.github.ascopes.protobufmavenplugin.platform.FileUtils;

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/dependency/MavenDependencyPathResolver.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/dependency/MavenDependencyPathResolver.java
@@ -16,6 +16,7 @@
 
 package io.github.ascopes.protobufmavenplugin.dependency;
 
+import io.github.ascopes.protobufmavenplugin.MavenArtifact;
 import java.io.File;
 import java.nio.file.Path;
 import java.util.ArrayList;

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/dependency/PlatformArtifactFactory.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/dependency/PlatformArtifactFactory.java
@@ -19,6 +19,7 @@ package io.github.ascopes.protobufmavenplugin.dependency;
 import static java.util.Objects.requireNonNullElse;
 import static java.util.Objects.requireNonNullElseGet;
 
+import io.github.ascopes.protobufmavenplugin.MavenArtifact;
 import io.github.ascopes.protobufmavenplugin.platform.HostSystem;
 import javax.inject.Inject;
 import javax.inject.Named;

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/generate/GenerationRequest.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/generate/GenerationRequest.java
@@ -16,8 +16,8 @@
 
 package io.github.ascopes.protobufmavenplugin.generate;
 
+import io.github.ascopes.protobufmavenplugin.MavenArtifact;
 import io.github.ascopes.protobufmavenplugin.dependency.DependencyResolutionDepth;
-import io.github.ascopes.protobufmavenplugin.dependency.MavenArtifact;
 import java.net.URL;
 import java.nio.file.Path;
 import java.util.Collection;

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/source/ProtoSourceResolver.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/source/ProtoSourceResolver.java
@@ -19,7 +19,6 @@ package io.github.ascopes.protobufmavenplugin.source;
 import static java.util.function.Predicate.not;
 
 import io.github.ascopes.protobufmavenplugin.platform.FileUtils;
-import io.github.ascopes.protobufmavenplugin.platform.HostSystem;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;


### PR DESCRIPTION
Move MavenArtifact class to base package since it is part of the public API that is referenced in documentation.