### PR TITLE
GH-184: Add parameter to skip plugin invocation.

### DIFF
--- a/protobuf-maven-plugin/src/it/grpc-plugin/test.groovy
+++ b/protobuf-maven-plugin/src/it/grpc-plugin/test.groovy
@@ -18,7 +18,7 @@ import java.nio.file.Path
 import static org.assertj.core.api.Assertions.assertThat
 
 Path baseDirectory = basedir.toPath().toAbsolutePath()
-def generatedSourcesDir = baseDirectory.resolve("target/generated-sources/protobuf")
+Path generatedSourcesDir = baseDirectory.resolve("target/generated-sources/protobuf")
 def classesDir = baseDirectory.resolve("target/classes")
 def expectedGeneratedFiles = [
     "org/example/helloworld/Helloworld",

--- a/protobuf-maven-plugin/src/it/http-url-grpc-plugin/test.groovy
+++ b/protobuf-maven-plugin/src/it/http-url-grpc-plugin/test.groovy
@@ -18,7 +18,7 @@ import java.nio.file.Path
 import static org.assertj.core.api.Assertions.assertThat
 
 Path baseDirectory = basedir.toPath().toAbsolutePath()
-def generatedSourcesDir = baseDirectory.resolve("target/generated-sources/protobuf")
+Path generatedSourcesDir = baseDirectory.resolve("target/generated-sources/protobuf")
 def classesDir = baseDirectory.resolve("target/classes")
 def expectedGeneratedFiles = [
     "org/example/helloworld/Helloworld",

--- a/protobuf-maven-plugin/src/it/http-url-protoc/test.groovy
+++ b/protobuf-maven-plugin/src/it/http-url-protoc/test.groovy
@@ -18,7 +18,7 @@ import java.nio.file.Path
 import static org.assertj.core.api.Assertions.assertThat
 
 Path baseDirectory = basedir.toPath().toAbsolutePath()
-def generatedSourcesDir = baseDirectory.resolve("target/generated-sources/protobuf")
+Path generatedSourcesDir = baseDirectory.resolve("target/generated-sources/protobuf")
 def classesDir = baseDirectory.resolve("target/classes")
 def expectedGeneratedFiles = [
     "org/example/helloworld/Helloworld",

--- a/protobuf-maven-plugin/src/it/java-main-lite/test.groovy
+++ b/protobuf-maven-plugin/src/it/java-main-lite/test.groovy
@@ -18,7 +18,7 @@ import java.nio.file.Path
 import static org.assertj.core.api.Assertions.assertThat
 
 Path baseDirectory = basedir.toPath().toAbsolutePath()
-def generatedSourcesDir = baseDirectory.resolve("target/generated-sources/protobuf")
+Path generatedSourcesDir = baseDirectory.resolve("target/generated-sources/protobuf")
 def classesDir = baseDirectory.resolve("target/classes")
 def expectedGeneratedFiles = [
     "org/example/helloworld/Helloworld",

--- a/protobuf-maven-plugin/src/it/java-main/test.groovy
+++ b/protobuf-maven-plugin/src/it/java-main/test.groovy
@@ -18,7 +18,7 @@ import java.nio.file.Path
 import static org.assertj.core.api.Assertions.assertThat
 
 Path baseDirectory = basedir.toPath().toAbsolutePath()
-def generatedSourcesDir = baseDirectory.resolve("target/generated-sources/protobuf")
+Path generatedSourcesDir = baseDirectory.resolve("target/generated-sources/protobuf")
 def classesDir = baseDirectory.resolve("target/classes")
 def expectedGeneratedFiles = [
     "org/example/helloworld/Helloworld",

--- a/protobuf-maven-plugin/src/it/java-paths/test.groovy
+++ b/protobuf-maven-plugin/src/it/java-paths/test.groovy
@@ -18,7 +18,7 @@ import java.nio.file.Path
 import static org.assertj.core.api.Assertions.assertThat
 
 Path baseDirectory = basedir.toPath().toAbsolutePath()
-def generatedSourcesDir = baseDirectory.resolve("target/generated-sources/protobuf")
+Path generatedSourcesDir = baseDirectory.resolve("target/generated-sources/protobuf")
 def classesDir = baseDirectory.resolve("target/classes")
 def expectedGeneratedFiles = [
     "org/example/helloworld/Helloworld",

--- a/protobuf-maven-plugin/src/it/java-test/test.groovy
+++ b/protobuf-maven-plugin/src/it/java-test/test.groovy
@@ -18,7 +18,7 @@ import java.nio.file.Path
 import static org.assertj.core.api.Assertions.assertThat
 
 Path baseDirectory = basedir.toPath().toAbsolutePath()
-def generatedSourcesDir = baseDirectory.resolve("target/generated-test-sources/protobuf")
+Path generatedSourcesDir = baseDirectory.resolve("target/generated-test-sources/protobuf")
 def classesDir = baseDirectory.resolve("target/test-classes")
 def expectedGeneratedFiles = [
     "org/example/helloworld/Helloworld",

--- a/protobuf-maven-plugin/src/it/kotlin-main/test.groovy
+++ b/protobuf-maven-plugin/src/it/kotlin-main/test.groovy
@@ -18,7 +18,7 @@ import java.nio.file.Path
 import static org.assertj.core.api.Assertions.assertThat
 
 Path baseDirectory = basedir.toPath().toAbsolutePath()
-def generatedSourcesDir = baseDirectory.resolve("target/generated-sources/protobuf")
+Path generatedSourcesDir = baseDirectory.resolve("target/generated-sources/protobuf")
 def classesDir = baseDirectory.resolve("target/classes")
 def expectedGeneratedJavaFiles = [
     "org/example/helloworld/Helloworld",

--- a/protobuf-maven-plugin/src/it/kotlin-test/test.groovy
+++ b/protobuf-maven-plugin/src/it/kotlin-test/test.groovy
@@ -18,7 +18,7 @@ import java.nio.file.Path
 import static org.assertj.core.api.Assertions.assertThat
 
 Path baseDirectory = basedir.toPath().toAbsolutePath()
-def generatedSourcesDir = baseDirectory.resolve("target/generated-test-sources/protobuf")
+Path generatedSourcesDir = baseDirectory.resolve("target/generated-test-sources/protobuf")
 def classesDir = baseDirectory.resolve("target/test-classes")
 def expectedGeneratedJavaFiles = [
     "org/example/helloworld/Helloworld",

--- a/protobuf-maven-plugin/src/it/skip/invoker.properties
+++ b/protobuf-maven-plugin/src/it/skip/invoker.properties
@@ -1,0 +1,17 @@
+#
+# Copyright (C) 2023 - 2024, Ashley Scopes.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+invoker.goals = clean package -Dprotobuf.skip

--- a/protobuf-maven-plugin/src/it/skip/pom.xml
+++ b/protobuf-maven-plugin/src/it/skip/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2023 - 2024, Ashley Scopes.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>@project.groupId@</groupId>
+    <artifactId>protobuf-maven-plugin-parent</artifactId>
+    <version>@project.version@</version>
+    <relativePath>../../../../pom.xml</relativePath>
+  </parent>
+
+  <groupId>java-main</groupId>
+  <artifactId>java-main</artifactId>
+
+  <properties>
+    <protobuf.version>4.26.1</protobuf.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>${protobuf.version}</version>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+
+        <configuration>
+          <protocVersion>${protobuf.version}</protocVersion>
+        </configuration>
+
+        <executions>
+          <execution>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/protobuf-maven-plugin/src/it/skip/src/main/protobuf/helloworld.proto
+++ b/protobuf-maven-plugin/src/it/skip/src/main/protobuf/helloworld.proto
@@ -1,0 +1,27 @@
+//
+// Copyright (C) 2023 - 2024, Ashley Scopes.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "org.example.helloworld";
+
+package org.example.helloworld;
+
+message GreetingRequest {
+  string name = 1;
+}
+

--- a/protobuf-maven-plugin/src/it/skip/test.groovy
+++ b/protobuf-maven-plugin/src/it/skip/test.groovy
@@ -18,25 +18,8 @@ import java.nio.file.Path
 import static org.assertj.core.api.Assertions.assertThat
 
 Path baseDirectory = basedir.toPath().toAbsolutePath()
-Path generatedSourcesDir = baseDirectory.resolve("target/generated-test-sources/protobuf")
-def classesDir = baseDirectory.resolve("target/test-classes")
-def expectedGeneratedFiles = [
-    "org/example/helloworld/Helloworld",
-    "org/example/helloworld/GreetingRequest",
-    "org/example/helloworld/GreetingRequestOrBuilder",
-]
+Path generatedSourcesDir = baseDirectory.resolve("target/generated-sources/protobuf")
 
-assertThat(generatedSourcesDir).isDirectory()
-
-assertThat(classesDir).isDirectory()
-
-expectedGeneratedFiles.forEach {
-  assertThat(generatedSourcesDir.resolve("${it}.java"))
-      .exists()
-      .isNotEmptyFile()
-  assertThat(classesDir.resolve("${it}.class"))
-      .exists()
-      .isNotEmptyFile()
-}
+assertThat(generatedSourcesDir).doesNotExist()
 
 return true

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/AbstractGenerateMojo.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/AbstractGenerateMojo.java
@@ -39,6 +39,8 @@ import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Abstract base for a code generation Mojo that calls {@code protoc}.
@@ -46,6 +48,8 @@ import org.jspecify.annotations.Nullable;
  * @author Ashley Scopes
  */
 public abstract class AbstractGenerateMojo extends AbstractMojo {
+
+  private static final Logger log = LoggerFactory.getLogger(AbstractGenerateMojo.class);
 
   ///
   /// MOJO dependencies.
@@ -391,6 +395,14 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
   boolean registerAsCompilationRoot;
 
   /**
+   * Whether to skip the plugin execution entirely.
+   *
+   * @since 2.0.0
+   */
+  @Parameter(defaultValue = "false", property = "protobuf.skip")
+  boolean skip;
+
+  /**
    * Additional dependencies to compile, pulled from the Maven repository.
    *
    * <p>Note that this will resolve dependencies recursively unless
@@ -574,6 +586,11 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    */
   @Override
   public void execute() throws MojoExecutionException, MojoFailureException {
+    if (skip) {
+      log.info("Plugin execution is skipped");
+      return;
+    }
+
     var enabledLanguages = Language.setBuilder()
         .addIf(cppEnabled, Language.CPP)
         .addIf(csharpEnabled, Language.C_SHARP)

--- a/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/AbstractGenerateMojoTestTemplate.java
+++ b/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/AbstractGenerateMojoTestTemplate.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 
@@ -126,6 +127,24 @@ abstract class AbstractGenerateMojoTestTemplate<A extends AbstractGenerateMojo> 
       // Then
       assertThat(mojo.defaultOutputDirectory())
           .isEqualTo(expectedDefaultOutputDirectory());
+    }
+  }
+
+  @DisplayName("Plugin skipping tests")
+  @Nested
+  class PluginSkippingTest {
+
+    @DisplayName("nothing is run when the plugin is skipped")
+    @Test
+    void nothingIsRunWhenThePluginIsSkipped() throws Throwable {
+      // Given
+      mojo.skip = true;
+
+      // When
+      mojo.execute();
+
+      // Then
+      verifyNoInteractions(mojo.sourceCodeGenerator);
     }
   }
 


### PR DESCRIPTION
Adds a parameter `skip` to skip plugin invocation. This can be specified via `-Dprotobuf.skip` on the command line.

Also added unit test case and integration test case.

Closes GH-184.