### PR TITLE
Support 'zip:' as a URL protocol

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,7 @@
   <properties>
     <!-- Dependencies -->
     <assertj.version>3.25.3</assertj.version>
+    <auto-service.version>1.1.1</auto-service.version>
     <immutables.version>2.10.1</immutables.version>
     <jspecify.version>0.3.0</jspecify.version>
     <junit.version>5.10.2</junit.version>
@@ -149,6 +150,12 @@
         <groupId>com.github.marschall</groupId>
         <artifactId>memoryfilesystem</artifactId>
         <version>${memoryfilesystem.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.google.auto.service</groupId>
+        <artifactId>auto-service</artifactId>
+        <version>${auto-service.version}</version>
       </dependency>
 
       <dependency>

--- a/protobuf-maven-plugin/pom.xml
+++ b/protobuf-maven-plugin/pom.xml
@@ -34,27 +34,14 @@
     <maven>3.8.2</maven>
   </prerequisites>
 
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>org.junit</groupId>
-        <artifactId>junit-bom</artifactId>
-        <version>${junit.version}</version>
-        <scope>import</scope>
-        <type>pom</type>
-      </dependency>
-
-      <dependency>
-        <groupId>org.mockito</groupId>
-        <artifactId>mockito-bom</artifactId>
-        <version>${mockito.version}</version>
-        <scope>import</scope>
-        <type>pom</type>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
   <dependencies>
+    <dependency>
+      <groupId>com.google.auto.service</groupId>
+      <artifactId>auto-service</artifactId>
+      <!-- Annotation processor only -->
+      <scope>provided</scope>
+    </dependency>
+  
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>

--- a/protobuf-maven-plugin/src/it/scalapb-plugin/pom.xml
+++ b/protobuf-maven-plugin/src/it/scalapb-plugin/pom.xml
@@ -88,7 +88,7 @@
 
           <binaryUrlPlugins>
             <binaryUrlPlugin>
-              <url>jar:https://github.com/scalapb/ScalaPB/releases/download/v0.11.15/protoc-gen-scala-${scalapb.version}-linux-x86_64.zip!/protoc-gen-scala</url>
+              <url>zip:https://github.com/scalapb/ScalaPB/releases/download/v0.11.15/protoc-gen-scala-${scalapb.version}-linux-x86_64.zip!/protoc-gen-scala</url>
               <options>flat_package,grpc</options>
             </binaryUrlPlugin>
           </binaryUrlPlugins>

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/UrlProtocPlugin.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/UrlProtocPlugin.java
@@ -16,7 +16,6 @@
 
 package io.github.ascopes.protobufmavenplugin.plugins;
 
-import java.net.URL;
 import org.immutables.value.Value.Modifiable;
 
 
@@ -32,5 +31,7 @@ import org.immutables.value.Value.Modifiable;
 @Modifiable
 public abstract class UrlProtocPlugin implements OptionalProtocPlugin {
 
-  public abstract URL getUrl();
+  // Kept as a String to defer parsing URLs until all SPIs have been loaded
+  // in the current classloader. Was java.net.URL prior to v2.1.1
+  public abstract String getUrl();
 }

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/protoc/ProtocResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/protoc/ProtocResolver.java
@@ -25,7 +25,6 @@ import io.github.ascopes.protobufmavenplugin.dependencies.aether.AetherMavenArti
 import io.github.ascopes.protobufmavenplugin.utils.FileUtils;
 import io.github.ascopes.protobufmavenplugin.utils.HostSystem;
 import java.io.IOException;
-import java.net.URL;
 import java.nio.file.Path;
 import java.util.Optional;
 import javax.inject.Inject;
@@ -82,7 +81,7 @@ public final class ProtocResolver {
     }
 
     var path = version.contains(":")
-        ? resolveFromUrl(version)
+        ? urlResourceFetcher.fetchFileFromUrl(version, ".exe")
         : resolveFromMavenRepositories(version);
 
     if (path.isPresent()) {
@@ -94,14 +93,6 @@ public final class ProtocResolver {
     }
 
     return path;
-  }
-
-  private Optional<Path> resolveFromUrl(String url) throws ResolutionException {
-    try {
-      return urlResourceFetcher.fetchFileFromUrl(new URL(url), ".exe");
-    } catch (IOException ex) {
-      throw new ResolutionException(ex.getMessage(), ex);
-    }
   }
 
   private Optional<Path> resolveFromMavenRepositories(String version) throws ResolutionException {

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/spi/ZipUrlStreamHandlerProvider.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/spi/ZipUrlStreamHandlerProvider.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2023 - 2024, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.ascopes.protobufmavenplugin.spi;
+
+import com.google.auto.service.AutoService;
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
+import java.net.spi.URLStreamHandlerProvider;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * A URL stream handler that is used to register the {@code zip}
+ * protocol.
+ *
+ * <p>In reality, it just delegates to the JAR handler internally, which is already
+ * compatible with ZIP files. We provide this to create a more intuitive interface
+ * for users than using the JAR protocol for non-JAR files.
+ *
+ * @author Ashley Scopes
+ * @since 2.1.1
+ */
+@AutoService(URLStreamHandlerProvider.class)
+public final class ZipUrlStreamHandlerProvider extends URLStreamHandlerProvider {
+
+  // No state is stored, so we can just reuse a singleton instance.
+  private static final URLStreamHandler instance = new URLStreamHandler() {
+    @Override
+    public URLConnection openConnection(URL url) throws IOException {
+      // The handler for JAR files can deal with processing ZIP files for us.
+      return new URL("jar", null, url.getFile()).openConnection();
+    }
+  };
+
+  @Override
+  public @Nullable URLStreamHandler createURLStreamHandler(String protocol) {
+    return protocol.equalsIgnoreCase("zip")
+        ? instance
+        : null;
+  }
+}

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/spi/package-info.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/spi/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2023 - 2024, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Service provider interfaces.
+ */
+package io.github.ascopes.protobufmavenplugin.spi;

--- a/protobuf-maven-plugin/src/site/markdown/index.md
+++ b/protobuf-maven-plugin/src/site/markdown/index.md
@@ -534,10 +534,10 @@ Any protocols supported by your JRE should be able to be used here, including:
 - `http:`
 - `https:`
 - `ftp:`
-- `jar:` - this also works for ZIP files, and can be used to dereference files within the archive,
-  e.g. `jar:https://github.com/some-project/some-repo/releases/download/v1.1.1/plugin.zip!/plugin.exe`,
-  which would download `https://github.com/some-project/some-repo/releases/download/v1.1.1/plugin.zip`
-  and internally extract `plugin.exe` from that archive.
+- `zip:`, e.g. `zip:file:///path/to/file.zip!/bin/protoc-gen-foo` which would read
+  `/bin/protoc-gen-foo` from the ZIP at `/path/to/file.zip`.
+- `jar:`, e.g. `jar:file:///path/to/file.jar!/bin/protoc-gen-foo` which would read
+  `/bin/protoc-gen-foo` from the JAR at `/path/to/file.jar`.
 
 Each `binaryUrlPlugin` can take an optional `options` parameter which will
 be passed as an option to the plugin if specified.
@@ -548,8 +548,8 @@ cannot be resolved. This is useful for specific cases where resources may only b
 prevent the application being built locally. If set to optional, then any "not found" response provided by
 the underlying URL protocol will be ignored.
 
-This is not recommended outside specific use cases, and care should be taken to ensure the
-legitimacy and security of any URLs being provided prior to adding them.
+Remember that it is up to you to ensure the legitimacy of the URLs that you are
+reading. Where possible, prefer the use of Maven-based resources instead.
 
 Providing authentication details or proxy details is not supported at this time.
 

--- a/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/spi/ZipUrlStreamHandlerProviderTest.java
+++ b/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/spi/ZipUrlStreamHandlerProviderTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (C) 2023 - 2024, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.ascopes.protobufmavenplugin.spi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.UUID;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@DisplayName("ZipUrlStreamHandlerProvider tests")
+class ZipUrlStreamHandlerProviderTest {
+
+  @TempDir
+  Path tempDir;
+
+  @DisplayName("The handler provider is returned when the URL scheme is 'zip'")
+  @ParameterizedTest(name = "(scheme = {0})")
+  @ValueSource(strings = {"zip", "ZIP", "zIp"})
+  void theHandlerProviderIsReturnedWhenTheUrlSchemeIsZip(String scheme) {
+    // Given
+    var handlerProvider = new ZipUrlStreamHandlerProvider();
+
+    // When
+    var handler = handlerProvider.createURLStreamHandler(scheme);
+
+    // Then
+    assertThat(handler).isNotNull();
+  }
+
+  @DisplayName("The handler provider is not returned when the URL scheme is not 'zip'")
+  @ParameterizedTest(name = "(scheme = {0})")
+  @ValueSource(strings = {"jar", "gz", "tar", "wheel", "zippo", "gzip"})
+  void theHandlerProviderIsNotReturnedWhenTheUrlSchemeIsNotZip(String scheme) {
+    // Given
+    var handlerProvider = new ZipUrlStreamHandlerProvider();
+
+    // When
+    var handler = handlerProvider.createURLStreamHandler(scheme);
+
+    // Then
+    assertThat(handler).isNull();
+  }
+
+  @DisplayName("ZIP contents can be read correctly via the registered SPI")
+  @Test
+  void zipContentsCanBeReadCorrectlyViaRegisteredSpi() throws IOException {
+    // Given
+    var expectedBazContent = UUID.randomUUID().toString();
+    var expectedBorkContent = UUID.randomUUID().toString();
+    createFile(tempDir.resolve("zip/foo/bar/Baz.txt"), expectedBazContent);
+    createFile(tempDir.resolve("zip/foo/bar/Bork.txt"), expectedBorkContent);
+
+    var zipName = UUID.randomUUID() + ".zip";
+    var zipFile = createZip(zipName, tempDir.resolve("zip"));
+
+    // When
+    var bazUrl = new URL("zip:file://" + zipFile.toString() + "!/foo/bar/Baz.txt");
+    var borkUrl = new URL("zip:file://" + zipFile.toString() + "!/foo/bar/Bork.txt");
+
+    var actualBazContent = readContent(bazUrl);
+    var actualBorkContent = readContent(borkUrl);
+
+    // Then
+    assertSoftly(softly -> {
+      softly.assertThat(actualBazContent)
+          .as("content of %s", bazUrl)
+          .isEqualTo(expectedBazContent);
+      softly.assertThat(actualBorkContent)
+          .as("content of %s", borkUrl)
+          .isEqualTo(expectedBorkContent);
+    });
+  }
+
+  private Path createFile(Path path, String data) throws IOException {
+    Files.createDirectories(path.getParent());
+    return Files.writeString(path, data).toAbsolutePath();
+  }
+
+  // Create a zip file named <name> containing the contents of
+  // <baseDir> recursively.
+  private Path createZip(String name, Path baseDir) throws IOException {
+    var zipPath = tempDir.resolve(name);
+
+    try (
+        var zip = new ZipOutputStream(Files.newOutputStream(zipPath));
+        var files = Files.walk(baseDir).filter(Files::isRegularFile)
+    ) {
+      var iter = files.iterator();
+
+      while (iter.hasNext()) {
+        var nextFile = iter.next();
+        var nextFileName = baseDir.relativize(nextFile).toString();
+
+        zip.putNextEntry(new ZipEntry(nextFileName));
+        var nextFileData = Files.readAllBytes(nextFile);
+        zip.write(nextFileData, 0, nextFileData.length);
+        zip.closeEntry();
+      }
+    }
+
+    return zipPath.toAbsolutePath();
+  }
+
+  private String readContent(URL url) throws IOException {
+    var conn = url.openConnection();
+    conn.connect();
+    try (
+        var is = conn.getInputStream();
+        var baos = new ByteArrayOutputStream()
+    ) {
+      is.transferTo(baos);
+      return baos.toString();
+    }
+  }
+}

--- a/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/spi/ZipUrlStreamHandlerProviderTest.java
+++ b/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/spi/ZipUrlStreamHandlerProviderTest.java
@@ -29,6 +29,8 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -67,6 +69,9 @@ class ZipUrlStreamHandlerProviderTest {
     assertThat(handler).isNull();
   }
 
+  // File paths break on Windows due to their style when using the Path
+  // API directly, so ignore on there for now.
+  @DisabledOnOs(OS.WINDOWS)
   @DisplayName("ZIP contents can be read correctly via the registered SPI")
   @Test
   void zipContentsCanBeReadCorrectlyViaRegisteredSpi() throws IOException {


### PR DESCRIPTION
Adds a URL stream handler provider to support using `zip:` as a protocol, which is more idiomatic than `jar:` for regular zips.

Technically a new feature but including as a bugfix for now as it is addressing what is in my opinion a readability and understandability issue. No new components are directly exposed to users either.