### PR TITLE
GH-182: Optional plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>io.github.ascopes</groupId>
   <artifactId>protobuf-maven-plugin-parent</artifactId>
-  <version>2.0.0-alpha2-SNAPSHOT</version>
+  <version>2.0.0-alpha3-SNAPSHOT</version>
 
   <name>Protobuf Maven Plugin Parent</name>
   <description>Parent POM for the Protobuf Maven Plugin.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>io.github.ascopes</groupId>
   <artifactId>protobuf-maven-plugin-parent</artifactId>
-  <version>2.0.0-alpha3-SNAPSHOT</version>
+  <version>2.0.0-alpha2-SNAPSHOT</version>
 
   <name>Protobuf Maven Plugin Parent</name>
   <description>Parent POM for the Protobuf Maven Plugin.</description>

--- a/protobuf-maven-plugin/pom.xml
+++ b/protobuf-maven-plugin/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes</groupId>
     <artifactId>protobuf-maven-plugin-parent</artifactId>
-    <version>2.0.0-alpha3-SNAPSHOT</version>
+    <version>2.0.0-alpha2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/protobuf-maven-plugin/pom.xml
+++ b/protobuf-maven-plugin/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes</groupId>
     <artifactId>protobuf-maven-plugin-parent</artifactId>
-    <version>2.0.0-alpha2-SNAPSHOT</version>
+    <version>2.0.0-alpha3-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/AbstractGenerateMojo.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/AbstractGenerateMojo.java
@@ -189,6 +189,17 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
   boolean failOnMissingSources;
 
   /**
+   * Whether to fail if no output languages and no plugins are enabled.
+   *
+   * <p>This defaults to {@code true}, but may be set to {@code false} if all plugins are optional
+   * and no languages are enabled.
+   *
+   * @since 2.0.0
+   */
+  @Parameter(defaultValue = "true")
+  boolean failOnMissingTargets;
+
+  /**
    * Specify that any warnings emitted by {@code protoc} should be treated as errors and fail the
    * build.
    *
@@ -560,6 +571,7 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
             .map(File::toPath)
             .collect(Collectors.toList()))
         .isFailOnMissingSources(failOnMissingSources)
+        .isFailOnMissingTargets(failOnMissingTargets)
         .isFatalWarnings(fatalWarnings)
         .isIgnoreProjectDependencies(ignoreProjectDependencies)
         .isLiteEnabled(liteOnly)

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/AbstractGenerateMojo.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/AbstractGenerateMojo.java
@@ -99,6 +99,9 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    *   <li>{@code classifier} - the artifact classifier - optional</li>
    *   <li>{@code options} - a string of options to pass to the plugin
    *       - optional.</li>
+   *   <li>{@code skip} - set to {@code true} to skip invoking this plugin -
+   *       useful if you want to control whether the plugin runs via a
+   *       property - optional.</li>
    * </ul>
    *
    * @since 0.3.0
@@ -124,6 +127,17 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    *
    * <p>Prior to v2.0.0, this attribute was a list of strings.
    *
+   * <p>Objects support the following attributes:
+   *
+   * <ul>
+   *   <li>{@code name} - the name of the binary to resolve.</li>
+   *   <li>{@code options} - a string of options to pass to the plugin
+   *       - optional.</li>
+   *   <li>{@code skip} - set to {@code true} to skip invoking this plugin -
+   *       useful if you want to control whether the plugin runs via a
+   *       property - optional.</li>
+   * </ul>
+   *
    * @since 2.0.0
    */
   @Parameter
@@ -133,6 +147,7 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    * Binary plugins to use with the protobuf compiler, specified as a valid URL.
    *
    * <p>This includes support for:
+   *
    * <ul>
    *   <li>Local file system objects, specified using {@code file://path/to/file}</li>
    *   <li>HTTP resources, specified using {@code http://example.website/path/to/file}</li>
@@ -154,6 +169,17 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    * }</pre>
    *
    * <p>Prior to v2.0.0, this attribute was a list of URLs.
+   *
+   * <p>Objects support the following attributes:
+   *
+   * <ul>
+   *   <li>{@code url} - the URL to resolve.</li>
+   *   <li>{@code options} - a string of options to pass to the plugin
+   *       - optional.</li>
+   *   <li>{@code skip} - set to {@code true} to skip invoking this plugin -
+   *       useful if you want to control whether the plugin runs via a
+   *       property - optional.</li>
+   * </ul>
    *
    * @since 2.0.0
    */
@@ -287,6 +313,9 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    *   <li>{@code classifier} - the artifact classifier - optional</li>
    *   <li>{@code options} - a string of options to pass to the plugin
    *       - optional.</li>
+   *   <li>{@code skip} - set to {@code true} to skip invoking this plugin -
+   *       useful if you want to control whether the plugin runs via a
+   *       property - optional.</li>
    * </ul>
    *
    * @since 0.3.0

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/MavenProtocPlugin.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/MavenProtocPlugin.java
@@ -16,6 +16,7 @@
 
 package io.github.ascopes.protobufmavenplugin;
 
+import org.immutables.value.Value.Derived;
 import org.immutables.value.Value.Immutable;
 import org.immutables.value.Value.Modifiable;
 import org.jspecify.annotations.Nullable;
@@ -34,6 +35,7 @@ import org.jspecify.annotations.Nullable;
 public interface MavenProtocPlugin extends MavenArtifact, ProtocPlugin {
 
   // Do not allow Immutables to allow us to specify this attribute.
+  @Derived
   @Override
   @Nullable
   default DependencyResolutionDepth getDependencyResolutionDepth() {

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/OptionalProtocPlugin.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/OptionalProtocPlugin.java
@@ -16,22 +16,19 @@
 
 package io.github.ascopes.protobufmavenplugin;
 
-import java.net.URL;
-import org.immutables.value.Value.Modifiable;
-
+import org.immutables.value.Value.Default;
 
 /**
- * Implementation independent descriptor for a protoc plugin that can
- * be resolved from a URL.
+ * Protoc plugin base that can be optionally ignored if it cannot be resolved.
  *
- * <p>URL-based plugins can be marked as optional if they should be
- * skipped when the resource is unable to be resolved.
+ * <p>By default, plugins are <strong>NOT</strong> optional.
  *
- * @author Ashley Scopes
+ * @author Ashley Scopes, Anthony Alayo
  * @since 2.0.0
  */
-@Modifiable
-public interface UrlProtocPlugin extends OptionalProtocPlugin {
-
-  URL getUrl();
+public interface OptionalProtocPlugin extends ProtocPlugin {
+  @Default
+  default boolean isOptional() {
+    return false;
+  }
 }

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/OptionalProtocPlugin.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/OptionalProtocPlugin.java
@@ -16,6 +16,8 @@
 
 package io.github.ascopes.protobufmavenplugin;
 
+import org.immutables.value.Value.Default;
+
 /**
  * Protoc plugin base that can be optionally ignored if it cannot be resolved.
  *
@@ -26,6 +28,8 @@ package io.github.ascopes.protobufmavenplugin;
  */
 public interface OptionalProtocPlugin extends ProtocPlugin {
 
-  // Expected to default to false implicitly.
-  boolean isOptional();
+  @Default
+  default boolean isOptional() {
+    return false;
+  }
 }

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/OptionalProtocPlugin.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/OptionalProtocPlugin.java
@@ -16,8 +16,6 @@
 
 package io.github.ascopes.protobufmavenplugin;
 
-import org.immutables.value.Value.Default;
-
 /**
  * Protoc plugin base that can be optionally ignored if it cannot be resolved.
  *
@@ -28,7 +26,6 @@ import org.immutables.value.Value.Default;
  */
 public interface OptionalProtocPlugin extends ProtocPlugin {
 
-  @Default
   default boolean isOptional() {
     return false;
   }

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/OptionalProtocPlugin.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/OptionalProtocPlugin.java
@@ -16,8 +16,6 @@
 
 package io.github.ascopes.protobufmavenplugin;
 
-import org.immutables.value.Value.Default;
-
 /**
  * Protoc plugin base that can be optionally ignored if it cannot be resolved.
  *
@@ -27,8 +25,7 @@ import org.immutables.value.Value.Default;
  * @since 2.0.0
  */
 public interface OptionalProtocPlugin extends ProtocPlugin {
-  @Default
-  default boolean isOptional() {
-    return false;
-  }
+
+  // Expected to default to false implicitly.
+  boolean isOptional();
 }

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/PathProtocPlugin.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/PathProtocPlugin.java
@@ -23,11 +23,14 @@ import org.immutables.value.Value.Modifiable;
  * Implementation independent descriptor for a protoc plugin that can
  * be resolved from the system {@code $PATH}.
  *
+ * <p>Path-based plugins can be marked as optional if they should be
+ * skipped when the resource is unable to be resolved.
+ *
  * @author Ashley Scopes
  * @since 2.0.0
  */
 @Modifiable
-public interface PathProtocPlugin extends ProtocPlugin {
+public interface PathProtocPlugin extends OptionalProtocPlugin {
 
   String getName();
 }

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/ProtocPlugin.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/ProtocPlugin.java
@@ -28,4 +28,7 @@ import org.jspecify.annotations.Nullable;
 public interface ProtocPlugin {
   @Nullable
   String getOptions();
+
+  @Nullable
+  Boolean isOptional();
 }

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/ProtocPlugin.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/ProtocPlugin.java
@@ -28,4 +28,6 @@ import org.jspecify.annotations.Nullable;
 public interface ProtocPlugin {
   @Nullable
   String getOptions();
+
+  boolean isSkip();
 }

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/ProtocPlugin.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/ProtocPlugin.java
@@ -16,7 +16,6 @@
 
 package io.github.ascopes.protobufmavenplugin;
 
-import org.immutables.value.Value.Default,;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -29,7 +28,6 @@ public interface ProtocPlugin {
   @Nullable
   String getOptions();
 
-  @Default
   default boolean isSkip() {
     return false;
   }

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/ProtocPlugin.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/ProtocPlugin.java
@@ -16,8 +16,8 @@
 
 package io.github.ascopes.protobufmavenplugin;
 
+import org.immutables.value.Value.Default,;
 import org.jspecify.annotations.Nullable;
-
 
 /**
  * Base interface for a Protoc plugin reference.
@@ -29,5 +29,8 @@ public interface ProtocPlugin {
   @Nullable
   String getOptions();
 
-  boolean isSkip();
+  @Default
+  default boolean isSkip() {
+    return false;
+  }
 }

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/ProtocPlugin.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/ProtocPlugin.java
@@ -28,7 +28,4 @@ import org.jspecify.annotations.Nullable;
 public interface ProtocPlugin {
   @Nullable
   String getOptions();
-
-  @Nullable
-  Boolean isOptional();
 }

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generate/GenerationRequest.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generate/GenerationRequest.java
@@ -61,6 +61,8 @@ public interface GenerationRequest {
 
   boolean isFailOnMissingSources();
 
+  boolean isFailOnMissingTargets();
+
   boolean isFatalWarnings();
 
   boolean isIgnoreProjectDependencies();

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generate/SourceCodeGenerator.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generate/SourceCodeGenerator.java
@@ -16,7 +16,6 @@
 
 package io.github.ascopes.protobufmavenplugin.generate;
 
-import io.github.ascopes.protobufmavenplugin.ProtocPlugin;
 import io.github.ascopes.protobufmavenplugin.dependency.MavenDependencyPathResolver;
 import io.github.ascopes.protobufmavenplugin.dependency.MavenProjectDependencyPathResolver;
 import io.github.ascopes.protobufmavenplugin.dependency.ResolutionException;
@@ -105,10 +104,16 @@ public final class SourceCodeGenerator {
       }
     }
 
-    //if (resolvedPlugins.isEmpty() && hasPlugins(request) && pluginsOptional(request)) {
-    //  log.info("No resolved plugins found and all are optional, nothing to do.");
-    //  return true;
-    //}
+    if (resolvedPlugins.isEmpty() && request.getEnabledLanguages().isEmpty()) {
+      if (request.isFailOnMissingTargets()) {
+        log.error("No languages are enabled and no plugins found, check your "
+            + "configuration and try again.");
+        return false;
+      } else {
+        log.warn("No languages are enabled and no plugins found; nothing to do!");
+        return true;
+      }
+    }
 
     createOutputDirectories(request);
 

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generate/SourceCodeGenerator.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generate/SourceCodeGenerator.java
@@ -87,18 +87,6 @@ public final class SourceCodeGenerator {
     this.commandLineExecutor = commandLineExecutor;
   }
 
-  private boolean hasPlugins(GenerationRequest request) {
-    return !request.getBinaryUrlPlugins().isEmpty()
-        || !request.getBinaryMavenPlugins().isEmpty()
-        || !request.getBinaryPathPlugins().isEmpty();
-  }
-
-  private boolean pluginsOptional(GenerationRequest request) {
-    return request.getBinaryUrlPlugins().stream().allMatch(ProtocPlugin::isOptional)
-        && request.getBinaryMavenPlugins().stream().allMatch(ProtocPlugin::isOptional)
-        && request.getBinaryPathPlugins().stream().allMatch(ProtocPlugin::isOptional);
-  }
-
   public boolean generate(GenerationRequest request) throws ResolutionException, IOException {
     final var protocPath = discoverProtocPath(request);
 
@@ -117,10 +105,10 @@ public final class SourceCodeGenerator {
       }
     }
 
-    if (resolvedPlugins.isEmpty() && hasPlugins(request) && pluginsOptional(request)) {
-      log.info("No resolved plugins found and all are optional, nothing to do.");
-      return true;
-    }
+    //if (resolvedPlugins.isEmpty() && hasPlugins(request) && pluginsOptional(request)) {
+    //  log.info("No resolved plugins found and all are optional, nothing to do.");
+    //  return true;
+    //}
 
     createOutputDirectories(request);
 

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/package-info.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/package-info.java
@@ -18,6 +18,7 @@
     beanFriendlyModifiables = true,
     create = "new",
     defaults = @Immutable(copy = false),
+    defaultAsDefault = true,
     deferCollectionAllocation = true,
     headerComments = true,
     jacksonIntegration = false,

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugin/BinaryPluginResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugin/BinaryPluginResolver.java
@@ -104,7 +104,7 @@ public final class BinaryPluginResolver {
         .iterator()
         .next();
 
-    if (plugin.isOptional() && !Files.exists(path)) {
+    if (plugin.isOptional() != null && plugin.isOptional() && !Files.exists(path)) {
       return Optional.empty();
     }
 
@@ -118,7 +118,7 @@ public final class BinaryPluginResolver {
     var path = systemPathResolver.resolve(plugin.getName());
 
     if (!path.isPresent()) {
-      if (plugin.isOptional()) {
+      if (plugin.isOptional() != null && plugin.isOptional()) {
         return Optional.empty();
       }
 

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugin/BinaryPluginResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugin/BinaryPluginResolver.java
@@ -36,6 +36,8 @@ import java.util.Collection;
 import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Named;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Protoc plugin resolver for native binaries on the system.
@@ -44,6 +46,8 @@ import javax.inject.Named;
  */
 @Named
 public final class BinaryPluginResolver {
+
+  private static final Logger log = LoggerFactory.getLogger(BinaryPluginResolver.class);
 
   private final MavenDependencyPathResolver dependencyResolver;
   private final PlatformClassifierFactory platformClassifierFactory;
@@ -98,6 +102,8 @@ public final class BinaryPluginResolver {
 
     plugin = pluginBuilder.build();
 
+    log.debug("Resolving Maven protoc plugin {}", plugin);
+
     // Only one dependency should ever be returned here.
     var path = dependencyResolver.resolveOne(plugin, DependencyResolutionDepth.DIRECT)
         .iterator()
@@ -111,6 +117,9 @@ public final class BinaryPluginResolver {
   private Optional<ResolvedProtocPlugin> resolvePathPlugin(
       PathProtocPlugin plugin
   ) throws ResolutionException {
+
+    log.debug("Resolving Path protoc plugin {}", plugin);
+
     var maybePath = systemPathResolver.resolve(plugin.getName());
 
     if (maybePath.isEmpty() && plugin.isOptional()) {
@@ -127,8 +136,10 @@ public final class BinaryPluginResolver {
   private Optional<ResolvedProtocPlugin> resolveUrlPlugin(
       UrlProtocPlugin plugin
   ) throws ResolutionException {
-    var maybePath = urlResourceFetcher
-        .fetchFileFromUrl(plugin.getUrl(), ".exe");
+
+    log.debug("Resolving URL protoc plugin {}", plugin);
+
+    var maybePath = urlResourceFetcher.fetchFileFromUrl(plugin.getUrl(), ".exe");
 
     if (maybePath.isEmpty() && plugin.isOptional()) {
       return Optional.empty();

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugin/JvmPluginResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugin/JvmPluginResolver.java
@@ -35,6 +35,8 @@ import java.util.Iterator;
 import java.util.List;
 import javax.inject.Inject;
 import javax.inject.Named;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Wraps a JVM-based plugin invocation using an OS-native script that calls Java.
@@ -47,6 +49,8 @@ import javax.inject.Named;
  */
 @Named
 public final class JvmPluginResolver {
+
+  private static final Logger log = LoggerFactory.getLogger(BinaryPluginResolver.class);
 
   private final HostSystem hostSystem;
   private final MavenDependencyPathResolver dependencyResolver;
@@ -76,6 +80,12 @@ public final class JvmPluginResolver {
   private ResolvedProtocPlugin resolve(
       MavenProtocPlugin plugin
   ) throws IOException, ResolutionException {
+
+    log.debug(
+        "Resolving JVM-based Maven protoc plugin {} and generating OS-specific boostrap scripts",
+        plugin
+    );
+
     var pluginId = pluginIdDigest(plugin);
     var argLine = resolveAndBuildArgLine(plugin);
 

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugin/JvmPluginResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugin/JvmPluginResolver.java
@@ -72,6 +72,11 @@ public final class JvmPluginResolver {
   ) throws IOException, ResolutionException {
     var resolvedPlugins = new ArrayList<ResolvedProtocPlugin>();
     for (var plugin : plugins) {
+      if (plugin.isSkip()) {
+        log.info("Skipping plugin {}", plugin);
+        continue;
+      }
+
       resolvedPlugins.add(resolve(plugin));
     }
     return resolvedPlugins;

--- a/protobuf-maven-plugin/src/site/markdown/index.md
+++ b/protobuf-maven-plugin/src/site/markdown/index.md
@@ -492,6 +492,11 @@ executable name instead:
 Each `binarPathPlugin` can take an optional `options` parameter which will
 be passed as an option to the plugin if specified.
 
+You can also mark these plugins as being optional by setting `<optional>true</optional>` on the
+individual plugin objects. This will prevent the Maven plugin from failing the build if the `protoc` plugin
+cannot be resolved on the system path. This is useful for specific cases where resources may only be available 
+during CI builds but do not prevent the application being built locally.
+
 #### Binary plugins from specific locations
 
 In some situations, you may wish to download plugins directly from a URL or run them from a 
@@ -523,8 +528,22 @@ specific file system path:
 </plugin>
 ```
 
+Any protocols supported by your JRE should be able to be used here, including:
+
+- `file://`
+- `http://`
+- `https://`
+- `ftp://`
+- `jar://`
+
 Each `binaryUrlPlugin` can take an optional `options` parameter which will
 be passed as an option to the plugin if specified.
+
+You can also mark these plugins as being optional by setting `<optional>true</optional>` on the
+individual plugin objects. This will prevent the Maven plugin from failing the build if the `protoc` plugin
+cannot be resolved. This is useful for specific cases where resources may only be available during CI builds but do not
+prevent the application being built locally. If set to optional, then any "not found" response provided by
+the underlying URL protocol will be ignored.
 
 This is not recommended outside specific use cases, and care should be taken to ensure the
 legitimacy and security of any URLs being provided prior to adding them.


### PR DESCRIPTION
Implements new functionality to allow users to flag URL and path-based protoc plugins as being "optional". This enables skipping unresolvable plugins in situations where they may only be available during CI or in specific conditions.

Also implements a flag to skip plugins if desired. This allows users to control plugin execution via properties, such as by using `<skip>${protoc.grpc.skip}</skip>`.

Builds on the work contributed by @anthonyalayo in GH-183 with additional changes to improve internal APIs to robustly support the change.

Fixes GH-182.