### PR TITLE
Do not pass missing default source directory to protoc

### DIFF
--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/AbstractGenerateMojo.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/AbstractGenerateMojo.java
@@ -579,7 +579,7 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
 
   private Collection<Path> sourceDirectories() {
     if (sourceDirectories == null || sourceDirectories.isEmpty()) {
-      var defaultSourceDirectory = defaultSourceDirectory()
+      var defaultSourceDirectory = defaultSourceDirectory();
       // Don't bother injecting the default source directory if it doesn't exist. Let the
       // plugin error instead.
       return Files.exists(defaultSourceDirectory)

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/AbstractGenerateMojo.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/AbstractGenerateMojo.java
@@ -28,6 +28,7 @@ import io.github.ascopes.protobufmavenplugin.generate.SourceRootRegistrar;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
@@ -578,7 +579,12 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
 
   private Collection<Path> sourceDirectories() {
     if (sourceDirectories == null || sourceDirectories.isEmpty()) {
-      return List.of(defaultSourceDirectory());
+      var defaultSourceDirectory = defaultSourceDirectory()
+      // Don't bother injecting the default source directory if it doesn't exist. Let the
+      // plugin error instead.
+      return Files.exists(defaultSourceDirectory)
+          ? List.of(defaultSourceDirectory)
+          : List.of();
     }
 
     return sourceDirectories.stream()


### PR DESCRIPTION
If the default source directory does not exist, do not bother passing it to protoc as it will just result in an additional warning for the import path.