### PR TITLE
GH-277: Support explicit plugin ordering

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>io.github.ascopes</groupId>
   <artifactId>protobuf-maven-plugin-parent</artifactId>
-  <version>2.2.4-SNAPSHOT</version>
+  <version>2.3.0-SNAPSHOT</version>
 
   <name>Protobuf Maven Plugin Parent</name>
   <description>Parent POM for the Protobuf Maven Plugin.</description>

--- a/protobuf-maven-plugin/pom.xml
+++ b/protobuf-maven-plugin/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes</groupId>
     <artifactId>protobuf-maven-plugin-parent</artifactId>
-    <version>2.2.4-SNAPSHOT</version>
+    <version>2.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>protobuf-maven-plugin</artifactId>

--- a/protobuf-maven-plugin/src/it/gh-277-plugin-ordering/invoker.properties
+++ b/protobuf-maven-plugin/src/it/gh-277-plugin-ordering/invoker.properties
@@ -1,0 +1,17 @@
+#
+# Copyright (C) 2023 - 2024, Ashley Scopes.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+invoker.goals = clean package

--- a/protobuf-maven-plugin/src/it/gh-277-plugin-ordering/pom.xml
+++ b/protobuf-maven-plugin/src/it/gh-277-plugin-ordering/pom.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2023 - 2024, Ashley Scopes.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>@project.groupId@</groupId>
+    <artifactId>protobuf-maven-plugin-parent</artifactId>
+    <version>@project.version@</version>
+    <relativePath>../../../../pom.xml</relativePath>
+  </parent>
+
+  <groupId>gh-277-plugin-ordering</groupId>
+  <artifactId>gh-277-plugin-ordering</artifactId>
+
+  <properties>
+    <grpc.version>1.64.0</grpc.version>
+    <javax-annotation-api.version>1.3.2</javax-annotation-api.version>
+    <protobuf.version>4.27.1</protobuf.version>
+    <reactor-core.version>3.6.3</reactor-core.version>
+    <reactor-grpc.version>1.2.4</reactor-grpc.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>${protobuf.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.salesforce.servicelibs</groupId>
+      <artifactId>reactor-grpc-stub</artifactId>
+      <version>${reactor-grpc.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-protobuf</artifactId>
+      <version>${grpc.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-stub</artifactId>
+      <version>${grpc.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.projectreactor</groupId>
+      <artifactId>reactor-core</artifactId>
+      <version>${reactor-core.version}</version>
+    </dependency>
+
+    <!-- See https://github.com/grpc/grpc-java/issues/9179 -->
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+      <version>${javax-annotation-api.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+
+        <configuration>
+          <binaryMavenPlugins>
+            <binaryMavenPlugin>
+              <groupId>com.salesforce.servicelibs</groupId>
+              <artifactId>reactor-grpc</artifactId>
+              <version>${reactor-grpc.version}</version>
+              <order>200</order>
+            </binaryMavenPlugin>
+
+            <binaryMavenPlugin>
+              <groupId>io.grpc</groupId>
+              <artifactId>protoc-gen-grpc-java</artifactId>
+              <version>${grpc.version}</version>
+              <order>100</order>
+            </binaryMavenPlugin>
+          </binaryMavenPlugins>
+
+          <protocVersion>${protobuf.version}</protocVersion>
+        </configuration>
+
+        <executions>
+          <execution>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/protobuf-maven-plugin/src/it/gh-277-plugin-ordering/src/main/java/org/example/helloworld/ReactorGreetingServiceImpl.java
+++ b/protobuf-maven-plugin/src/it/gh-277-plugin-ordering/src/main/java/org/example/helloworld/ReactorGreetingServiceImpl.java
@@ -14,27 +14,15 @@
  * limitations under the License.
  */
 
-package io.github.ascopes.protobufmavenplugin.plugins;
+package org.example.helloworld;
 
-import java.nio.file.Path;
-import java.util.Optional;
-import org.immutables.value.Value.Immutable;
+import reactor.core.publisher.Mono;
 
-/**
- * Model that holds details about a resolved protoc plugin.
- *
- * <p>Only used internally, never exposed via the plugin API to users.
- *
- * @author Ashley Scopes
- */
-@Immutable
-public interface ResolvedProtocPlugin {
-
-  Path getPath();
-
-  String getId();
-
-  Optional<String> getOptions();
-
-  int getOrder();
+public class ReactorGreetingServiceImpl extends ReactorGreetingServiceGrpc.GreetingServiceImplBase {
+  @Override
+  public Mono<GreetingResponse> greet(Mono<GreetingRequest> request) {
+    return request.map(body -> GreetingResponse.newBuilder()
+            .setText("Hello, " + body.getName() + "!")
+            .build());
+  }
 }

--- a/protobuf-maven-plugin/src/it/gh-277-plugin-ordering/src/main/protobuf/helloworld.proto
+++ b/protobuf-maven-plugin/src/it/gh-277-plugin-ordering/src/main/protobuf/helloworld.proto
@@ -1,0 +1,35 @@
+//
+// Copyright (C) 2023 - 2024, Ashley Scopes.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "org.example.helloworld";
+
+package org.example.helloworld;
+
+message GreetingRequest {
+  string name = 1;
+}
+
+message GreetingResponse {
+  string text = 1;
+}
+
+service GreetingService {
+  rpc Greet(GreetingRequest) returns (GreetingResponse);
+}
+

--- a/protobuf-maven-plugin/src/it/gh-277-plugin-ordering/test.groovy
+++ b/protobuf-maven-plugin/src/it/gh-277-plugin-ordering/test.groovy
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2023 - 2024, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.NoSuchElementException
+
+import static org.assertj.core.api.Assertions.assertThat
+import static org.assertj.core.api.Assertions.fail
+
+Path baseDirectory = basedir.toPath().toAbsolutePath()
+Path logFile = baseDirectory.resolve("build.log")
+List<String> logLines = Files.readAllLines(logFile)
+
+int indexOfMatch(List<String> logLines, String pattern) {
+  for (int i = 0; i < logLines.size(); ++i) {
+    if (logLines.get(i).matches(pattern)) {
+      return i
+    }
+  }
+
+  fail("No pattern %s found in log lines:%n%s", pattern, String.join("\n", logLines))
+}
+
+assertThat(indexOfMatch(logLines, ".*--plugin=.*?reactor-grpc.*"))
+    .as("index of commandline argument for the reactor GRPC plugin")
+    .isGreaterThan(indexOfMatch(logLines, ".*--plugin=.*?protoc-gen-grpc-java.*"))
+
+return true

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generation/SourceCodeGenerator.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generation/SourceCodeGenerator.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -158,7 +159,7 @@ public final class SourceCodeGenerator {
   private Collection<ResolvedProtocPlugin> discoverPlugins(
       GenerationRequest request
   ) throws IOException, ResolutionException {
-    return concat(
+    var plugins = concat(
         binaryPluginResolver
             .resolveMavenPlugins(request.getBinaryMavenPlugins()),
         binaryPluginResolver
@@ -168,6 +169,12 @@ public final class SourceCodeGenerator {
         jvmPluginResolver
             .resolveMavenPlugins(request.getJvmMavenPlugins())
     );
+
+    // Sort by precedence then by initial order (sort is stable which guarantees this property).
+    return plugins
+        .stream()
+        .sorted(Comparator.comparingInt(ResolvedProtocPlugin::getOrder))
+        .collect(Collectors.toUnmodifiableList());
   }
 
   private Collection<ProtoFileListing> discoverImportPaths(

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/AbstractGenerateMojo.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/AbstractGenerateMojo.java
@@ -123,6 +123,8 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    *   <li>{@code classifier} - the artifact classifier - optional</li>
    *   <li>{@code options} - a string of options to pass to the plugin
    *       - optional.</li>
+   *   <li>{@code order} - an integer order to run the plugins in. Defaults
+   *       to 100,000. Higher numbers run later than lower numbers.</li>
    *   <li>{@code skip} - set to {@code true} to skip invoking this plugin -
    *       useful if you want to control whether the plugin runs via a
    *       property - optional.</li>
@@ -155,6 +157,8 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    *   <li>{@code name} - the name of the binary to resolve.</li>
    *   <li>{@code options} - a string of options to pass to the plugin
    *       - optional.</li>
+   *   <li>{@code order} - an integer order to run the plugins in. Defaults
+   *       to 100,000. Higher numbers run later than lower numbers.</li>
    *   <li>{@code skip} - set to {@code true} to skip invoking this plugin -
    *       useful if you want to control whether the plugin runs via a
    *       property - optional.</li>
@@ -214,6 +218,8 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    *   <li>{@code url} - the URL to resolve.</li>
    *   <li>{@code options} - a string of options to pass to the plugin
    *       - optional.</li>
+   *   <li>{@code order} - an integer order to run the plugins in. Defaults
+   *       to 100,000. Higher numbers run later than lower numbers.</li>
    *   <li>{@code skip} - set to {@code true} to skip invoking this plugin -
    *       useful if you want to control whether the plugin runs via a
    *       property - optional.</li>

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/BinaryPluginResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/BinaryPluginResolver.java
@@ -149,6 +149,7 @@ public final class BinaryPluginResolver {
         .id(Digests.sha1(path.toString()))
         .path(path)
         .options(plugin.getOptions())
+        .order(plugin.getOrder())
         .build();
   }
 

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/JvmPluginResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/JvmPluginResolver.java
@@ -102,6 +102,7 @@ public final class JvmPluginResolver {
         .id(pluginId)
         .path(scriptPath)
         .options(plugin.getOptions())
+        .order(plugin.getOrder())
         .build();
   }
 

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/ProtocPlugin.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/ProtocPlugin.java
@@ -31,6 +31,12 @@ public interface ProtocPlugin {
 
   @Nullable String getOptions();
 
+  default int getOrder() {
+    // A semi-sensible default value that can allow users to easily
+    // place values before or after the default order.
+    return 100_000;
+  }
+
   default boolean isSkip() {
     return false;
   }

--- a/protobuf-maven-plugin/src/site/markdown/index.md
+++ b/protobuf-maven-plugin/src/site/markdown/index.md
@@ -440,6 +440,38 @@ Providing authentication details or proxy details is not supported at this time.
 If you wish to generate GRPC stubs, or outputs for other languages like Scala that are not already
 covered by the protoc executable, you can add custom plugins to your build.
 
+### Common options
+
+Each plugin is defined as an XML object with various attributes. Many depend on the type of plugin
+you are adding (see the sections below), but all plugins share some common attributes:
+
+- `options` - a string value that can be passed to the plugin as a parameter. Defaults to being
+  unspecified.
+- `order` - an integer that controls the plugin execution order relative to other plugins.
+  Smaller numbers make plugins run before those with larger numbers. Defaults to `100000`, meaning
+  you can place plugins before or after those that do not define an order if you wish.
+- `skip` - a boolean that, when true, skips the execution of the plugin entierly. Defaults to
+  `false`.
+
+### Defining plugins in the parent POM
+
+You can define plugins in a parent POM and child projects will inherit it.
+
+By default, if you define the plugin in the parent and the child POM, Maven will merge the
+definitions together.
+
+If you wish for plugins in the child POM to be appended to the list in the parent POM, you can
+add the `combine.children="append"` XML attribute to the parent POM elements:
+
+```xml
+<binaryMavenPlugins combine.children="append">
+  ...
+</binaryMavenPlugins>
+```
+
+You can alternatively use `combine.self="override"` if you want child POMs to totally replace
+anything defined in the parent.
+
 ### Binary plugins
 
 Binary plugins are OS-specific executables that are passed to `protoc` directly, and are the 
@@ -471,9 +503,6 @@ that plugin directly via the group ID, artifact ID, and version (like any other 
 </plugin>
 ```
 
-Each `binaryMavenPlugin` can take an optional `options` parameter which will
-be passed as an option to the plugin if specified.
-
 #### Binary plugins from the system path
 
 If you instead wish to read the executable from the system `$PATH`, then you can specify an
@@ -497,9 +526,6 @@ executable name instead:
   ...
 </plugin>
 ```
-
-Each `binaryPathPlugin` can take an optional `options` parameter which will
-be passed as an option to the plugin if specified.
 
 You can also mark these plugins as being optional by setting `<optional>true</optional>` on the
 individual plugin objects. This will prevent the Maven plugin from failing the build if the `protoc` plugin
@@ -558,9 +584,6 @@ Any protocols supported by your JRE should be able to be used here, including:
   which would download `https://github.com/some-project/some-repo/releases/download/v1.1.1/plugin.zip`
   and internally extract `plugin.exe` from that archive.
 
-Each `binaryUrlPlugin` can take an optional `options` parameter which will
-be passed as an option to the plugin if specified.
-
 You can also mark these plugins as being optional by setting `<optional>true</optional>` on the
 individual plugin objects. This will prevent the Maven plugin from failing the build if the `protoc` plugin
 cannot be resolved. This is useful for specific cases where resources may only be available during CI builds but do not
@@ -600,9 +623,6 @@ dependencies to execute.
   ...
 </plugin>
 ```
-
-Each `jvmMavenPlugin` can take an optional `options` parameter which will
-be passed as an option to the plugin if specified.
 
 Currently, you are required to be able to execute `*.bat` files on Windows, or have 
 `sh` available on the system `$PATH` for any other platform.


### PR DESCRIPTION
- Add new feature that allows users to explicitly order plugins across multiple POMs by specifying `<order>12345</order>`.
- Document new behaviour.
- Document plugin common attributes in one place.
- Implement integration test for ordering.

Fixes GH-277.