### PR TITLE
Skip ITs on Android if they cannot invoke the binaries correctly

### DIFF
--- a/protobuf-maven-plugin/src/it/embed-main-sources/selector.groovy
+++ b/protobuf-maven-plugin/src/it/embed-main-sources/selector.groovy
@@ -13,20 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-// Only execute this test if the user has protoc installed on their
-// PATH and it is successfully executable.
-try {
-  println("Checking if protoc is on the system path...")
-  int exitCode = "protoc --version".execute().waitFor()
-
-  if (exitCode == 0) {
-    return true
-  } else {
-    println("Skipping this test: protoc system binary exited with code ${exitCode}")
-    return false
-  }
-} catch (IOException ex) {
-  println("Skipping this test. ${ex.getClass().getName()}: ${ex.getMessage()}")
+if ("uname -o".execute().text =~ /Android.*/) {
+  println("Skipping test as it uses incompatible binaries for Android")
   return false
+} else {
+  return true
 }

--- a/protobuf-maven-plugin/src/it/gh-132-duplicate-maven-dependencies/selector.groovy
+++ b/protobuf-maven-plugin/src/it/gh-132-duplicate-maven-dependencies/selector.groovy
@@ -13,20 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-// Only execute this test if the user has protoc installed on their
-// PATH and it is successfully executable.
-try {
-  println("Checking if protoc is on the system path...")
-  int exitCode = "protoc --version".execute().waitFor()
-
-  if (exitCode == 0) {
-    return true
-  } else {
-    println("Skipping this test: protoc system binary exited with code ${exitCode}")
-    return false
-  }
-} catch (IOException ex) {
-  println("Skipping this test. ${ex.getClass().getName()}: ${ex.getMessage()}")
+if ("uname -o".execute().text =~ /Android.*/) {
+  println("Skipping test as it uses incompatible binaries for Android")
   return false
+} else {
+  return true
 }

--- a/protobuf-maven-plugin/src/it/gh-134-multiple-artifact-versions/selector.groovy
+++ b/protobuf-maven-plugin/src/it/gh-134-multiple-artifact-versions/selector.groovy
@@ -13,20 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-// Only execute this test if the user has protoc installed on their
-// PATH and it is successfully executable.
-try {
-  println("Checking if protoc is on the system path...")
-  int exitCode = "protoc --version".execute().waitFor()
-
-  if (exitCode == 0) {
-    return true
-  } else {
-    println("Skipping this test: protoc system binary exited with code ${exitCode}")
-    return false
-  }
-} catch (IOException ex) {
-  println("Skipping this test. ${ex.getClass().getName()}: ${ex.getMessage()}")
+if ("uname -o".execute().text =~ /Android.*/) {
+  println("Skipping test as it uses incompatible binaries for Android")
   return false
+} else {
+  return true
 }

--- a/protobuf-maven-plugin/src/it/gh-135-compile-dependencies/selector.groovy
+++ b/protobuf-maven-plugin/src/it/gh-135-compile-dependencies/selector.groovy
@@ -13,20 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-// Only execute this test if the user has protoc installed on their
-// PATH and it is successfully executable.
-try {
-  println("Checking if protoc is on the system path...")
-  int exitCode = "protoc --version".execute().waitFor()
-
-  if (exitCode == 0) {
-    return true
-  } else {
-    println("Skipping this test: protoc system binary exited with code ${exitCode}")
-    return false
-  }
-} catch (IOException ex) {
-  println("Skipping this test. ${ex.getClass().getName()}: ${ex.getMessage()}")
+if ("uname -o".execute().text =~ /Android.*/) {
+  println("Skipping test as it uses incompatible binaries for Android")
   return false
+} else {
+  return true
 }

--- a/protobuf-maven-plugin/src/it/gh-164-direct-dependency-resolution-depth-for-source-dependencies/selector.groovy
+++ b/protobuf-maven-plugin/src/it/gh-164-direct-dependency-resolution-depth-for-source-dependencies/selector.groovy
@@ -13,20 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-// Only execute this test if the user has protoc installed on their
-// PATH and it is successfully executable.
-try {
-  println("Checking if protoc is on the system path...")
-  int exitCode = "protoc --version".execute().waitFor()
-
-  if (exitCode == 0) {
-    return true
-  } else {
-    println("Skipping this test: protoc system binary exited with code ${exitCode}")
-    return false
-  }
-} catch (IOException ex) {
-  println("Skipping this test. ${ex.getClass().getName()}: ${ex.getMessage()}")
+if ("uname -o".execute().text =~ /Android.*/) {
+  println("Skipping test as it uses incompatible binaries for Android")
   return false
+} else {
+  return true
 }

--- a/protobuf-maven-plugin/src/it/gh-164-transitive-dependency-conflicts/selector.groovy
+++ b/protobuf-maven-plugin/src/it/gh-164-transitive-dependency-conflicts/selector.groovy
@@ -13,20 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-// Only execute this test if the user has protoc installed on their
-// PATH and it is successfully executable.
-try {
-  println("Checking if protoc is on the system path...")
-  int exitCode = "protoc --version".execute().waitFor()
-
-  if (exitCode == 0) {
-    return true
-  } else {
-    println("Skipping this test: protoc system binary exited with code ${exitCode}")
-    return false
-  }
-} catch (IOException ex) {
-  println("Skipping this test. ${ex.getClass().getName()}: ${ex.getMessage()}")
+if ("uname -o".execute().text =~ /Android.*/) {
+  println("Skipping test as it uses incompatible binaries for Android")
   return false
+} else {
+  return true
 }

--- a/protobuf-maven-plugin/src/it/gh-164-transitive-dependency-resolution-depth-for-source-dependencies/selector.groovy
+++ b/protobuf-maven-plugin/src/it/gh-164-transitive-dependency-resolution-depth-for-source-dependencies/selector.groovy
@@ -13,20 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-// Only execute this test if the user has protoc installed on their
-// PATH and it is successfully executable.
-try {
-  println("Checking if protoc is on the system path...")
-  int exitCode = "protoc --version".execute().waitFor()
-
-  if (exitCode == 0) {
-    return true
-  } else {
-    println("Skipping this test: protoc system binary exited with code ${exitCode}")
-    return false
-  }
-} catch (IOException ex) {
-  println("Skipping this test. ${ex.getClass().getName()}: ${ex.getMessage()}")
+if ("uname -o".execute().text =~ /Android.*/) {
+  println("Skipping test as it uses incompatible binaries for Android")
   return false
+} else {
+  return true
 }

--- a/protobuf-maven-plugin/src/it/gh-172-transitive-dependency-conflicts/selector.groovy
+++ b/protobuf-maven-plugin/src/it/gh-172-transitive-dependency-conflicts/selector.groovy
@@ -13,20 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-// Only execute this test if the user has protoc installed on their
-// PATH and it is successfully executable.
-try {
-  println("Checking if protoc is on the system path...")
-  int exitCode = "protoc --version".execute().waitFor()
-
-  if (exitCode == 0) {
-    return true
-  } else {
-    println("Skipping this test: protoc system binary exited with code ${exitCode}")
-    return false
-  }
-} catch (IOException ex) {
-  println("Skipping this test. ${ex.getClass().getName()}: ${ex.getMessage()}")
+if ("uname -o".execute().text =~ /Android.*/) {
+  println("Skipping test as it uses incompatible binaries for Android")
   return false
+} else {
+  return true
 }

--- a/protobuf-maven-plugin/src/it/gh-250-excludes/selector.groovy
+++ b/protobuf-maven-plugin/src/it/gh-250-excludes/selector.groovy
@@ -13,20 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-// Only execute this test if the user has protoc installed on their
-// PATH and it is successfully executable.
-try {
-  println("Checking if protoc is on the system path...")
-  int exitCode = "protoc --version".execute().waitFor()
-
-  if (exitCode == 0) {
-    return true
-  } else {
-    println("Skipping this test: protoc system binary exited with code ${exitCode}")
-    return false
-  }
-} catch (IOException ex) {
-  println("Skipping this test. ${ex.getClass().getName()}: ${ex.getMessage()}")
+if ("uname -o".execute().text =~ /Android.*/) {
+  println("Skipping test as it uses incompatible binaries for Android")
   return false
+} else {
+  return true
 }

--- a/protobuf-maven-plugin/src/it/gh-250-includes/selector.groovy
+++ b/protobuf-maven-plugin/src/it/gh-250-includes/selector.groovy
@@ -13,20 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-// Only execute this test if the user has protoc installed on their
-// PATH and it is successfully executable.
-try {
-  println("Checking if protoc is on the system path...")
-  int exitCode = "protoc --version".execute().waitFor()
-
-  if (exitCode == 0) {
-    return true
-  } else {
-    println("Skipping this test: protoc system binary exited with code ${exitCode}")
-    return false
-  }
-} catch (IOException ex) {
-  println("Skipping this test. ${ex.getClass().getName()}: ${ex.getMessage()}")
+if ("uname -o".execute().text =~ /Android.*/) {
+  println("Skipping test as it uses incompatible binaries for Android")
   return false
+} else {
+  return true
 }

--- a/protobuf-maven-plugin/src/it/gh-267-resolve-test-jar-type/selector.groovy
+++ b/protobuf-maven-plugin/src/it/gh-267-resolve-test-jar-type/selector.groovy
@@ -13,20 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-// Only execute this test if the user has protoc installed on their
-// PATH and it is successfully executable.
-try {
-  println("Checking if protoc is on the system path...")
-  int exitCode = "protoc --version".execute().waitFor()
-
-  if (exitCode == 0) {
-    return true
-  } else {
-    println("Skipping this test: protoc system binary exited with code ${exitCode}")
-    return false
-  }
-} catch (IOException ex) {
-  println("Skipping this test. ${ex.getClass().getName()}: ${ex.getMessage()}")
+if ("uname -o".execute().text =~ /Android.*/) {
+  println("Skipping test as it uses incompatible binaries for Android")
   return false
+} else {
+  return true
 }

--- a/protobuf-maven-plugin/src/it/gh-267-resolve-tests-classifier/selector.groovy
+++ b/protobuf-maven-plugin/src/it/gh-267-resolve-tests-classifier/selector.groovy
@@ -13,20 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-// Only execute this test if the user has protoc installed on their
-// PATH and it is successfully executable.
-try {
-  println("Checking if protoc is on the system path...")
-  int exitCode = "protoc --version".execute().waitFor()
-
-  if (exitCode == 0) {
-    return true
-  } else {
-    println("Skipping this test: protoc system binary exited with code ${exitCode}")
-    return false
-  }
-} catch (IOException ex) {
-  println("Skipping this test. ${ex.getClass().getName()}: ${ex.getMessage()}")
+if ("uname -o".execute().text =~ /Android.*/) {
+  println("Skipping test as it uses incompatible binaries for Android")
   return false
+} else {
+  return true
 }

--- a/protobuf-maven-plugin/src/it/gh-277-plugin-ordering/selector.groovy
+++ b/protobuf-maven-plugin/src/it/gh-277-plugin-ordering/selector.groovy
@@ -13,20 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-// Only execute this test if the user has protoc installed on their
-// PATH and it is successfully executable.
-try {
-  println("Checking if protoc is on the system path...")
-  int exitCode = "protoc --version".execute().waitFor()
-
-  if (exitCode == 0) {
-    return true
-  } else {
-    println("Skipping this test: protoc system binary exited with code ${exitCode}")
-    return false
-  }
-} catch (IOException ex) {
-  println("Skipping this test. ${ex.getClass().getName()}: ${ex.getMessage()}")
+if ("uname -o".execute().text =~ /Android.*/) {
+  println("Skipping test as it uses incompatible binaries for Android")
   return false
+} else {
+  return true
 }

--- a/protobuf-maven-plugin/src/it/grpc-plugin/selector.groovy
+++ b/protobuf-maven-plugin/src/it/grpc-plugin/selector.groovy
@@ -13,20 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-// Only execute this test if the user has protoc installed on their
-// PATH and it is successfully executable.
-try {
-  println("Checking if protoc is on the system path...")
-  int exitCode = "protoc --version".execute().waitFor()
-
-  if (exitCode == 0) {
-    return true
-  } else {
-    println("Skipping this test: protoc system binary exited with code ${exitCode}")
-    return false
-  }
-} catch (IOException ex) {
-  println("Skipping this test. ${ex.getClass().getName()}: ${ex.getMessage()}")
+if ("uname -o".execute().text =~ /Android.*/) {
+  println("Skipping test as it uses incompatible binaries for Android")
   return false
+} else {
+  return true
 }

--- a/protobuf-maven-plugin/src/it/help-goal/selector.groovy
+++ b/protobuf-maven-plugin/src/it/help-goal/selector.groovy
@@ -13,20 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-// Only execute this test if the user has protoc installed on their
-// PATH and it is successfully executable.
-try {
-  println("Checking if protoc is on the system path...")
-  int exitCode = "protoc --version".execute().waitFor()
-
-  if (exitCode == 0) {
-    return true
-  } else {
-    println("Skipping this test: protoc system binary exited with code ${exitCode}")
-    return false
-  }
-} catch (IOException ex) {
-  println("Skipping this test. ${ex.getClass().getName()}: ${ex.getMessage()}")
+if ("uname -o".execute().text =~ /Android.*/) {
+  println("Skipping test as it uses incompatible binaries for Android")
   return false
+} else {
+  return true
 }

--- a/protobuf-maven-plugin/src/it/http-url-grpc-plugin/selector.groovy
+++ b/protobuf-maven-plugin/src/it/http-url-grpc-plugin/selector.groovy
@@ -15,15 +15,15 @@
  */
 
 // Only execute on x86 Linux systems, as the URL we test against is CPU and OS specific.
-if (System.getProperty("os.name").equalsIgnoreCase("Linux")) {
-  if (System.getProperty("os.arch").equalsIgnoreCase("amd64")) {
-    println("This system is Linux and x86_64, running this test case...")
-    return true
-  } else {
-    println("Skipping this test case as the system is not x86_64")
-    return false
-  }
-} else {
+if (!System.getProperty("os.arch").equalsIgnoreCase("amd64")) {
+  println("Skipping this test case as the system is not x86_64")
+  return false
+} else if (!System.getProperty("os.name").equalsIgnoreCase("Linux")) {
   println("Not running this test as this is not a Linux system...")
   return false
+} else if ("uname -o".execute().text =~ /Android.*/) {
+  println("Skipping test as it uses incompatible binaries for Android")
+  return false
+} else {
+  return true
 }

--- a/protobuf-maven-plugin/src/it/http-url-protoc/selector.groovy
+++ b/protobuf-maven-plugin/src/it/http-url-protoc/selector.groovy
@@ -15,7 +15,7 @@
  */
 
 // Only execute on x86 Linux systems, as the URL we test against is CPU and OS specific.
-if (System.getProperty("os.arch").equalsIgnoreCase("amd64")) {
+if (!System.getProperty("os.arch").equalsIgnoreCase("amd64")) {
   println("Skipping this test case as the system is not x86_64")
   return false
 } else if (!System.getProperty("os.name").equalsIgnoreCase("Linux")) {

--- a/protobuf-maven-plugin/src/it/http-url-protoc/selector.groovy
+++ b/protobuf-maven-plugin/src/it/http-url-protoc/selector.groovy
@@ -15,15 +15,15 @@
  */
 
 // Only execute on x86 Linux systems, as the URL we test against is CPU and OS specific.
-if (System.getProperty("os.name").equalsIgnoreCase("Linux")) {
-  if (System.getProperty("os.arch").equalsIgnoreCase("amd64")) {
-    println("This system is Linux and x86_64, running this test case...")
-    return true
-  } else {
-    println("Skipping this test case as the system is not x86_64")
-    return false
-  }
-} else {
+if (System.getProperty("os.arch").equalsIgnoreCase("amd64")) {
+  println("Skipping this test case as the system is not x86_64")
+  return false
+} else if (!System.getProperty("os.name").equalsIgnoreCase("Linux")) {
   println("Not running this test as this is not a Linux system...")
   return false
+} else if ("uname -o".execute().text =~ /Android.*/) {
+  println("Skipping test as it uses incompatible binaries for Android")
+  return false
+} else {
+  return true
 }

--- a/protobuf-maven-plugin/src/it/java-main-empty/selector.groovy
+++ b/protobuf-maven-plugin/src/it/java-main-empty/selector.groovy
@@ -13,20 +13,3 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-// Only execute this test if the user has protoc installed on their
-// PATH and it is successfully executable.
-try {
-  println("Checking if protoc is on the system path...")
-  int exitCode = "protoc --version".execute().waitFor()
-
-  if (exitCode == 0) {
-    return true
-  } else {
-    println("Skipping this test: protoc system binary exited with code ${exitCode}")
-    return false
-  }
-} catch (IOException ex) {
-  println("Skipping this test. ${ex.getClass().getName()}: ${ex.getMessage()}")
-  return false
-}

--- a/protobuf-maven-plugin/src/it/java-main-lite/selector.groovy
+++ b/protobuf-maven-plugin/src/it/java-main-lite/selector.groovy
@@ -13,20 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-// Only execute this test if the user has protoc installed on their
-// PATH and it is successfully executable.
-try {
-  println("Checking if protoc is on the system path...")
-  int exitCode = "protoc --version".execute().waitFor()
-
-  if (exitCode == 0) {
-    return true
-  } else {
-    println("Skipping this test: protoc system binary exited with code ${exitCode}")
-    return false
-  }
-} catch (IOException ex) {
-  println("Skipping this test. ${ex.getClass().getName()}: ${ex.getMessage()}")
+if ("uname -o".execute().text =~ /Android.*/) {
+  println("Skipping test as it uses incompatible binaries for Android")
   return false
+} else {
+  return true
 }

--- a/protobuf-maven-plugin/src/it/java-main/selector.groovy
+++ b/protobuf-maven-plugin/src/it/java-main/selector.groovy
@@ -13,20 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-// Only execute this test if the user has protoc installed on their
-// PATH and it is successfully executable.
-try {
-  println("Checking if protoc is on the system path...")
-  int exitCode = "protoc --version".execute().waitFor()
-
-  if (exitCode == 0) {
-    return true
-  } else {
-    println("Skipping this test: protoc system binary exited with code ${exitCode}")
-    return false
-  }
-} catch (IOException ex) {
-  println("Skipping this test. ${ex.getClass().getName()}: ${ex.getMessage()}")
+if ("uname -o".execute().text =~ /Android.*/) {
+  println("Skipping test as it uses incompatible binaries for Android")
   return false
+} else {
+  return true
 }

--- a/protobuf-maven-plugin/src/it/java-paths/selector.groovy
+++ b/protobuf-maven-plugin/src/it/java-paths/selector.groovy
@@ -13,20 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-// Only execute this test if the user has protoc installed on their
-// PATH and it is successfully executable.
-try {
-  println("Checking if protoc is on the system path...")
-  int exitCode = "protoc --version".execute().waitFor()
-
-  if (exitCode == 0) {
-    return true
-  } else {
-    println("Skipping this test: protoc system binary exited with code ${exitCode}")
-    return false
-  }
-} catch (IOException ex) {
-  println("Skipping this test. ${ex.getClass().getName()}: ${ex.getMessage()}")
+if ("uname -o".execute().text =~ /Android.*/) {
+  println("Skipping test as it uses incompatible binaries for Android")
   return false
+} else {
+  return true
 }

--- a/protobuf-maven-plugin/src/it/java-test-lite/selector.groovy
+++ b/protobuf-maven-plugin/src/it/java-test-lite/selector.groovy
@@ -13,20 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-// Only execute this test if the user has protoc installed on their
-// PATH and it is successfully executable.
-try {
-  println("Checking if protoc is on the system path...")
-  int exitCode = "protoc --version".execute().waitFor()
-
-  if (exitCode == 0) {
-    return true
-  } else {
-    println("Skipping this test: protoc system binary exited with code ${exitCode}")
-    return false
-  }
-} catch (IOException ex) {
-  println("Skipping this test. ${ex.getClass().getName()}: ${ex.getMessage()}")
+if ("uname -o".execute().text =~ /Android.*/) {
+  println("Skipping test as it uses incompatible binaries for Android")
   return false
+} else {
+  return true
 }

--- a/protobuf-maven-plugin/src/it/java-test/selector.groovy
+++ b/protobuf-maven-plugin/src/it/java-test/selector.groovy
@@ -13,20 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-// Only execute this test if the user has protoc installed on their
-// PATH and it is successfully executable.
-try {
-  println("Checking if protoc is on the system path...")
-  int exitCode = "protoc --version".execute().waitFor()
-
-  if (exitCode == 0) {
-    return true
-  } else {
-    println("Skipping this test: protoc system binary exited with code ${exitCode}")
-    return false
-  }
-} catch (IOException ex) {
-  println("Skipping this test. ${ex.getClass().getName()}: ${ex.getMessage()}")
+if ("uname -o".execute().text =~ /Android.*/) {
+  println("Skipping test as it uses incompatible binaries for Android")
   return false
+} else {
+  return true
 }

--- a/protobuf-maven-plugin/src/it/kotlin-main/selector.groovy
+++ b/protobuf-maven-plugin/src/it/kotlin-main/selector.groovy
@@ -13,20 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-// Only execute this test if the user has protoc installed on their
-// PATH and it is successfully executable.
-try {
-  println("Checking if protoc is on the system path...")
-  int exitCode = "protoc --version".execute().waitFor()
-
-  if (exitCode == 0) {
-    return true
-  } else {
-    println("Skipping this test: protoc system binary exited with code ${exitCode}")
-    return false
-  }
-} catch (IOException ex) {
-  println("Skipping this test. ${ex.getClass().getName()}: ${ex.getMessage()}")
+if ("uname -o".execute().text =~ /Android.*/) {
+  println("Skipping test as it uses incompatible binaries for Android")
   return false
+} else {
+  return true
 }

--- a/protobuf-maven-plugin/src/it/kotlin-test/selector.groovy
+++ b/protobuf-maven-plugin/src/it/kotlin-test/selector.groovy
@@ -13,20 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-// Only execute this test if the user has protoc installed on their
-// PATH and it is successfully executable.
-try {
-  println("Checking if protoc is on the system path...")
-  int exitCode = "protoc --version".execute().waitFor()
-
-  if (exitCode == 0) {
-    return true
-  } else {
-    println("Skipping this test: protoc system binary exited with code ${exitCode}")
-    return false
-  }
-} catch (IOException ex) {
-  println("Skipping this test. ${ex.getClass().getName()}: ${ex.getMessage()}")
+if ("uname -o".execute().text =~ /Android.*/) {
+  println("Skipping test as it uses incompatible binaries for Android")
   return false
+} else {
+  return true
 }

--- a/protobuf-maven-plugin/src/it/maven-dependency-protopath/selector.groovy
+++ b/protobuf-maven-plugin/src/it/maven-dependency-protopath/selector.groovy
@@ -13,20 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-// Only execute this test if the user has protoc installed on their
-// PATH and it is successfully executable.
-try {
-  println("Checking if protoc is on the system path...")
-  int exitCode = "protoc --version".execute().waitFor()
-
-  if (exitCode == 0) {
-    return true
-  } else {
-    println("Skipping this test: protoc system binary exited with code ${exitCode}")
-    return false
-  }
-} catch (IOException ex) {
-  println("Skipping this test. ${ex.getClass().getName()}: ${ex.getMessage()}")
+if ("uname -o".execute().text =~ /Android.*/) {
+  println("Skipping test as it uses incompatible binaries for Android")
   return false
+} else {
+  return true
 }

--- a/protobuf-maven-plugin/src/it/reactor-grpc-binary-plugin/selector.groovy
+++ b/protobuf-maven-plugin/src/it/reactor-grpc-binary-plugin/selector.groovy
@@ -13,4 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-return ["x86_64", "amd64", "aarch64"].contains(System.getProperty("os.arch"))
+
+if (!["x86_64", "amd64", "aarch64"].contains(System.getProperty("os.arch"))) {
+  println("Skipping this test case as the system is not AMD64 or AARCH64")
+  return false
+} else if ("uname -o".execute().text =~ /Android.*/) {
+  println("Skipping test as it uses incompatible binaries for Android")
+  return false
+} else {
+  return true
+}

--- a/protobuf-maven-plugin/src/it/reactor-grpc-jvm-plugin/selector.groovy
+++ b/protobuf-maven-plugin/src/it/reactor-grpc-jvm-plugin/selector.groovy
@@ -13,20 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-// Only execute this test if the user has protoc installed on their
-// PATH and it is successfully executable.
-try {
-  println("Checking if protoc is on the system path...")
-  int exitCode = "protoc --version".execute().waitFor()
-
-  if (exitCode == 0) {
-    return true
-  } else {
-    println("Skipping this test: protoc system binary exited with code ${exitCode}")
-    return false
-  }
-} catch (IOException ex) {
-  println("Skipping this test. ${ex.getClass().getName()}: ${ex.getMessage()}")
+if ("uname -o".execute().text =~ /Android.*/) {
+  println("Skipping test as it uses incompatible binaries for Android")
   return false
+} else {
+  return true
 }

--- a/protobuf-maven-plugin/src/it/scalapb-plugin/selector.groovy
+++ b/protobuf-maven-plugin/src/it/scalapb-plugin/selector.groovy
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 // Only execute on x86 Linux systems, as the URL we test against is CPU and OS specific.
-if (System.getProperty("os.name").equalsIgnoreCase("Linux")) {
-	if (System.getProperty("os.arch").equalsIgnoreCase("amd64")) {
-		println("This system is Linux and x86_64, running this test case...")
-		return true
-	} else {
-		println("Skipping this test case as the system is not x86_64")
-		return false
-	}
+if (!System.getProperty("os.arch").equalsIgnoreCase("amd64")) {
+  println("Skipping this test case as the system is not x86_64")
+  return false
+} else if (!System.getProperty("os.name").equalsIgnoreCase("Linux")) {
+  println("Not running this test as this is not a Linux system...")
+  return false
+} else if ("uname -o".execute().text =~ /Android.*/) {
+  println("Skipping test as it uses incompatible binaries for Android")
+  return false
 } else {
-	println("Not running this test as this is not a Linux system...")
-	return false
+  return true
 }


### PR DESCRIPTION
Detect if tests are running on Android and skip them as appropriate.