### PR TITLE
Fix missing unit test report set on generated site

### DIFF
--- a/protobuf-maven-plugin/pom.xml
+++ b/protobuf-maven-plugin/pom.xml
@@ -371,17 +371,35 @@
 
         <reportSets>
           <reportSet>
-            <id>coverage</id>
+            <id>coverage-unit</id>
             <reports>
               <report>report</report>
+            </reports>
+            <configuration>
+              <includeCurrentProject>true</includeCurrentProject>
+              <title>${project.name} - unit test coverage</title>
+            </configuration>
+          </reportSet>
+
+          <reportSet>
+            <id>coverage-integration</id>
+            <reports>
               <report>report-integration</report>
+            </reports>
+            <configuration>
+              <includeCurrentProject>true</includeCurrentProject>
+              <title>${project.name} - integration test coverage</title>
+            </configuration>
+          </reportSet>
+
+          <reportSet>
+            <id>coverage-all</id>
+            <reports>
               <report>report-aggregate</report>
             </reports>
             <configuration>
-              <dataFileIncludes>
-                <dataFileIncludes>**/jacoco*.exec</dataFileIncludes>
-              </dataFileIncludes>
               <includeCurrentProject>true</includeCurrentProject>
+              <title>${project.name} - aggregate coverage</title>
             </configuration>
           </reportSet>
         </reportSets>

--- a/protobuf-maven-plugin/pom.xml
+++ b/protobuf-maven-plugin/pom.xml
@@ -377,6 +377,11 @@
             </reports>
             <configuration>
               <includeCurrentProject>true</includeCurrentProject>
+              <footer>
+                  This only contains coverage for the platform the artifact was built
+                  from. Please refer to the codecov.io link on the project for full
+                  cross-platform coverage.
+              </footer>
               <title>${project.name} - unit test coverage</title>
             </configuration>
           </reportSet>
@@ -388,6 +393,11 @@
             </reports>
             <configuration>
               <includeCurrentProject>true</includeCurrentProject>
+              <footer>
+                  This only contains coverage for the platform the artifact was built
+                  from. Please refer to the codecov.io link on the project for full
+                  cross-platform coverage.
+              </footer>
               <title>${project.name} - integration test coverage</title>
             </configuration>
           </reportSet>
@@ -399,6 +409,11 @@
             </reports>
             <configuration>
               <includeCurrentProject>true</includeCurrentProject>
+              <footer>
+                  This only contains coverage for the platform the artifact was built
+                  from. Please refer to the codecov.io link on the project for full
+                  cross-platform coverage.
+              </footer>
               <title>${project.name} - aggregate coverage</title>
             </configuration>
           </reportSet>

--- a/protobuf-maven-plugin/src/site/site.xml
+++ b/protobuf-maven-plugin/src/site/site.xml
@@ -47,15 +47,16 @@
       ]]>
     </head>
 
-    <menu name="Getting Started">
+    <menu name="Documentation">
       <item name="Usage" href="index.html"/>
       <item name="Goals" href="plugin-info.html"/>
     </menu>
-    <menu ref="reports">
-      <!-- We include this alongside JaCoCo as we run this against
-           multiple platforms as part of CI. -->
-      <item name="Coverage (multiplatform)" href="https://app.codecov.io/gh/ascopes/protobuf-maven-plugin"/>
+    <menu name="External Links">
+      <item name="Cross-platform coverage (codecov.io)" href="https://app.codecov.io/gh/ascopes/protobuf-maven-plugin"/>
+      <item name="GitHub" href="https://github.com/ascopes/protobuf-maven-plugin"/>
+      <item name="Maven Central" href="https://central.sonatype.com/artifact/io.github.ascopes/protobuf-maven-plugin"/>
     </menu>
+    <menu ref="reports"/>
   </body>
 
   <custom>

--- a/protobuf-maven-plugin/src/site/site.xml
+++ b/protobuf-maven-plugin/src/site/site.xml
@@ -65,6 +65,7 @@
         <sitesearch/>
       </googleSearch>
 
+      <profile>production</profile>
       <skipGenerationDate>true</skipGenerationDate>
     </fluidoSkin>
   </custom>

--- a/protobuf-maven-plugin/src/site/site.xml
+++ b/protobuf-maven-plugin/src/site/site.xml
@@ -61,12 +61,6 @@
 
   <custom>
     <fluidoSkin>
-      <gitHub>
-        <projectId>ascopes/protobuf-maven-plugin</projectId>
-        <ribbonOrientation>right</ribbonOrientation>
-        <ribbonColor>red</ribbonColor>
-      </gitHub>
-
       <googleSearch>
         <sitesearch/>
       </googleSearch>

--- a/protobuf-maven-plugin/src/site/site.xml
+++ b/protobuf-maven-plugin/src/site/site.xml
@@ -51,7 +51,11 @@
       <item name="Usage" href="index.html"/>
       <item name="Goals" href="plugin-info.html"/>
     </menu>
-    <menu ref="reports"/>
+    <menu ref="reports">
+      <!-- We include this alongside JaCoCo as we run this against
+           multiple platforms as part of CI. -->
+      <item name="Coverage (multiplatform)" href="https://app.codecov.io/gh/ascopes/protobuf-maven-plugin"/>
+    </menu>
   </body>
 
   <custom>

--- a/protobuf-maven-plugin/src/site/site.xml
+++ b/protobuf-maven-plugin/src/site/site.xml
@@ -64,6 +64,8 @@
       <googleSearch>
         <sitesearch/>
       </googleSearch>
+
+      <skipGenerationDate>true</skipGenerationDate>
     </fluidoSkin>
   </custom>
 


### PR DESCRIPTION
The unit test report is missing from the generated Maven site, which means the coverage is being reported incorrectly.