### PR TITLE
Do not treat backslashes in batch scripts as special characters

### DIFF
--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/utils/Shlex.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/utils/Shlex.java
@@ -128,7 +128,6 @@ public final class Shlex {
         case '%':
           sb.append("%%");
           break;
-        case '\\':
         case '"':
         case '\'':
         case ' ':

--- a/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/utils/ShlexTest.java
+++ b/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/utils/ShlexTest.java
@@ -106,7 +106,7 @@ class ShlexTest {
         arguments(list("/usr/bin/env", "protoc"), "/usr/bin/env protoc"),
         arguments(list("foo bar", "baz"), "foo^ bar baz"),
         arguments(list("foo bar", "baz", "bork qux"), "foo^ bar baz bork^ qux"),
-        arguments(list("foo\\bar", "baz"), "foo^\\bar baz"),
+        arguments(list("foo\\bar", "baz"), "foo\\bar baz"),
         arguments(list("ABCDEFGHIJKLMNOPQRSTUVWXYZ"), "ABCDEFGHIJKLMNOPQRSTUVWXYZ"),
         arguments(list("abcdefghijklmnopqrstuvwxyz"), "abcdefghijklmnopqrstuvwxyz"),
         arguments(list("0123456789"), "0123456789"),
@@ -114,7 +114,7 @@ class ShlexTest {
         arguments(list("."), "."),
         arguments(list("/"), "/"),
         arguments(list("="), "="),
-        arguments(list("\\"), "^\\"),
+        arguments(list("\\"), "\\"),  // Don't expect this one to be escaped
         arguments(list("\""), "^\""),
         arguments(list("'"), "^'"),
         arguments(list(" "), "^ "),


### PR DESCRIPTION
This appears to be unnecessary and results in noisy command line strings when running on Windows. 