### PR TITLE
GH-168: Support provisionally providing options to protoc plugins

### DIFF
--- a/protobuf-maven-plugin/src/it/http-url-grpc-plugin/pom.xml
+++ b/protobuf-maven-plugin/src/it/http-url-grpc-plugin/pom.xml
@@ -97,7 +97,9 @@
 
         <configuration>
           <binaryUrlPlugins>
-            <binaryUrlPlugin>https://repo1.maven.org/maven2/io/grpc/protoc-gen-grpc-java/${grpc.version}/protoc-gen-grpc-java-${grpc.version}-linux-x86_64.exe</binaryUrlPlugin>
+            <binaryUrlPlugin>
+              <url>https://repo1.maven.org/maven2/io/grpc/protoc-gen-grpc-java/${grpc.version}/protoc-gen-grpc-java-${grpc.version}-linux-x86_64.exe</url>
+            </binaryUrlPlugin>
           </binaryUrlPlugins>
 
           <protocVersion>${protobuf.version}</protocVersion>

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/AbstractGenerateMojo.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/AbstractGenerateMojo.java
@@ -90,7 +90,7 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    * executable, or are using a more obscure system architecture, then using a
    * {@code jvmMavenPlugin} may be more preferrable.
    *
-   * <p>{@code MavenArtifactBean} objects support the following attributes:
+   * <p>Objects support the following attributes:
    *
    * <ul>
    *   <li>{@code groupId} - the group ID - required</li>
@@ -98,14 +98,14 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    *   <li>{@code version} - the version - required</li>
    *   <li>{@code type} - the artifact type - optional</li>
    *   <li>{@code classifier} - the artifact classifier - optional</li>
-   *   <li>{@code dependencyResolutionDepth} - the dependency resolution depth to override
-   *      the project settings with - optional</li>
+   *   <li>{@code options} - a string of options to pass to the plugin
+   *       - optional.</li>
    * </ul>
    *
    * @since 0.3.0
    */
   @Parameter
-  @Nullable List<MavenArtifactBean> binaryMavenPlugins;
+  @Nullable List<MavenProtocPluginBean> binaryMavenPlugins;
 
   /**
    * Binary plugins to use with the protobuf compiler, sourced from the system {@code PATH}.
@@ -113,14 +113,22 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    * <p>For example:
    * <pre>{@code
    * <binaryPathPlugins>
-   *   <binaryPathPlugin>protoc-gen-grpc-java</binaryPathPlugin>
+   *   <binaryPathPlugin>
+   *     <name>protoc-gen-grpc-java</name>
+   *   </binaryPathPlugin>
+   *   <binaryPathPlugin>
+   *     <name>protoc-gen-something-else</name>
+   *     <options>foo=bar</options>
+   *   </binaryPathPlugin>
    * </binaryPathPlugins>
    * }</pre>
    *
-   * @since 0.3.0
+   * <p>Prior to v2.0.0, this attribute was a list of strings.
+   *
+   * @since 2.0.0
    */
   @Parameter
-  @Nullable List<String> binaryPathPlugins;
+  @Nullable List<PathProtocPluginBean> binaryPathPlugins;
 
   /**
    * Binary plugins to use with the protobuf compiler, specified as a valid URL.
@@ -136,14 +144,22 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    * <p>For example:
    * <pre>{@code
    *   <binaryUrlPlugins>
-   *     <binaryUrlPlugin>ftp://myorganisation.org/protoc/plugins/myplugin.exe</binaryUrlPlugin>
+   *     <binaryUrlPlugin>
+   *       <url>ftp://myorganisation.org/protoc/plugins/myplugin.exe</url>
+   *     </binaryUrlPlugin>
+   *     <binaryUrlPlugin>
+   *       <url>ftp://myorganisation.org/protoc/plugins/myplugin2.exe</url>
+   *       <options>foo=bar</options>
+   *     </binaryUrlPlugin>
    *   </binaryUrlPlugins>
    * }</pre>
    *
-   * @since 0.4.0
+   * <p>Prior to v2.0.0, this attribute was a list of URLs.
+   *
+   * @since 2.0.0
    */
   @Parameter
-  @Nullable List<URL> binaryUrlPlugins;
+  @Nullable List<UrlProtocPluginBean> binaryUrlPlugins;
 
   /**
    * The scope to resolve dependencies with.
@@ -201,7 +217,7 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    *
    * <p>These will not be compiled into Java sources directly.
    *
-   * <p>{@code MavenArtifactBean} objects support the following attributes:
+   * <p>Objects support the following attributes:
    *
    * <ul>
    *   <li>{@code groupId} - the group ID - required</li>
@@ -254,7 +270,7 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    * <p>This mechanism allows plugin vendors to implement their plugins in
    * Java and just distribute platform-independent JAR instead.
    *
-   * <p>{@code MavenArtifactBean} objects support the following attributes:
+   * <p>Objects support the following attributes:
    *
    * <ul>
    *   <li>{@code groupId} - the group ID - required</li>
@@ -262,14 +278,14 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    *   <li>{@code version} - the version - required</li>
    *   <li>{@code type} - the artifact type - optional</li>
    *   <li>{@code classifier} - the artifact classifier - optional</li>
-   *   <li>{@code dependencyResolutionDepth} - the dependency resolution depth to override
-   *      the project settings with - optional</li>
+   *   <li>{@code options} - a string of options to pass to the plugin
+   *       - optional.</li>
    * </ul>
    *
    * @since 0.3.0
    */
   @Parameter
-  @Nullable List<MavenArtifactBean> jvmMavenPlugins;
+  @Nullable List<MavenProtocPluginBean> jvmMavenPlugins;
 
   /**
    * Whether to only generate "lite" messages or not.
@@ -356,7 +372,7 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    * </sourceDependencies>
    * }</pre>
    *
-   * <p>{@code MavenArtifactBean} objects support the following attributes:
+   * <p>Objects support the following attributes:
    *
    * <ul>
    *   <li>{@code groupId} - the group ID - required</li>

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/MavenProtocPlugin.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/MavenProtocPlugin.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2023 - 2024, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.ascopes.protobufmavenplugin;
+
+import org.immutables.value.Value.Immutable;
+import org.immutables.value.Value.Modifiable;
+import org.jspecify.annotations.Nullable;
+
+
+/**
+ * Implementation independent descriptor for a protoc plugin that can
+ * be resolved from a Maven repository.
+ *
+ * @author Ashley Scopes
+ * @since 2.0.0
+ */
+@Immutable
+@Modifiable
+@SuppressWarnings("immutables:subtype")
+public interface MavenProtocPlugin extends MavenArtifact, ProtocPlugin {
+
+  // Do not allow Immutables to allow us to specify this attribute.
+  @Override
+  @Nullable
+  default DependencyResolutionDepth getDependencyResolutionDepth() {
+    return null;
+  }
+}

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/PathProtocPlugin.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/PathProtocPlugin.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2023 - 2024, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.ascopes.protobufmavenplugin;
+
+import org.immutables.value.Value.Modifiable;
+
+
+/**
+ * Implementation independent descriptor for a protoc plugin that can
+ * be resolved from the system {@code $PATH}.
+ *
+ * @author Ashley Scopes
+ * @since 2.0.0
+ */
+@Modifiable
+public interface PathProtocPlugin extends ProtocPlugin {
+
+  String getName();
+}

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/ProtocPlugin.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/ProtocPlugin.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2023 - 2024, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.ascopes.protobufmavenplugin;
+
+import org.jspecify.annotations.Nullable;
+
+
+/**
+ * Base interface for a Protoc plugin reference.
+ *
+ * @author Ashley Scopes
+ * @since 2.0.0
+ */
+public interface ProtocPlugin {
+  @Nullable
+  String getOptions();
+}

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/UrlProtocPlugin.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/UrlProtocPlugin.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2023 - 2024, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.ascopes.protobufmavenplugin;
+
+import java.net.URL;
+import org.immutables.value.Value.Modifiable;
+
+
+/**
+ * Implementation independent descriptor for a protoc plugin that can
+ * be resolved from a URL.
+ *
+ * @author Ashley Scopes
+ * @since 2.0.0
+ */
+@Modifiable
+public interface UrlProtocPlugin extends ProtocPlugin {
+
+  URL getUrl();
+}

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/execute/ArgLineBuilder.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/execute/ArgLineBuilder.java
@@ -140,6 +140,9 @@ public final class ArgLineBuilder {
       // to inject this flag to be consistent.
       list.add("--plugin=protoc-gen-" + plugin.getId() + "=" + plugin.getPath());
       list.add("--" + plugin.getId() + "_out=" + outputPath);
+      plugin.getOptions()
+          .map(options -> "--" + plugin.getId() + "_opt=" + options)
+          .ifPresent(list::add);
     }
   }
 }

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/execute/ArgLineBuilder.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/execute/ArgLineBuilder.java
@@ -17,7 +17,7 @@
 package io.github.ascopes.protobufmavenplugin.execute;
 
 import io.github.ascopes.protobufmavenplugin.generate.Language;
-import io.github.ascopes.protobufmavenplugin.plugin.ResolvedPlugin;
+import io.github.ascopes.protobufmavenplugin.plugin.ResolvedProtocPlugin;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -86,7 +86,7 @@ public final class ArgLineBuilder {
     return this;
   }
 
-  public ArgLineBuilder plugins(Collection<ResolvedPlugin> plugins, Path outputPath) {
+  public ArgLineBuilder plugins(Collection<ResolvedProtocPlugin> plugins, Path outputPath) {
     for (var plugin : plugins) {
       targets.add(new PluginTarget(plugin, outputPath));
     }
@@ -126,10 +126,10 @@ public final class ArgLineBuilder {
 
   private static final class PluginTarget implements Target {
 
-    private final ResolvedPlugin plugin;
+    private final ResolvedProtocPlugin plugin;
     private final Path outputPath;
 
-    private PluginTarget(ResolvedPlugin plugin, Path outputPath) {
+    private PluginTarget(ResolvedProtocPlugin plugin, Path outputPath) {
       this.plugin = plugin;
       this.outputPath = outputPath;
     }

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generate/GenerationRequest.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generate/GenerationRequest.java
@@ -18,6 +18,9 @@ package io.github.ascopes.protobufmavenplugin.generate;
 
 import io.github.ascopes.protobufmavenplugin.DependencyResolutionDepth;
 import io.github.ascopes.protobufmavenplugin.MavenArtifact;
+import io.github.ascopes.protobufmavenplugin.MavenProtocPlugin;
+import io.github.ascopes.protobufmavenplugin.PathProtocPlugin;
+import io.github.ascopes.protobufmavenplugin.UrlProtocPlugin;
 import java.net.URL;
 import java.nio.file.Path;
 import java.util.Collection;
@@ -31,11 +34,11 @@ import org.immutables.value.Value.Immutable;
 @Immutable
 public interface GenerationRequest {
 
-  Collection<? extends MavenArtifact> getBinaryMavenPlugins();
+  Collection<? extends MavenProtocPlugin> getBinaryMavenPlugins();
 
-  Collection<String> getBinaryPathPlugins();
+  Collection<? extends PathProtocPlugin> getBinaryPathPlugins();
 
-  Collection<URL> getBinaryUrlPlugins();
+  Collection<? extends UrlProtocPlugin> getBinaryUrlPlugins();
 
   DependencyResolutionDepth getDependencyResolutionDepth();
 
@@ -45,7 +48,7 @@ public interface GenerationRequest {
 
   Collection<Path> getImportPaths();
 
-  Collection<? extends MavenArtifact> getJvmMavenPlugins();
+  Collection<? extends MavenProtocPlugin> getJvmMavenPlugins();
 
   Path getOutputDirectory();
 

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generate/SourceCodeGenerator.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generate/SourceCodeGenerator.java
@@ -23,7 +23,7 @@ import io.github.ascopes.protobufmavenplugin.execute.ArgLineBuilder;
 import io.github.ascopes.protobufmavenplugin.execute.CommandLineExecutor;
 import io.github.ascopes.protobufmavenplugin.plugin.BinaryPluginResolver;
 import io.github.ascopes.protobufmavenplugin.plugin.JvmPluginResolver;
-import io.github.ascopes.protobufmavenplugin.plugin.ResolvedPlugin;
+import io.github.ascopes.protobufmavenplugin.plugin.ResolvedProtocPlugin;
 import io.github.ascopes.protobufmavenplugin.protoc.ProtocResolver;
 import io.github.ascopes.protobufmavenplugin.source.ProtoFileListing;
 import io.github.ascopes.protobufmavenplugin.source.ProtoSourceResolver;
@@ -150,7 +150,7 @@ public final class SourceCodeGenerator {
     return commandLineExecutor.execute(args);
   }
 
-  private Collection<ResolvedPlugin> discoverPlugins(
+  private Collection<ResolvedProtocPlugin> discoverPlugins(
       GenerationRequest request
   ) throws IOException, ResolutionException {
     return concat(

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugin/JvmPluginResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugin/JvmPluginResolver.java
@@ -17,7 +17,7 @@
 package io.github.ascopes.protobufmavenplugin.plugin;
 
 import io.github.ascopes.protobufmavenplugin.DependencyResolutionDepth;
-import io.github.ascopes.protobufmavenplugin.MavenArtifact;
+import io.github.ascopes.protobufmavenplugin.MavenProtocPlugin;
 import io.github.ascopes.protobufmavenplugin.dependency.MavenDependencyPathResolver;
 import io.github.ascopes.protobufmavenplugin.dependency.ResolutionException;
 import io.github.ascopes.protobufmavenplugin.generate.TemporarySpace;
@@ -63,18 +63,18 @@ public final class JvmPluginResolver {
     this.temporarySpace = temporarySpace;
   }
 
-  public Collection<ResolvedPlugin> resolveMavenPlugins(
-      Collection<? extends MavenArtifact> plugins
+  public Collection<ResolvedProtocPlugin> resolveMavenPlugins(
+      Collection<? extends MavenProtocPlugin> plugins
   ) throws IOException, ResolutionException {
-    var resolvedPlugins = new ArrayList<ResolvedPlugin>();
+    var resolvedPlugins = new ArrayList<ResolvedProtocPlugin>();
     for (var plugin : plugins) {
       resolvedPlugins.add(resolve(plugin));
     }
     return resolvedPlugins;
   }
 
-  private ResolvedPlugin resolve(
-      MavenArtifact plugin
+  private ResolvedProtocPlugin resolve(
+      MavenProtocPlugin plugin
   ) throws IOException, ResolutionException {
     var pluginId = pluginIdDigest(plugin);
     var argLine = resolveAndBuildArgLine(plugin);
@@ -83,15 +83,16 @@ public final class JvmPluginResolver {
         ? writeWindowsBatchScript(pluginId, argLine)
         : writeShellScript(pluginId, argLine);
 
-    return ImmutableResolvedPlugin
+    return ImmutableResolvedProtocPlugin
         .builder()
         .id(pluginId)
         .path(scriptPath)
+        .options(plugin.getOptions())
         .build();
   }
 
   private List<String> resolveAndBuildArgLine(
-      MavenArtifact plugin
+      MavenProtocPlugin plugin
   ) throws ResolutionException {
 
     // Resolve dependencies first.
@@ -129,7 +130,7 @@ public final class JvmPluginResolver {
     return sb.toString();
   }
 
-  private String pluginIdDigest(MavenArtifact plugin) {
+  private String pluginIdDigest(MavenProtocPlugin plugin) {
     return Digests.sha1(plugin.toString());
   }
 

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugin/ResolvedProtocPlugin.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugin/ResolvedProtocPlugin.java
@@ -17,6 +17,7 @@
 package io.github.ascopes.protobufmavenplugin.plugin;
 
 import java.nio.file.Path;
+import java.util.Optional;
 import org.immutables.value.Value.Immutable;
 
 /**
@@ -25,9 +26,11 @@ import org.immutables.value.Value.Immutable;
  * @author Ashley Scopes
  */
 @Immutable
-public interface ResolvedPlugin {
+public interface ResolvedProtocPlugin {
 
   Path getPath();
 
   String getId();
+
+  Optional<String> getOptions();
 }

--- a/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/AbstractGenerateMojoTestTemplate.java
+++ b/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/AbstractGenerateMojoTestTemplate.java
@@ -35,7 +35,6 @@ import io.github.ascopes.protobufmavenplugin.generate.SourceCodeGenerator;
 import io.github.ascopes.protobufmavenplugin.generate.SourceRootRegistrar;
 import java.io.File;
 import java.io.IOException;
-import java.net.URL;
 import java.nio.file.Path;
 import java.util.EnumSet;
 import java.util.List;
@@ -188,7 +187,7 @@ abstract class AbstractGenerateMojoTestTemplate<A extends AbstractGenerateMojo> 
     @NullAndEmptySource
     @ParameterizedTest(name = "when {0}")
     void whenBinaryMavenPluginsNullExpectEmptyListInRequest(
-        List<MavenArtifactBean> plugins
+        List<MavenProtocPluginBean> plugins
     ) throws Throwable {
       // Given
       mojo.binaryMavenPlugins = plugins;
@@ -207,7 +206,7 @@ abstract class AbstractGenerateMojoTestTemplate<A extends AbstractGenerateMojo> 
     @Test
     void whenBinaryMavenPluginsProvidedExpectPluginsInRequest() throws Throwable {
       // Given
-      List<MavenArtifactBean> plugins = mock();
+      List<MavenProtocPluginBean> plugins = mock();
       mojo.binaryMavenPlugins = plugins;
 
       // When
@@ -228,7 +227,9 @@ abstract class AbstractGenerateMojoTestTemplate<A extends AbstractGenerateMojo> 
     @DisplayName("when binaryPathPlugins is null, expect an empty list in the request")
     @NullAndEmptySource
     @ParameterizedTest(name = "when {0}")
-    void whenBinaryPathPluginsNullExpectEmptyListInRequest(List<String> plugins) throws Throwable {
+    void whenBinaryPathPluginsNullExpectEmptyListInRequest(
+        List<PathProtocPluginBean> plugins
+    ) throws Throwable {
       // Given
       mojo.binaryPathPlugins = plugins;
 
@@ -246,7 +247,7 @@ abstract class AbstractGenerateMojoTestTemplate<A extends AbstractGenerateMojo> 
     @Test
     void whenBinaryPathPluginsProvidedExpectPluginsInRequest() throws Throwable {
       // Given
-      List<String> plugins = mock();
+      List<PathProtocPluginBean> plugins = mock();
       mojo.binaryPathPlugins = plugins;
 
       // When
@@ -267,7 +268,9 @@ abstract class AbstractGenerateMojoTestTemplate<A extends AbstractGenerateMojo> 
     @DisplayName("when binaryUrlPlugins is null, expect an empty list in the request")
     @NullAndEmptySource
     @ParameterizedTest(name = "when {0}")
-    void whenBinaryUrlPluginsNullExpectEmptyListInRequest(List<URL> plugins) throws Throwable {
+    void whenBinaryUrlPluginsNullExpectEmptyListInRequest(
+        List<UrlProtocPluginBean> plugins
+    ) throws Throwable {
       // Given
       mojo.binaryUrlPlugins = plugins;
 
@@ -285,7 +288,7 @@ abstract class AbstractGenerateMojoTestTemplate<A extends AbstractGenerateMojo> 
     @Test
     void whenBinaryUrlPluginsProvidedExpectPluginsInRequest() throws Throwable {
       // Given
-      List<URL> plugins = mock();
+      List<UrlProtocPluginBean> plugins = mock();
       mojo.binaryUrlPlugins = plugins;
 
       // When
@@ -478,7 +481,7 @@ abstract class AbstractGenerateMojoTestTemplate<A extends AbstractGenerateMojo> 
     @NullAndEmptySource
     @ParameterizedTest(name = "when {0}")
     void whenJvmMavenPluginsNullExpectEmptyListInRequest(
-        List<MavenArtifactBean> plugins
+        List<MavenProtocPluginBean> plugins
     ) throws Throwable {
       // Given
       mojo.jvmMavenPlugins = plugins;
@@ -497,7 +500,7 @@ abstract class AbstractGenerateMojoTestTemplate<A extends AbstractGenerateMojo> 
     @Test
     void whenJvmMavenPluginsProvidedExpectPluginsInRequest() throws Throwable {
       // Given
-      List<MavenArtifactBean> plugins = mock();
+      List<MavenProtocPluginBean> plugins = mock();
       mojo.jvmMavenPlugins = plugins;
 
       // When


### PR DESCRIPTION
- GH-168: Add 'options' attributes to protoc plugin parameters
    - Add options attribute to binaryMavenPlugins param.
    - Add options attribute to jvmMavenPlugins param.
    - Change binaryPathPlugins param to be a list of objects
      with a name attribute (**breaking change**).
    - Change binaryUrlPlugins param to be a list of objects
      with a url attribute (**breaking change**).
    - Add options attribute to binaryPathPlugins param.
    - Add options attribute to binaryUrlPlugins param.
    - Disallow setting dependencyResolutionDepth on Maven
      protoc plugin params, as it should always be
      ignored.
- GH-168: Propagate plugin options to protoc argline