### PR TITLE
Update the option for generating python stubs in the documentation

### DIFF
--- a/protobuf-maven-plugin/src/site/markdown/index.md
+++ b/protobuf-maven-plugin/src/site/markdown/index.md
@@ -282,7 +282,7 @@ are disabled then at least one plugin must be provided.
     </tr>
     <tr>
       <td>Python typeshed stubs</td>
-      <td><code>pyiEnabled</code></td>
+      <td><code>pythonStubsEnabled</code></td>
       <td><code>false</code></td>
       <td>Enable this alongside <code>pythonEnabled</code> to generate MyPy-compatible typehint stubs.</td>
     </tr>


### PR DESCRIPTION
Update the option for generating python stubs in the language sources configuration table.

Previously, the table included `pyiEnabled` but the plugin actually needs `pythonStubsEnabled`.

Fixes #199 