### PR TITLE
Rename protoc.version to protobuf.compiler.version

### DIFF
--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/AbstractGenerateMojo.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/AbstractGenerateMojo.java
@@ -370,16 +370,21 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    *   <li>FTP resources, specified using {@code ftp://example.server/path/to/file}</li>
    * </ul>
    *
-   * <p>Note that specifying {@code -Dprotoc.version} in the {@code MAVEN_OPTS} or on the
-   * command line overrides the version specified in the POM. This enables users to easily
+   * <p>Note that specifying {@code -Dprotobuf.compiler.version} in the {@code MAVEN_OPTS} or on 
+   * the command line overrides the version specified in the POM. This enables users to easily
    * override the version of {@code protoc} in use if their system is unable to support the
    * version specified in the POM. Termux users in particular will find
-   * {@code -Dprotoc.version=PATH} to be useful, due to platform limitations with
+   * {@code -Dprotobuf.compiler.version=PATH} to be useful, due to platform limitations with
    * {@code libpthread} that can result in {@code SIGSYS} (Bad System Call) being raised.
+   *
+   * <p>Prior to v2.0.0, this parameter was named {@code protoc.version} when specified on the
+   * commandline via JVM properties. This has been changed in v2.0.0 to
+   * {@code protobuf.compiler.version} for consistency and to reduce naming collisions with
+   * user-specified properties.
    *
    * @since 0.0.1
    */
-  @Parameter(required = true, property = "protoc.version")
+  @Parameter(required = true, property = "protobuf.compiler.version")
   String protocVersion;
 
   /**
@@ -657,9 +662,9 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
   }
 
   private String protocVersion() {
-    // Give precedence to overriding the protoc version via the command line
+    // Give precedence to overriding the protobuf.compiler.version via the command line
     // in case the Maven binaries are incompatible with the current system.
-    var overriddenVersion = System.getProperty("protoc.version");
+    var overriddenVersion = System.getProperty("protobuf.compiler.version");
     requireNonNull(protocVersion, "protocVersion has not been set");
     return requireNonNullElse(overriddenVersion, protocVersion);
   }

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/protoc/ProtocResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/protoc/ProtocResolver.java
@@ -72,7 +72,7 @@ public final class ProtocResolver {
   public Optional<Path> resolve(String version) throws ResolutionException {
     if (version.equalsIgnoreCase("latest")) {
       throw new IllegalArgumentException(
-          "Cannot use LATEST for the protoc version. "
+          "Cannot use LATEST for the protobuf.compiler.version. "
               + "Google has not released linear versions in the past, meaning that "
               + "using LATEST will have unexpected behaviour."
       );
@@ -112,7 +112,7 @@ public final class ProtocResolver {
               + "running the detected protoc binary from Maven central. If this is "
               + "an issue, install the protoc compiler manually from your package "
               + "manager (apt update && apt install protobuf), and then invoke "
-              + "Maven with the -Dprotoc.version=PATH flag."
+              + "Maven with the -Dprotobuf.compiler.version=PATH flag."
       );
     }
 

--- a/protobuf-maven-plugin/src/site/markdown/index.md
+++ b/protobuf-maven-plugin/src/site/markdown/index.md
@@ -76,9 +76,9 @@ and will be output to `target/generated-sources/protobuf`
 in the `configuration` block if needed.
 
 The `protoc` version itself can be set via the `<protocVersion>` configuration parameter
-as shown above, or can be set via the `protoc.version` property in your POM. It may
-optionally be totally overridden on the command line by passing `-Dprotoc.version=xxx`,
-in which case the `<protocVersion>` and `protoc.version` will be ignored. This is done
+as shown above, or can be set via the `protobuf.compiler.version` property in your POM. It may
+optionally be totally overridden on the command line by passing `-Dprotobuf.compiler.version=xxx`,
+in which case the `<protocVersion>` and `protobuf.compiler.version` will be ignored. This is done
 to allow users who may have an incompatible system to be able to request a build using
 the `$PATH`-based `protoc` binary on their system (documented later in this page).
 

--- a/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/AbstractGenerateMojoTestTemplate.java
+++ b/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/AbstractGenerateMojoTestTemplate.java
@@ -616,13 +616,13 @@ abstract class AbstractGenerateMojoTestTemplate<A extends AbstractGenerateMojo> 
           .withMessage("protocVersion has not been set");
     }
 
-    @DisplayName("when protoc.version is set in system properties, expect that to be used")
+    @DisplayName("when protobuf.compiler.version is set, expect that to be used")
     @Test
     @UsesSystemProperties
     void whenProtocVersionSetInSystemPropertiesExpectThatToBeUsed() throws Throwable {
       // Given
       mojo.protocVersion = "1.2.3";
-      System.setProperty("protoc.version", "4.5.6");
+      System.setProperty("protobuf.compiler.version", "4.5.6");
 
       // When
       mojo.execute();
@@ -634,9 +634,7 @@ abstract class AbstractGenerateMojoTestTemplate<A extends AbstractGenerateMojo> 
       assertThat(actualRequest.getProtocVersion()).isEqualTo("4.5.6");
     }
 
-    @DisplayName(
-        "when protoc.version is not set in system properties, expect the parameter to be used"
-    )
+    @DisplayName("when protobuf.compiler.version is not set, expect the parameter to be used")
     @Test
     @UsesSystemProperties
     void whenProtocVersionNotSetInSystemPropertiesExpectParameterToBeUsed() throws Throwable {


### PR DESCRIPTION
This reduces naming conflicts and ensures all parameters start with the 'protobuf.' prefix when provided via JVM system properties.