### PR TITLE
Remove documentation for version ranges for protoc.

### DIFF
--- a/src/main/java/io/github/ascopes/protobufmavenplugin/AbstractGenerateMojo.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/AbstractGenerateMojo.java
@@ -66,10 +66,6 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    * <p>This should correspond to the version of {@code protobuf-java} or similar that is in
    * use.
    *
-   * <p>The value can be a static version, or a valid Maven version range (such as
-   * "{@code [3.5.0,4.0.0)}"). It is recommended to use a static version to ensure your builds are
-   * reproducible.
-   *
    * <p>If set to "{@code PATH}", then {@code protoc} is resolved from the system path rather than
    * being downloaded. This is useful if you need to use an unsupported architecture/OS, or a
    * development version of {@code protoc}.


### PR DESCRIPTION
The version range compatibility has never worked correctly and is a suboptimal solution that does not provide reproducible builds. In v1.2.0, we are removing it entirely as it has never been supported properly.