### PR TITLE
GH-207: Implement ability to embed proto sources in output JAR

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>io.github.ascopes</groupId>
   <artifactId>protobuf-maven-plugin-parent</artifactId>
-  <version>2.0.4-SNAPSHOT</version>
+  <version>2.1.0-SNAPSHOT</version>
 
   <name>Protobuf Maven Plugin Parent</name>
   <description>Parent POM for the Protobuf Maven Plugin.</description>

--- a/protobuf-maven-plugin/pom.xml
+++ b/protobuf-maven-plugin/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes</groupId>
     <artifactId>protobuf-maven-plugin-parent</artifactId>
-    <version>2.0.4-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>protobuf-maven-plugin</artifactId>

--- a/protobuf-maven-plugin/src/it/embed-main-sources/invoker.properties
+++ b/protobuf-maven-plugin/src/it/embed-main-sources/invoker.properties
@@ -1,0 +1,17 @@
+#
+# Copyright (C) 2023 - 2024, Ashley Scopes.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+invoker.goals = clean package

--- a/protobuf-maven-plugin/src/it/embed-main-sources/pom.xml
+++ b/protobuf-maven-plugin/src/it/embed-main-sources/pom.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2023 - 2024, Ashley Scopes.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>@project.groupId@</groupId>
+    <artifactId>protobuf-maven-plugin-parent</artifactId>
+    <version>@project.version@</version>
+    <relativePath>../../../../pom.xml</relativePath>
+  </parent>
+
+  <groupId>embed-main-sources</groupId>
+  <artifactId>embed-main-sources</artifactId>
+
+  <properties>
+    <protobuf.version>4.26.1</protobuf.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>${protobuf.version}</version>
+      <scope>compile</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+
+        <configuration>
+          <embedSourcesInClassOutputs>true</embedSourcesInClassOutputs>
+          <protocVersion>${protobuf.version}</protocVersion>
+        </configuration>
+
+        <executions>
+          <execution>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/protobuf-maven-plugin/src/it/embed-main-sources/src/main/protobuf/helloworld.proto
+++ b/protobuf-maven-plugin/src/it/embed-main-sources/src/main/protobuf/helloworld.proto
@@ -1,0 +1,27 @@
+//
+// Copyright (C) 2023 - 2024, Ashley Scopes.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "org.example.helloworld";
+
+package org.example.helloworld;
+
+message GreetingRequest {
+  string name = 1;
+}
+

--- a/protobuf-maven-plugin/src/it/embed-main-sources/src/main/protobuf/org/example/channel.proto
+++ b/protobuf-maven-plugin/src/it/embed-main-sources/src/main/protobuf/org/example/channel.proto
@@ -1,0 +1,34 @@
+//
+// Copyright (C) 2023 - 2024, Ashley Scopes.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+package org.example.channels;
+
+option java_multiple_files = true;
+option java_package = "org.example.channels";
+
+import "google/protobuf/timestamp.proto";
+import "org/example/user.proto";
+
+message Channel {
+  string id = 1;
+  string name = 2;
+  google.protobuf.Timestamp created_at = 3;
+  optional google.protobuf.Timestamp updated_at = 4;
+  users.User owner = 5;
+  repeated org.example.users.User members = 6;
+}

--- a/protobuf-maven-plugin/src/it/embed-main-sources/src/main/protobuf/org/example/message.proto
+++ b/protobuf-maven-plugin/src/it/embed-main-sources/src/main/protobuf/org/example/message.proto
@@ -1,0 +1,44 @@
+//
+// Copyright (C) 2023 - 2024, Ashley Scopes.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+package org.example.messages;
+
+option java_multiple_files = true;
+option java_package = "org.example.messages";
+
+import "google/protobuf/timestamp.proto";
+import "org/example/channel.proto";
+import "org/example/user.proto";
+
+message CommentMessage {
+  string id = 1;
+  string contents = 2;
+  google.protobuf.Timestamp created_at = 3;
+  optional google.protobuf.Timestamp updated_at = 4;
+  org.example.users.User author = 5;
+}
+
+message ChannelMessage {
+  string id = 1;
+  string contents = 2;
+  google.protobuf.Timestamp created_at = 3;
+  optional google.protobuf.Timestamp updated_at = 4;
+  org.example.users.User author = 5;
+  org.example.channels.Channel channel = 6;
+  repeated CommentMessage comments = 7;
+}

--- a/protobuf-maven-plugin/src/it/embed-main-sources/src/main/protobuf/org/example/user.proto
+++ b/protobuf-maven-plugin/src/it/embed-main-sources/src/main/protobuf/org/example/user.proto
@@ -1,0 +1,32 @@
+//
+// Copyright (C) 2023 - 2024, Ashley Scopes.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+package org.example.users;
+
+option java_multiple_files = true;
+option java_package = "org.example.users";
+
+import "google/protobuf/timestamp.proto";
+
+message User {
+  string id = 1;
+  string name = 2;
+  optional string nickname = 3;
+  google.protobuf.Timestamp created_at = 4;
+  optional google.protobuf.Timestamp updated_at = 5;
+}

--- a/protobuf-maven-plugin/src/it/embed-main-sources/src/test/java/org/example/helloworld/ProtobufTest.java
+++ b/protobuf-maven-plugin/src/it/embed-main-sources/src/test/java/org/example/helloworld/ProtobufTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2023 - 2024, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.example.helloworld;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.util.ArrayList;
+import org.junit.jupiter.api.Test;
+
+class ProtobufTest {
+  @Test
+  void generatedProtobufSourcesAreFullMessages() throws Throwable {
+    // When
+    var superClasses = new ArrayList<String>();
+    Class<?> superClass = GreetingRequest.class;
+
+    do {
+      superClasses.add(superClass.getName());
+      superClass = superClass.getSuperclass();
+    } while (superClass != null);
+
+    // Then
+    // GeneratedMessageV3 for protobuf-java 3.25.3 and older.
+    // GeneratedMessage for protobuf-java 4.26.0 and newer.
+    assertTrue(superClasses.contains("com.google.protobuf.GeneratedMessage"));
+  }
+
+  @Test
+  void generatedProtobufSourcesAreValid() throws Throwable {
+    // Given
+    var expectedGreetingRequest = GreetingRequest
+        .newBuilder()
+        .setName("Ashley")
+        .build();
+
+    // When
+    var baos = new ByteArrayOutputStream();
+    expectedGreetingRequest.writeTo(baos);
+    var actualGreetingRequest = GreetingRequest.parseFrom(baos.toByteArray());
+
+    assertNotEquals(0, baos.toByteArray().length);
+
+    // Then
+    assertEquals(expectedGreetingRequest.getName(), actualGreetingRequest.getName());
+  }
+}

--- a/protobuf-maven-plugin/src/it/embed-main-sources/test.groovy
+++ b/protobuf-maven-plugin/src/it/embed-main-sources/test.groovy
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2023 - 2024, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import java.nio.file.Path
+
+import static org.assertj.core.api.Assertions.assertThat
+
+Path baseDirectory = basedir.toPath().toAbsolutePath()
+def classesDir = baseDirectory.resolve("target/classes")
+def expectedFiles = [
+    "helloworld.proto",
+    "org/example/message.proto",
+    "org/example/channel.proto",
+    "org/example/user.proto",
+]
+
+assertThat(classesDir).isDirectory()
+
+expectedFiles.forEach {
+  assertThat(classesDir.resolve(it))
+      .exists()
+      .isNotEmptyFile()
+}
+
+return true

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generation/GenerationRequest.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generation/GenerationRequest.java
@@ -59,6 +59,8 @@ public interface GenerationRequest {
 
   SourceRootRegistrar getSourceRootRegistrar();
 
+  boolean isEmbedSourcesInClassOutputs();
+
   boolean isFailOnMissingSources();
 
   boolean isFailOnMissingTargets();

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generation/SourceCodeGenerator.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generation/SourceCodeGenerator.java
@@ -144,6 +144,11 @@ public final class SourceCodeGenerator {
     }
 
     registerSourceRoots(request);
+
+    if (request.isEmbedSourcesInClassOutputs()) {
+      embedSourcesInClassOutputs(request.getSourceRootRegistrar(), sourcePaths);
+    }
+
     return true;
   }
 
@@ -250,6 +255,19 @@ public final class SourceCodeGenerator {
       registrar.registerSourceRoot(mavenSession, directory);
     } else {
       log.debug("Not registering {} as a compilation root", directory);
+    }
+  }
+
+  private void embedSourcesInClassOutputs(
+      SourceRootRegistrar registrar,
+      Collection<ProtoFileListing> listings
+  ) throws ResolutionException {
+    for (var listing : listings) {
+      try {
+        registrar.embedListing(mavenSession, listing);
+      } catch (IOException ex) {
+        throw new ResolutionException("Failed to embed " + listing.getProtoFilesRoot(), ex);
+      }
     }
   }
 

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generation/SourceRootRegistrar.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generation/SourceRootRegistrar.java
@@ -16,50 +16,83 @@
 
 package io.github.ascopes.protobufmavenplugin.generation;
 
+import io.github.ascopes.protobufmavenplugin.sources.ProtoFileListing;
+import io.github.ascopes.protobufmavenplugin.utils.FileUtils;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.function.BiConsumer;
+import java.util.function.Function;
 import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Build;
 import org.apache.maven.project.MavenProject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Registrar for source roots.
+ * Strategy for registration of sources with the Maven project.
+ *
+ * <p>This cannot be extended outside of the predefined strategies
+ * that already exist in this class.
  *
  * @author Ashley Scopes
  */
-@FunctionalInterface
-public interface SourceRootRegistrar {
+public final class SourceRootRegistrar {
 
-  MavenRegistrar MAIN = new MavenRegistrar("main", MavenProject::addCompileSourceRoot);
-  MavenRegistrar TEST = new MavenRegistrar("test", MavenProject::addTestCompileSourceRoot);
+  public static final SourceRootRegistrar MAIN = new SourceRootRegistrar(
+      "main",
+      MavenProject::addCompileSourceRoot,
+      Build::getOutputDirectory
+  );
 
-  void registerSourceRoot(MavenSession session, Path path);
+  public static final SourceRootRegistrar TEST = new SourceRootRegistrar(
+      "test",
+      MavenProject::addTestCompileSourceRoot,
+      Build::getTestOutputDirectory
+  );
 
-  /**
-   * A basic registrar for {@link MavenProject} sources.
-   */
-  final class MavenRegistrar implements SourceRootRegistrar {
+  private static final Logger log = LoggerFactory.getLogger(SourceRootRegistrar.class);
 
-    static final Logger log = LoggerFactory.getLogger(SourceRootRegistrar.class);
+  private final String name;
+  private final BiConsumer<MavenProject, String> sourceRootRegistrar;
+  private final Function<Build, String> classOutputDirectoryGetter;
 
-    private final String name;
-    private final BiConsumer<MavenProject, String> delegate;
+  private SourceRootRegistrar(
+      String name,
+      BiConsumer<MavenProject, String> sourceRootRegistrar,
+      Function<Build, String> classOutputDirectoryGetter
+  ) {
+    this.name = name;
+    this.sourceRootRegistrar = sourceRootRegistrar;
+    this.classOutputDirectoryGetter = classOutputDirectoryGetter;
+  }
 
-    private MavenRegistrar(String name, BiConsumer<MavenProject, String> delegate) {
-      this.name = name;
-      this.delegate = delegate;
+  public void registerSourceRoot(MavenSession session, Path path) {
+    log.info("Registering {} as a {} source root", path, this);
+    sourceRootRegistrar.accept(session.getCurrentProject(), path.toString());
+  }
+
+  public void embedListing(MavenSession session, ProtoFileListing listing) throws IOException {
+    log.info("Embedding sources from {} in {} class outputs", listing.getProtoFilesRoot(), this);
+    var targetDirectory = classOutputDirectoryGetter.andThen(Path::of)
+        .apply(session.getCurrentProject().getBuild());
+
+    // TODO: extract this logic out to FileUtils and use both here and in the archive extractor
+    // as it can be refactored into common code.
+    for (var sourceFile : listing.getProtoFiles()) {
+      var targetFile = FileUtils.changeRelativePath(
+          targetDirectory,
+          listing.getProtoFilesRoot(),
+          sourceFile
+      );
+      Files.createDirectories(targetFile.getParent());
+      Files.copy(sourceFile, targetFile, StandardCopyOption.REPLACE_EXISTING);
     }
+  }
 
-    @Override
-    public void registerSourceRoot(MavenSession session, Path path) {
-      log.info("Registering {} as a {} source root", path, this);
-      delegate.accept(session.getCurrentProject(), path.toString());
-    }
-
-    @Override
-    public String toString() {
-      return "Maven " + name;
-    }
+  @Override
+  public String toString() {
+    return "Maven " + name;
   }
 }

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/AbstractGenerateMojo.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/AbstractGenerateMojo.java
@@ -223,6 +223,19 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
   DependencyResolutionDepth dependencyResolutionDepth;
 
   /**
+   * Set whether to attach all compiled protobuf sources to the output of this
+   * Maven project so that they are included in any generated JAR.
+   *
+   * <p>Note that if you are using dependencies as sources, then those will also
+   * be attached, and may have license implications. Therefore, this will default
+   * to {@code false}.
+   *
+   * @since 2.1.0
+   */
+  @Parameter(defaultValue = DEFAULT_FALSE)
+  boolean embedSourcesInClassOutputs;
+
+  /**
    * Whether to fail on missing sources.
    *
    * <p>If no sources are detected, it is usually a sign that this plugin
@@ -638,6 +651,7 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
             .stream()
             .map(File::toPath)
             .collect(Collectors.toList()))
+        .isEmbedSourcesInClassOutputs(embedSourcesInClassOutputs)
         .isFailOnMissingSources(failOnMissingSources)
         .isFailOnMissingTargets(failOnMissingTargets)
         .isFatalWarnings(fatalWarnings)


### PR DESCRIPTION
Enable embedding protobuf sources that got compiled within the output classes directory for the project. This enables embedding them in any generated JAR.

Closes GH-207.