### PR TITLE
Fix structure of Immutables descriptors.

### DIFF
--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/AbstractGenerateMojo.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/AbstractGenerateMojo.java
@@ -272,7 +272,7 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    * @since 1.2.0
    */
   @Parameter
-  @Nullable List<MavenArtifactBean> importDependencies;
+  @Nullable List<MavenDependencyBean> importDependencies;
 
   /**
    * Specify additional paths to import protobuf sources from on the local file system.
@@ -440,7 +440,7 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    * @since 1.2.0
    */
   @Parameter
-  @Nullable List<MavenArtifactBean> sourceDependencies;
+  @Nullable List<MavenDependencyBean> sourceDependencies;
 
   /**
    * Override the source directories to compile from.

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/MavenDependency.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/MavenDependency.java
@@ -16,30 +16,19 @@
 
 package io.github.ascopes.protobufmavenplugin;
 
+import org.immutables.value.Value.Immutable;
+import org.immutables.value.Value.Modifiable;
 import org.jspecify.annotations.Nullable;
 
 
 /**
- * Base interface for a parameter that consumes Maven artifact
- * details.
+ * Implementation independent descriptor for an artifact or dependency that can be used in a Maven
+ * Plugin parameter.
  *
  * @author Ashley Scopes
  * @since 1.2.0
  */
-public interface MavenArtifact {
-
-  String getGroupId();
-
-  String getArtifactId();
-
-  String getVersion();
-
-  @Nullable
-  String getType();
-
-  @Nullable
-  String getClassifier();
-
-  @Nullable
-  DependencyResolutionDepth getDependencyResolutionDepth();
+@Immutable
+@Modifiable
+public abstract class MavenDependency implements MavenArtifact {
 }

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/MavenProtocPlugin.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/MavenProtocPlugin.java
@@ -31,14 +31,13 @@ import org.jspecify.annotations.Nullable;
  */
 @Immutable
 @Modifiable
-@SuppressWarnings("immutables:subtype")
-public interface MavenProtocPlugin extends MavenArtifact, ProtocPlugin {
+public abstract class MavenProtocPlugin implements MavenArtifact, ProtocPlugin {
 
-  // Do not allow Immutables to allow us to specify this attribute.
   @Derived
-  @Override
   @Nullable
-  default DependencyResolutionDepth getDependencyResolutionDepth() {
+  @Override
+  public DependencyResolutionDepth getDependencyResolutionDepth() {
+    // We never allow this to be specified for protoc plugins.
     return null;
   }
 }

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/PathProtocPlugin.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/PathProtocPlugin.java
@@ -30,7 +30,7 @@ import org.immutables.value.Value.Modifiable;
  * @since 2.0.0
  */
 @Modifiable
-public interface PathProtocPlugin extends OptionalProtocPlugin {
+public abstract class PathProtocPlugin implements OptionalProtocPlugin {
 
-  String getName();
+  public abstract String getName();
 }

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/UrlProtocPlugin.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/UrlProtocPlugin.java
@@ -31,7 +31,7 @@ import org.immutables.value.Value.Modifiable;
  * @since 2.0.0
  */
 @Modifiable
-public interface UrlProtocPlugin extends OptionalProtocPlugin {
+public abstract class UrlProtocPlugin implements OptionalProtocPlugin {
 
-  URL getUrl();
+  public abstract URL getUrl();
 }

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/protoc/ProtocResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/protoc/ProtocResolver.java
@@ -17,7 +17,7 @@
 package io.github.ascopes.protobufmavenplugin.protoc;
 
 import io.github.ascopes.protobufmavenplugin.DependencyResolutionDepth;
-import io.github.ascopes.protobufmavenplugin.ImmutableMavenArtifact;
+import io.github.ascopes.protobufmavenplugin.ImmutableMavenDependency;
 import io.github.ascopes.protobufmavenplugin.dependency.MavenDependencyPathResolver;
 import io.github.ascopes.protobufmavenplugin.dependency.PlatformClassifierFactory;
 import io.github.ascopes.protobufmavenplugin.dependency.ResolutionException;
@@ -116,7 +116,7 @@ public final class ProtocResolver {
       );
     }
 
-    var artifact = ImmutableMavenArtifact.builder()
+    var artifact = ImmutableMavenDependency.builder()
         .groupId(GROUP_ID)
         .artifactId(ARTIFACT_ID)
         .version(version)

--- a/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/AbstractGenerateMojoTestTemplate.java
+++ b/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/AbstractGenerateMojoTestTemplate.java
@@ -415,7 +415,7 @@ abstract class AbstractGenerateMojoTestTemplate<A extends AbstractGenerateMojo> 
     @NullAndEmptySource
     @ParameterizedTest(name = "when {0}")
     void whenImportDependenciesNullExpectEmptyListInRequest(
-        List<MavenArtifactBean> plugins
+        List<MavenDependencyBean> plugins
     ) throws Throwable {
       // Given
       mojo.importDependencies = plugins;
@@ -434,7 +434,7 @@ abstract class AbstractGenerateMojoTestTemplate<A extends AbstractGenerateMojo> 
     @Test
     void whenImportDependenciesProvidedExpectPluginsInRequest() throws Throwable {
       // Given
-      List<MavenArtifactBean> plugins = mock();
+      List<MavenDependencyBean> plugins = mock();
       mojo.importDependencies = plugins;
 
       // When
@@ -681,7 +681,7 @@ abstract class AbstractGenerateMojoTestTemplate<A extends AbstractGenerateMojo> 
     @NullAndEmptySource
     @ParameterizedTest(name = "when {0}")
     void whenSourceDependenciesNullExpectEmptyListInRequest(
-        List<MavenArtifactBean> dependencies
+        List<MavenDependencyBean> dependencies
     ) throws Throwable {
       // Given
       mojo.sourceDependencies = dependencies;
@@ -700,7 +700,7 @@ abstract class AbstractGenerateMojoTestTemplate<A extends AbstractGenerateMojo> 
     @Test
     void whenSourceDependenciesProvidedExpectDependenciesInRequest() throws Throwable {
       // Given
-      List<MavenArtifactBean> plugins = mock();
+      List<MavenDependencyBean> plugins = mock();
       mojo.sourceDependencies = plugins;
 
       // When


### PR DESCRIPTION
- Use abstract classes for direct bases of Immutable types. This allows overriding toString properly at a later date and shows the intention that it is not a mixin interface.
- Derive MavenDependency from MavenArtifact and move descriptor annotations to that class. This allows fixing a suppresses warning from immutables on MavenProtocPlugin.