### PR TITLE
Require Maven to be running online during execution.

### DIFF
--- a/src/main/java/io/github/ascopes/protobufmavenplugin/MainGenerateMojo.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/MainGenerateMojo.java
@@ -44,6 +44,7 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
     defaultPhase = LifecyclePhase.GENERATE_SOURCES,
     requiresDependencyCollection = ResolutionScope.COMPILE_PLUS_RUNTIME,
     requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME,
+    requiresOnline = true,
     threadSafe = true
 )
 public final class MainGenerateMojo extends AbstractGenerateMojo {

--- a/src/main/java/io/github/ascopes/protobufmavenplugin/TestGenerateMojo.java
+++ b/src/main/java/io/github/ascopes/protobufmavenplugin/TestGenerateMojo.java
@@ -49,6 +49,7 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
     defaultPhase = LifecyclePhase.GENERATE_TEST_SOURCES,
     requiresDependencyCollection = ResolutionScope.TEST,
     requiresDependencyResolution = ResolutionScope.TEST,
+    requiresOnline = true,
     threadSafe = true
 )
 public final class TestGenerateMojo extends AbstractGenerateMojo {


### PR DESCRIPTION
Enforce that Maven is running in online mode during builds due to the nature of how resolution is performed.