### PR TITLE
Make URL resolution optional

### DIFF
--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generate/SourceCodeGenerator.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generate/SourceCodeGenerator.java
@@ -142,7 +142,8 @@ public final class SourceCodeGenerator {
   }
 
   private Path discoverProtocPath(GenerationRequest request) throws ResolutionException {
-    return protocResolver.resolve(request.getProtocVersion());
+    return protocResolver.resolve(request.getProtocVersion())
+        .orElseThrow(() -> new ResolutionException("Protoc binary was not found"));
   }
 
   private boolean logProtocVersion(Path protocPath) throws IOException {

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugin/BinaryPluginResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugin/BinaryPluginResolver.java
@@ -123,7 +123,12 @@ public final class BinaryPluginResolver {
   private ResolvedProtocPlugin resolveUrlPlugin(
       UrlProtocPlugin plugin
   ) throws ResolutionException {
-    var path = urlResourceFetcher.fetchFileFromUrl(plugin.getUrl(), ".exe");
+    var path = urlResourceFetcher
+        .fetchFileFromUrl(plugin.getUrl(), ".exe")
+        .orElseThrow(() -> new ResolutionException(
+            "Resource at " + plugin.getUrl() + " does not exist"
+        ));
+
     makeExecutable(path);
 
     return createResolvedProtocPlugin(plugin, path);


### PR DESCRIPTION
Use optionals to handle URL resolution failures due to non-existent resources.

Prerequisite to simplifying bits of the solution in https://github.com/ascopes/protobuf-maven-plugin/issues/182 via https://github.com/ascopes/protobuf-maven-plugin/pull/189.