### PR TITLE
Write outputs of protoc invocations to the Maven logs

### DIFF
--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/protoc/CommandLineExecutor.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/protoc/CommandLineExecutor.java
@@ -64,8 +64,8 @@ public final class CommandLineExecutor {
     var startTimeNs = System.nanoTime();
     var proc = procBuilder.start();
 
-    var stdoutThread = redirectOutput(proc.getInputStream(), line -> log.info(">| {}", line));
-    var stderrThread = redirectOutput(proc.getErrorStream(), line -> log.warn(">| {}", line));
+    var stdoutThread = redirectOutput(proc.getInputStream(), line -> log.info("[OUT] {}", line));
+    var stderrThread = redirectOutput(proc.getErrorStream(), line -> log.warn("[ERR] {}", line));
 
     var exitCode = proc.waitFor();
     var elapsedTimeMs = (System.nanoTime() - startTimeNs) / 1_000_000L;


### PR DESCRIPTION
Changes how stdout and stderr are piped from protoc subprocesses so that their outputs get written directly to the Maven logs so that they can be directly queried should logs be redirected to a different location to stdout/stderr.

Outputs to stdout are written to info logs, and outputs to stderr are written to warn logs.

We do this via two daemon threads that consume the input streams via buffered readers.