### PR TITLE
Reenable protobuf path tests in CI for MacOS and Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,30 +31,9 @@ jobs:
           distribution: 'temurin'
           cache: maven
 
-      # Install protoc onto the PATH so that we can test PATH resolution.
-      - name: Install dependencies
+      - name: Install protoc to $PATH
         shell: bash
-        run: |-
-          set -eux
-          case "${{ matrix.os-name }}" in
-            macos-*)
-              # Re-enable once brew updates to protoc 26.1 or newer.
-              #brew install protobuf
-              #protoc --version
-              ;;
-            ubuntu-*)
-              sudo apt update -q
-              sudo apt install protobuf-compiler -qy
-              ;;
-            windows-*)
-              #choco install protoc
-              #protoc --version
-              ;;
-          esac
-
-          java -version
-          javac -version
-          ./mvnw --version
+        run: scripts/install-protoc-to-github-runner.sh
 
       - name: Build and test
         shell: bash
@@ -93,8 +72,13 @@ jobs:
         run: |-
           # Use -T1 here as the plugins emit warnings about thread safety if we use the
           # default concurrency settings for the project.
+          set -eux
           version=3.8.2
           ./mvnw -T1 -B wrapper:wrapper -Dmaven="${version}"
+
+      - name: Install protoc to $PATH
+        shell: bash
+        run: scripts/install-protoc-to-github-runner.sh
 
       - name: Build and test
         shell: bash

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,12 +52,8 @@ jobs:
           git config user.name '${{ github.actor }}'
           git config user.email '${{ github.actor }}@users.noreply.github.com'
 
-      - name: Install dependencies
-        run: |-
-          # Install protoc so those integration tests also run. This increases the reported
-          # coverage on the generated site to a more accurate value.
-          sudo apt update -q
-          sudo apt install protobuf-compiler -qy
+      - name: Install protoc to $PATH
+        run: scripts/install-protoc-to-github-runner.sh
 
       - name: Determine release version details
         run: |-

--- a/protobuf-maven-plugin/src/it/path-protoc/pom.xml
+++ b/protobuf-maven-plugin/src/it/path-protoc/pom.xml
@@ -32,7 +32,7 @@
   <artifactId>path-protoc</artifactId>
 
   <properties>
-    <protobuf.version>3.25.0</protobuf.version>
+    <protobuf.version>4.27.2</protobuf.version>
   </properties>
 
   <dependencies>

--- a/protobuf-maven-plugin/src/it/path-protoc/src/test/java/org/example/helloworld/ProtobufTest.java
+++ b/protobuf-maven-plugin/src/it/path-protoc/src/test/java/org/example/helloworld/ProtobufTest.java
@@ -37,7 +37,7 @@ class ProtobufTest {
     } while (superClass != null);
 
     // Then
-    assertTrue(superClasses.contains("com.google.protobuf.GeneratedMessageV3"));
+    assertTrue(superClasses.contains("com.google.protobuf.GeneratedMessage"));
   }
 
   @Test

--- a/scripts/bump-versions.sh
+++ b/scripts/bump-versions.sh
@@ -2,10 +2,10 @@
 ###
 ### Update the project version based upon criteria.
 ###
-
+### Author: Ashley Scopes
+###
 set -o errexit
 set -o nounset
-
 [[ -n ${DEBUG+undef} ]] && set -o xtrace
 
 function usage() {

--- a/scripts/close-nexus-repos.sh
+++ b/scripts/close-nexus-repos.sh
@@ -1,20 +1,4 @@
 #!/usr/bin/env bash
-#
-# Copyright (C) 2023 - 2024, ascopes
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
 ###
 ### Script that helps automate Nexus auto-staging promotion without using the
 ### Nexus Maven Plugin which will break when we exclude the acceptance tests from
@@ -35,14 +19,10 @@
 ### Note: this targets Sonatype Nexus Manager v2.x, not v3.x.
 ###
 ### Author: ascopes
-
-
+###
 set -o errexit
 set -o nounset
-
-if [[ -n ${DEBUG+undef} ]]; then
-  set -o xtrace
-fi
+[[ -n ${DEBUG+undef} ]] && set -o xtrace
 
 function usage() {
   echo "USAGE: ${BASH_SOURCE[0]} [-h] -a <artifactId> -g <groupId> -v <version> -u <userName> -p <password> -s <server>"

--- a/scripts/install-protoc-to-github-runner.sh
+++ b/scripts/install-protoc-to-github-runner.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+###
+### Script used during CI to install protoc onto GitHub runners.
+###
+### Users should avoid running this on their machines.
+###
+### Author: Ashley Scopes
+###
+set -o errexit
+set -o nounset
+[[ -n ${DEBUG+undef} ]] && set -o xtrace
+
+readonly version=4.27.2
+
+case "$(uname)" in
+  Linux)
+    readonly os_name=linux
+    ;;
+  Darwin)
+    readonly os_name=osx
+    ;;
+  *)
+    readonly os_name=windows
+    ;;
+esac
+
+readonly url="https://repo1.maven.org/maven2/com/google/protobuf/protoc/${version}/protoc-${version}-${os_name}-x86_64.exe"
+# shellcheck disable=SC2155
+readonly target_dir=$(mktemp -d)
+readonly target="${target_dir}/protoc"
+echo "${target_dir}" >> "${GITHUB_PATH}"
+export PATH="${PATH}:${target_dir}"
+
+echo "Installing ${url} to ${target}"
+curl --fail "${url}" -o "${target}"
+chmod -v 777 "${target}"
+
+if [[ "$(command -v protoc)" = "${target}" ]]; then
+  echo "Installation successful"
+  protoc --version
+else
+  echo -n "Failed to add protoc to path, path entry points to: "
+  command -v protoc
+  exit 2
+fi

--- a/scripts/site-local.sh
+++ b/scripts/site-local.sh
@@ -2,7 +2,8 @@
 ###
 ### Runs a web server hosting the generated site locally.
 ###
-
+### Author: Ashley Scopes
+###
 set -o errexit
 set -o xtrace
 


### PR DESCRIPTION
Use a consistent version of protoc when running path tests in CI which can also cover MacOS and Windows runners.

Bump path protoc test version of protobuf-java to v4.27.2 from v3.25.x