### PR TITLE
Improve Android detection

### DIFF
--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/protoc/ProtocResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/protoc/ProtocResolver.java
@@ -105,13 +105,13 @@ public final class ProtocResolver {
   }
 
   private Optional<Path> resolveFromMavenRepositories(String version) throws ResolutionException {
-    if (hostSystem.isProbablyAndroidTermux()) {
+    if (hostSystem.isProbablyAndroid()) {
       log.warn(
-          "It looks like you are using Termux on Android. You may encounter issues "
-              + "running the detected protoc binary from Maven central. If this is "
-              + "an issue, install the protoc compiler manually from your package "
-              + "manager (apt update && apt install protobuf), and then invoke "
-              + "Maven with the -Dprotobuf.compiler.version=PATH flag."
+          "It looks like you are using Android! Android is known to be missing "
+              + "system calls for Linux that the official protoc binaries rely on "
+              + "to work. If you encounter issues, run Maven again with the "
+              + "-Dprotobuf.compiler.version=PATH flag to rerun with the version "
+              + "of protoc that is on your $PATH."
       );
     }
 


### PR DESCRIPTION
Changes Termux detection internally to cover Android as a whole, and uses a less error prone way of detecting that environment.