### PR TITLE
GH-302: Fix import scope not being respected

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>io.github.ascopes</groupId>
   <artifactId>protobuf-maven-plugin-parent</artifactId>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.4.0-SNAPSHOT</version>
 
   <name>Protobuf Maven Plugin Parent</name>
   <description>Parent POM for the Protobuf Maven Plugin.</description>

--- a/protobuf-maven-plugin/pom.xml
+++ b/protobuf-maven-plugin/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes</groupId>
     <artifactId>protobuf-maven-plugin-parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>protobuf-maven-plugin</artifactId>

--- a/protobuf-maven-plugin/src/it/gh-302-runtime-scope-direct-resolution/invoker.properties
+++ b/protobuf-maven-plugin/src/it/gh-302-runtime-scope-direct-resolution/invoker.properties
@@ -1,0 +1,17 @@
+#
+# Copyright (C) 2023 - 2024, Ashley Scopes.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+invoker.goals = clean package

--- a/protobuf-maven-plugin/src/it/gh-302-runtime-scope-direct-resolution/pom.xml
+++ b/protobuf-maven-plugin/src/it/gh-302-runtime-scope-direct-resolution/pom.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2023 - 2024, Ashley Scopes.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>@project.groupId@</groupId>
+    <artifactId>protobuf-maven-plugin-parent</artifactId>
+    <version>@project.version@</version>
+    <relativePath>../../../../pom.xml</relativePath>
+  </parent>
+
+  <groupId>gh-302-runtime-scope-direct-resolution</groupId>
+  <artifactId>parent</artifactId>
+  <packaging>pom</packaging>
+
+  <modules>
+    <!-- Order is important in this test. -->
+    <module>runtime-dependency</module>
+    <module>project</module>
+  </modules>
+
+  <properties>
+    <protobuf.version>4.27.2</protobuf.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-java</artifactId>
+        <version>${protobuf.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+        </plugin>
+
+        <plugin>
+          <groupId>@project.groupId@</groupId>
+          <artifactId>@project.artifactId@</artifactId>
+          <version>@project.version@</version>
+
+          <configuration>
+            <embedSourcesInClassOutputs>true</embedSourcesInClassOutputs>
+            <protocVersion>${protobuf.version}</protocVersion>
+          </configuration>
+
+          <executions>
+            <execution>
+              <goals>
+                <goal>generate</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>

--- a/protobuf-maven-plugin/src/it/gh-302-runtime-scope-direct-resolution/project/pom.xml
+++ b/protobuf-maven-plugin/src/it/gh-302-runtime-scope-direct-resolution/project/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2023 - 2024, Ashley Scopes.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>gh-302-runtime-scope-direct-resolution</groupId>
+    <artifactId>parent</artifactId>
+    <version>@project.version@</version>
+  </parent>
+
+  <artifactId>project</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>gh-302-runtime-scope-direct-resolution</groupId>
+      <artifactId>runtime-dependency</artifactId>
+      <version>${project.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/protobuf-maven-plugin/src/it/gh-302-runtime-scope-direct-resolution/project/src/main/protobuf/org/example/compiler/compiler.proto
+++ b/protobuf-maven-plugin/src/it/gh-302-runtime-scope-direct-resolution/project/src/main/protobuf/org/example/compiler/compiler.proto
@@ -1,0 +1,28 @@
+//
+// Copyright (C) 2023 - 2024, Ashley Scopes.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_outer_classname = "CompilerProtos";
+option java_package = "org.example.compiler";
+
+package org.example.compiler;
+
+message Compiler {
+  string name = 1;
+  string version = 2;
+}

--- a/protobuf-maven-plugin/src/it/gh-302-runtime-scope-direct-resolution/runtime-dependency/pom.xml
+++ b/protobuf-maven-plugin/src/it/gh-302-runtime-scope-direct-resolution/runtime-dependency/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2023 - 2024, Ashley Scopes.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>gh-302-runtime-scope-direct-resolution</groupId>
+    <artifactId>parent</artifactId>
+    <version>@project.version@</version>
+  </parent>
+
+  <artifactId>runtime-dependency</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/protobuf-maven-plugin/src/it/gh-302-runtime-scope-direct-resolution/runtime-dependency/src/main/protobuf/org/example/runtime/runtime.proto
+++ b/protobuf-maven-plugin/src/it/gh-302-runtime-scope-direct-resolution/runtime-dependency/src/main/protobuf/org/example/runtime/runtime.proto
@@ -1,0 +1,28 @@
+//
+// Copyright (C) 2023 - 2024, Ashley Scopes.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_outer_classname = "RuntimeProtos";
+option java_package = "org.example.runtime";
+
+package org.example.runtime;
+
+message Runtime {
+  string name = 1;
+  string version = 2;
+}

--- a/protobuf-maven-plugin/src/it/gh-302-runtime-scope-direct-resolution/selector.groovy
+++ b/protobuf-maven-plugin/src/it/gh-302-runtime-scope-direct-resolution/selector.groovy
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2023 - 2024, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+if ("uname -o".execute().text =~ /Android.*/) {
+  println("Skipping test as it uses incompatible binaries for Android")
+  return false
+} else {
+  return true
+}

--- a/protobuf-maven-plugin/src/it/gh-302-runtime-scope-direct-resolution/test.groovy
+++ b/protobuf-maven-plugin/src/it/gh-302-runtime-scope-direct-resolution/test.groovy
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2023 - 2024, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+import static org.assertj.core.api.Assertions.assertThat
+
+static Path resolve(Path path, String... bits) {
+  for (String bit : bits) {
+    path = path.resolve(bit)
+  }
+  return path
+}
+
+Path baseDirectory = basedir.toPath().toAbsolutePath()
+Path runtimeDependencyTargetDir = resolve(baseDirectory,"runtime-dependency", "target")
+Path projectTargetDir = resolve(baseDirectory, "project", "target")
+
+/////////////////////////////////////////////////////////
+// `transitive-runtime-dependency' output expectations //
+/////////////////////////////////////////////////////////
+
+assertThat(runtimeDependencyTargetDir).isDirectory()
+assertThat(resolve(runtimeDependencyTargetDir,"classes", "org", "example", "runtime", "Runtime.class"))
+    .isRegularFile()
+assertThat(resolve(runtimeDependencyTargetDir,"classes", "org", "example", "runtime", "runtime.proto"))
+    .isRegularFile()
+
+// Compile dependencies are included in the archives directory.
+assertThat(Files.list(resolve(runtimeDependencyTargetDir, "protobuf-maven-plugin", "archives")))
+    .withFailMessage { "Expected protobuf-java-* directory to be present" }
+    .filteredOn { it.getFileName().toString().startsWith("protobuf-java-") }
+    .hasSize(1)
+
+///////////////////////////////////
+// `project' output expectations //
+///////////////////////////////////
+
+assertThat(projectTargetDir).isDirectory()
+assertThat(resolve(projectTargetDir,"classes", "org", "example", "compiler", "Compiler.class"))
+    .isRegularFile()
+assertThat(resolve(projectTargetDir,"classes", "org", "example", "compiler", "compiler.proto"))
+    .isRegularFile()
+
+// Compile dependencies are included in the archives directory.
+assertThat(Files.list(resolve(projectTargetDir,"protobuf-maven-plugin", "archives")))
+    .filteredOn { it.getFileName().toString().startsWith("protobuf-java-") }
+    .isNotEmpty()
+
+// Transitive runtime dependencies are not included in the archives directory.
+assertThat(Files.list(resolve(projectTargetDir,"protobuf-maven-plugin", "archives")))
+    .withFailMessage {
+      "Expected runtime-dependency-* directory to not be present, this means " +
+          "direct runtime dependencies are being included erroneously!"
+    }
+    .filteredOn { it.getFileName().toString().startsWith("runtime-dependency-") }
+    .isEmpty()
+
+return true

--- a/protobuf-maven-plugin/src/it/gh-302-runtime-scope-transitive-resolution/dependency/pom.xml
+++ b/protobuf-maven-plugin/src/it/gh-302-runtime-scope-transitive-resolution/dependency/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2023 - 2024, Ashley Scopes.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>gh-302-runtime-scope-transitive-resolution</groupId>
+    <artifactId>parent</artifactId>
+    <version>@project.version@</version>
+  </parent>
+
+  <artifactId>dependency</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>gh-302-runtime-scope-transitive-resolution</groupId>
+      <artifactId>transitive-runtime-dependency</artifactId>
+      <version>${project.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/protobuf-maven-plugin/src/it/gh-302-runtime-scope-transitive-resolution/invoker.properties
+++ b/protobuf-maven-plugin/src/it/gh-302-runtime-scope-transitive-resolution/invoker.properties
@@ -1,0 +1,17 @@
+#
+# Copyright (C) 2023 - 2024, Ashley Scopes.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+invoker.goals = clean package

--- a/protobuf-maven-plugin/src/it/gh-302-runtime-scope-transitive-resolution/pom.xml
+++ b/protobuf-maven-plugin/src/it/gh-302-runtime-scope-transitive-resolution/pom.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2023 - 2024, Ashley Scopes.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>@project.groupId@</groupId>
+    <artifactId>protobuf-maven-plugin-parent</artifactId>
+    <version>@project.version@</version>
+    <relativePath>../../../../pom.xml</relativePath>
+  </parent>
+
+  <groupId>gh-302-runtime-scope-transitive-resolution</groupId>
+  <artifactId>parent</artifactId>
+  <packaging>pom</packaging>
+
+  <modules>
+    <!-- Order is important in this test. -->
+    <module>transitive-runtime-dependency</module>
+    <module>dependency</module>
+    <module>project</module>
+  </modules>
+
+  <properties>
+    <protobuf.version>4.27.2</protobuf.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-java</artifactId>
+        <version>${protobuf.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+        </plugin>
+
+        <plugin>
+          <groupId>@project.groupId@</groupId>
+          <artifactId>@project.artifactId@</artifactId>
+          <version>@project.version@</version>
+
+          <configuration>
+            <embedSourcesInClassOutputs>true</embedSourcesInClassOutputs>
+            <protocVersion>${protobuf.version}</protocVersion>
+          </configuration>
+
+          <executions>
+            <execution>
+              <goals>
+                <goal>generate</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>

--- a/protobuf-maven-plugin/src/it/gh-302-runtime-scope-transitive-resolution/project/pom.xml
+++ b/protobuf-maven-plugin/src/it/gh-302-runtime-scope-transitive-resolution/project/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2023 - 2024, Ashley Scopes.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>gh-302-runtime-scope-transitive-resolution</groupId>
+    <artifactId>parent</artifactId>
+    <version>@project.version@</version>
+  </parent>
+
+  <artifactId>project</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>gh-302-runtime-scope-transitive-resolution</groupId>
+      <artifactId>dependency</artifactId>
+      <version>${project.version}</version>
+      <scope>compile</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/protobuf-maven-plugin/src/it/gh-302-runtime-scope-transitive-resolution/project/src/main/protobuf/org/example/compiler/compiler.proto
+++ b/protobuf-maven-plugin/src/it/gh-302-runtime-scope-transitive-resolution/project/src/main/protobuf/org/example/compiler/compiler.proto
@@ -1,0 +1,28 @@
+//
+// Copyright (C) 2023 - 2024, Ashley Scopes.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_outer_classname = "CompilerProtos";
+option java_package = "org.example.compiler";
+
+package org.example.compiler;
+
+message Compiler {
+  string name = 1;
+  string version = 2;
+}

--- a/protobuf-maven-plugin/src/it/gh-302-runtime-scope-transitive-resolution/selector.groovy
+++ b/protobuf-maven-plugin/src/it/gh-302-runtime-scope-transitive-resolution/selector.groovy
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2023 - 2024, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+if ("uname -o".execute().text =~ /Android.*/) {
+  println("Skipping test as it uses incompatible binaries for Android")
+  return false
+} else {
+  return true
+}

--- a/protobuf-maven-plugin/src/it/gh-302-runtime-scope-transitive-resolution/test.groovy
+++ b/protobuf-maven-plugin/src/it/gh-302-runtime-scope-transitive-resolution/test.groovy
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2023 - 2024, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+import static org.assertj.core.api.Assertions.assertThat
+
+static Path resolve(Path path, String... bits) {
+  for (String bit : bits) {
+    path = path.resolve(bit)
+  }
+  return path
+}
+
+Path baseDirectory = basedir.toPath().toAbsolutePath()
+Path transitiveRuntimeDependencyTargetDir = resolve(baseDirectory,"transitive-runtime-dependency", "target")
+Path projectTargetDir = resolve(baseDirectory, "project", "target")
+
+/////////////////////////////////////////////////////////
+// `transitive-runtime-dependency' output expectations //
+/////////////////////////////////////////////////////////
+
+assertThat(transitiveRuntimeDependencyTargetDir).isDirectory()
+assertThat(resolve(transitiveRuntimeDependencyTargetDir, "classes", "org", "example", "runtime", "Runtime.class"))
+    .isRegularFile()
+assertThat(resolve(transitiveRuntimeDependencyTargetDir, "classes", "org", "example", "runtime", "runtime.proto"))
+    .isRegularFile()
+
+// Compile dependencies are included in the archives directory.
+assertThat(Files.list(resolve(transitiveRuntimeDependencyTargetDir, "protobuf-maven-plugin", "archives")))
+    .withFailMessage { "Expected protobuf-java-* directory to be present" }
+    .filteredOn { it.getFileName().toString().startsWith("protobuf-java-") }
+    .hasSize(1)
+
+///////////////////////////////////
+// `project' output expectations //
+///////////////////////////////////
+
+assertThat(projectTargetDir).isDirectory()
+assertThat(resolve(projectTargetDir, "classes", "org", "example", "compiler", "Compiler.class"))
+    .isRegularFile()
+assertThat(resolve(projectTargetDir, "classes", "org", "example", "compiler", "compiler.proto"))
+    .isRegularFile()
+
+// Compile dependencies are included in the archives directory.
+assertThat(Files.list(resolve(projectTargetDir, "protobuf-maven-plugin", "archives")))
+    .filteredOn { it.getFileName().toString().startsWith("protobuf-java-") }
+    .isNotEmpty()
+
+// Transitive runtime dependencies are not included in the archives directory.
+assertThat(Files.list(resolve(projectTargetDir, "protobuf-maven-plugin", "archives")))
+    .withFailMessage {
+      "Expected transitive-runtime-dependency-* directory to not be present, this means " +
+          "transitive runtime dependencies are being included erroneously!"
+    }
+    .filteredOn { it.getFileName().toString().startsWith("transitive-runtime-dependency-") }
+    .isEmpty()
+
+return true

--- a/protobuf-maven-plugin/src/it/gh-302-runtime-scope-transitive-resolution/transitive-runtime-dependency/pom.xml
+++ b/protobuf-maven-plugin/src/it/gh-302-runtime-scope-transitive-resolution/transitive-runtime-dependency/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2023 - 2024, Ashley Scopes.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>gh-302-runtime-scope-transitive-resolution</groupId>
+    <artifactId>parent</artifactId>
+    <version>@project.version@</version>
+  </parent>
+
+  <artifactId>transitive-runtime-dependency</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/protobuf-maven-plugin/src/it/gh-302-runtime-scope-transitive-resolution/transitive-runtime-dependency/src/main/protobuf/org/example/runtime/runtime.proto
+++ b/protobuf-maven-plugin/src/it/gh-302-runtime-scope-transitive-resolution/transitive-runtime-dependency/src/main/protobuf/org/example/runtime/runtime.proto
@@ -1,0 +1,28 @@
+//
+// Copyright (C) 2023 - 2024, Ashley Scopes.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_outer_classname = "RuntimeProtos";
+option java_package = "org.example.runtime";
+
+package org.example.runtime;
+
+message Runtime {
+  string name = 1;
+  string version = 2;
+}

--- a/protobuf-maven-plugin/src/it/test-dependency-resolution/invoker.properties
+++ b/protobuf-maven-plugin/src/it/test-dependency-resolution/invoker.properties
@@ -1,0 +1,17 @@
+#
+# Copyright (C) 2023 - 2024, Ashley Scopes.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+invoker.goals = clean package

--- a/protobuf-maven-plugin/src/it/test-dependency-resolution/main-project/pom.xml
+++ b/protobuf-maven-plugin/src/it/test-dependency-resolution/main-project/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2023 - 2024, Ashley Scopes.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>test-dependency-resolution</groupId>
+    <artifactId>parent</artifactId>
+    <version>@project.version@</version>
+  </parent>
+
+  <artifactId>main-project</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>test-dependency-resolution</groupId>
+      <artifactId>test-dependency</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+
+        <executions>
+          <execution>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/protobuf-maven-plugin/src/it/test-dependency-resolution/main-project/src/main/protobuf/org/example/compiler/compiler.proto
+++ b/protobuf-maven-plugin/src/it/test-dependency-resolution/main-project/src/main/protobuf/org/example/compiler/compiler.proto
@@ -1,0 +1,27 @@
+//
+// Copyright (C) 2023 - 2024, Ashley Scopes.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "org.example.compiler";
+
+package org.example.compiler;
+
+message Compiler {
+  string name = 1;
+  string version = 2;
+}

--- a/protobuf-maven-plugin/src/it/test-dependency-resolution/pom.xml
+++ b/protobuf-maven-plugin/src/it/test-dependency-resolution/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2023 - 2024, Ashley Scopes.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>@project.groupId@</groupId>
+    <artifactId>protobuf-maven-plugin-parent</artifactId>
+    <version>@project.version@</version>
+    <relativePath>../../../../pom.xml</relativePath>
+  </parent>
+
+  <groupId>test-dependency-resolution</groupId>
+  <artifactId>parent</artifactId>
+  <packaging>pom</packaging>
+
+  <modules>
+    <!-- Order is important in this test. -->
+    <module>test-dependency</module>
+    <module>main-project</module>
+    <module>test-project</module>
+  </modules>
+
+  <properties>
+    <protobuf.version>4.27.2</protobuf.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-java</artifactId>
+        <version>${protobuf.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+        </plugin>
+
+        <plugin>
+          <groupId>@project.groupId@</groupId>
+          <artifactId>@project.artifactId@</artifactId>
+          <version>@project.version@</version>
+
+          <configuration>
+            <embedSourcesInClassOutputs>true</embedSourcesInClassOutputs>
+            <protocVersion>${protobuf.version}</protocVersion>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>

--- a/protobuf-maven-plugin/src/it/test-dependency-resolution/selector.groovy
+++ b/protobuf-maven-plugin/src/it/test-dependency-resolution/selector.groovy
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2023 - 2024, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+if ("uname -o".execute().text =~ /Android.*/) {
+  println("Skipping test as it uses incompatible binaries for Android")
+  return false
+} else {
+  return true
+}

--- a/protobuf-maven-plugin/src/it/test-dependency-resolution/test-dependency/pom.xml
+++ b/protobuf-maven-plugin/src/it/test-dependency-resolution/test-dependency/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2023 - 2024, Ashley Scopes.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>test-dependency-resolution</groupId>
+    <artifactId>parent</artifactId>
+    <version>@project.version@</version>
+  </parent>
+
+  <artifactId>test-dependency</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+
+        <executions>
+          <execution>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/protobuf-maven-plugin/src/it/test-dependency-resolution/test-dependency/src/main/protobuf/org/example/test/test.proto
+++ b/protobuf-maven-plugin/src/it/test-dependency-resolution/test-dependency/src/main/protobuf/org/example/test/test.proto
@@ -1,0 +1,28 @@
+//
+// Copyright (C) 2023 - 2024, Ashley Scopes.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_outer_classname = "TestProtos";
+option java_package = "org.example.test";
+
+package org.example.test;
+
+message TestSuite {
+  string name = 1;
+  string version = 2;
+}

--- a/protobuf-maven-plugin/src/it/test-dependency-resolution/test-project/pom.xml
+++ b/protobuf-maven-plugin/src/it/test-dependency-resolution/test-project/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2023 - 2024, Ashley Scopes.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>test-dependency-resolution</groupId>
+    <artifactId>parent</artifactId>
+    <version>@project.version@</version>
+  </parent>
+
+  <artifactId>test-project</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>test-dependency-resolution</groupId>
+      <artifactId>test-dependency</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+
+        <executions>
+          <execution>
+            <goals>
+              <goal>generate-test</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/protobuf-maven-plugin/src/it/test-dependency-resolution/test-project/src/test/protobuf/org/example/compiler/compiler.proto
+++ b/protobuf-maven-plugin/src/it/test-dependency-resolution/test-project/src/test/protobuf/org/example/compiler/compiler.proto
@@ -1,0 +1,27 @@
+//
+// Copyright (C) 2023 - 2024, Ashley Scopes.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "org.example.compiler";
+
+package org.example.compiler;
+
+message Compiler {
+  string name = 1;
+  string version = 2;
+}

--- a/protobuf-maven-plugin/src/it/test-dependency-resolution/test.groovy
+++ b/protobuf-maven-plugin/src/it/test-dependency-resolution/test.groovy
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2023 - 2024, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+import static org.assertj.core.api.Assertions.assertThat
+
+static Path resolve(Path path, String... bits) {
+  for (String bit : bits) {
+    path = path.resolve(bit)
+  }
+  return path
+}
+
+Path baseDirectory = basedir.toPath().toAbsolutePath()
+Path testDependencyTargetDir = resolve(baseDirectory,"test-dependency", "target")
+Path testProjectTargetDir = resolve(baseDirectory,"test-project", "target")
+Path mainProjectTargetDir = resolve(baseDirectory, "main-project", "target")
+
+///////////////////////////////////////////
+// `test-dependency' output expectations //
+///////////////////////////////////////////
+
+assertThat(testDependencyTargetDir).isDirectory()
+assertThat(resolve(testDependencyTargetDir, "classes", "org", "example", "test", "TestSuite.class"))
+    .isRegularFile()
+assertThat(resolve(testDependencyTargetDir, "classes", "org", "example", "test", "test.proto"))
+    .isRegularFile()
+assertThat(Files.list(resolve(testDependencyTargetDir, "protobuf-maven-plugin", "archives")))
+    .withFailMessage { "Expected protobuf-java-* directory to be present" }
+    .filteredOn { it.getFileName().toString().startsWith("protobuf-java-") }
+    .hasSize(1)
+
+////////////////////////////////////////
+// `test-project' output expectations //
+////////////////////////////////////////
+
+assertThat(testProjectTargetDir).isDirectory()
+assertThat(resolve(testProjectTargetDir,"test-classes", "org", "example", "compiler", "Compiler.class"))
+    .isRegularFile()
+assertThat(resolve(testProjectTargetDir,"test-classes", "org", "example", "compiler", "compiler.proto"))
+    .isRegularFile()
+assertThat(Files.list(resolve(testProjectTargetDir,"protobuf-maven-plugin", "archives")))
+    .withFailMessage { "Expected protobuf-java-* directory to be present" }
+    .filteredOn { it.getFileName().toString().startsWith("protobuf-java-") }
+    .hasSize(1)
+// We should include test sources in the test goal execution.
+assertThat(Files.list(resolve(testProjectTargetDir,"protobuf-maven-plugin", "archives")))
+    .withFailMessage { "Expected test-dependency-* directory to be present" }
+    .filteredOn { it.getFileName().toString().startsWith("test-dependency-") }
+    .hasSize(1)
+
+////////////////////////////////////////
+// `main-project' output expectations //
+////////////////////////////////////////
+
+assertThat(mainProjectTargetDir).isDirectory()
+assertThat(resolve(mainProjectTargetDir,"classes", "org", "example", "compiler", "Compiler.class"))
+    .isRegularFile()
+assertThat(resolve(mainProjectTargetDir,"classes", "org", "example", "compiler", "compiler.proto"))
+    .isRegularFile()
+assertThat(Files.list(resolve(mainProjectTargetDir,"protobuf-maven-plugin", "archives")))
+    .withFailMessage { "Expected protobuf-java-* directory to be present" }
+    .filteredOn { it.getFileName().toString().startsWith("protobuf-java-") }
+    .hasSize(1)
+// We should exclude test sources in the main goal execution.
+assertThat(Files.list(resolve(mainProjectTargetDir,"protobuf-maven-plugin", "archives")))
+    .withFailMessage { "Expected test-dependency-* directory to not be present" }
+    .filteredOn { it.getFileName().toString().startsWith("test-dependency-") }
+    .isEmpty()
+
+return true

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherMavenArtifactPathResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherMavenArtifactPathResolver.java
@@ -25,6 +25,7 @@ import io.github.ascopes.protobufmavenplugin.utils.FileUtils;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -47,6 +48,7 @@ import org.eclipse.aether.resolution.ArtifactResolutionException;
 import org.eclipse.aether.resolution.ArtifactResult;
 import org.eclipse.aether.resolution.DependencyRequest;
 import org.eclipse.aether.resolution.DependencyResolutionException;
+import org.eclipse.aether.util.filter.ScopeDependencyFilter;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -130,6 +132,7 @@ public class AetherMavenArtifactPathResolver {
    *
    * @param artifacts                        the artifacts to resolve.
    * @param defaultDependencyResolutionDepth the project default dependency resolution depth.
+   * @param dependencyScopes                 the allowed dependency scopes to resolve.
    * @param includeProjectDependencies       whether to also resolve project dependencies and return
    *                                         them in the result.
    * @return the paths to each resolved artifact.
@@ -138,6 +141,7 @@ public class AetherMavenArtifactPathResolver {
   public Collection<Path> resolveDependencies(
       Collection<? extends MavenArtifact> artifacts,
       DependencyResolutionDepth defaultDependencyResolutionDepth,
+      Set<String> dependencyScopes,
       boolean includeProjectDependencies
   ) throws ResolutionException {
     try {
@@ -153,8 +157,9 @@ public class AetherMavenArtifactPathResolver {
           dependenciesToResolve
       );
 
+      var scopeFilter = new ScopeDependencyFilter(dependencyScopes, null);
       var collectRequest = new CollectRequest(dependenciesToResolve, null, remoteRepositories);
-      var dependencyRequest = new DependencyRequest(collectRequest, null);
+      var dependencyRequest = new DependencyRequest(collectRequest, scopeFilter);
 
       return repositorySystem.resolveDependencies(repositorySession, dependencyRequest)
           .getArtifactResults()

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherMavenArtifactPathResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherMavenArtifactPathResolver.java
@@ -48,7 +48,6 @@ import org.eclipse.aether.resolution.ArtifactResolutionException;
 import org.eclipse.aether.resolution.ArtifactResult;
 import org.eclipse.aether.resolution.DependencyRequest;
 import org.eclipse.aether.resolution.DependencyResolutionException;
-import org.eclipse.aether.util.filter.ScopeDependencyFilter;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -157,7 +156,7 @@ public class AetherMavenArtifactPathResolver {
           dependenciesToResolve
       );
 
-      var scopeFilter = new ScopeDependencyFilter(dependencyScopes, null);
+      var scopeFilter = new ScopeDependencyFilter(dependencyScopes);
       var collectRequest = new CollectRequest(dependenciesToResolve, null, remoteRepositories);
       var dependencyRequest = new DependencyRequest(collectRequest, scopeFilter);
 

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/ScopeDependencyFilter.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/ScopeDependencyFilter.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2023 - 2024, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.ascopes.protobufmavenplugin.dependencies.aether;
+
+import java.util.List;
+import java.util.Set;
+import org.eclipse.aether.graph.DependencyFilter;
+import org.eclipse.aether.graph.DependencyNode;
+
+/**
+ * Slimmed-down implementation of {@link org.eclipse.aether.util.filter.ScopeDependencyFilter}.
+ *
+ * <p>This is provided as Maven 3.8.x does not include the Eclipse Aether ScopeDependencyFilter
+ * at runtime, whereas Maven 3.9.x and later does.
+ *
+ * <p>TODO: delete this for Maven 4.x and use the Aether implementation instead.
+ *
+ * @author Ashley Scopes
+ * @since 2.4.0
+ */
+final class ScopeDependencyFilter implements DependencyFilter {
+  private final Set<String> includedScopes;
+
+  /**
+   * Initialise this filter.
+   *
+   * @param includedScopes the scopes to allow.
+   */
+  ScopeDependencyFilter(Set<String> includedScopes) {
+    this.includedScopes = includedScopes;
+  }
+
+  @Override
+  public boolean accept(DependencyNode node, List<DependencyNode> parents) {
+    var dependency = node.getDependency();
+    return dependency == null || includedScopes.contains(dependency.getScope());
+  }
+}

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generation/GenerationRequest.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generation/GenerationRequest.java
@@ -24,6 +24,7 @@ import io.github.ascopes.protobufmavenplugin.plugins.UrlProtocPlugin;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 import org.immutables.value.Value.Immutable;
 
 /**
@@ -41,6 +42,8 @@ public interface GenerationRequest {
   Collection<? extends UrlProtocPlugin> getBinaryUrlPlugins();
 
   DependencyResolutionDepth getDependencyResolutionDepth();
+
+  Set<String> getDependencyScopes();
 
   Collection<Language> getEnabledLanguages();
 

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generation/SourceCodeGenerator.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generation/SourceCodeGenerator.java
@@ -184,6 +184,7 @@ public final class SourceCodeGenerator {
     var artifactPaths = artifactPathResolver.resolveDependencies(
         request.getImportDependencies(),
         request.getDependencyResolutionDepth(),
+        request.getDependencyScopes(),
         !request.isIgnoreProjectDependencies()
     );
 
@@ -217,6 +218,7 @@ public final class SourceCodeGenerator {
     var sourceDependencies = artifactPathResolver.resolveDependencies(
         request.getSourceDependencies(),
         request.getDependencyResolutionDepth(),
+        request.getDependencyScopes(),
         false
     );
 

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/AbstractGenerateMojo.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/AbstractGenerateMojo.java
@@ -37,6 +37,7 @@ import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -244,6 +245,15 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    */
   @Parameter(defaultValue = DEFAULT_TRANSITIVE)
   DependencyResolutionDepth dependencyResolutionDepth;
+
+  /**
+   * The dependency scopes to resolve dependencies for.
+   *
+   * @since 2.4.0
+   */
+  @Parameter
+  @Nullable
+  Set<String> dependencyScopes;
 
   /**
    * Set whether to attach all compiled protobuf sources to the output of this
@@ -714,6 +724,13 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
   abstract Path defaultOutputDirectory();
 
   /**
+   * The default dependency scopes used for resolution.
+   *
+   * @return the set of dependency scopes used for resolution.
+   */
+  abstract Set<String> defaultDependencyScopes();
+
+  /**
    * Execute the plugin and generate sources.
    *
    * @throws MojoExecutionException if execution fails.
@@ -744,6 +761,7 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
         .binaryPathPlugins(nonNullList(binaryPathPlugins))
         .binaryUrlPlugins(nonNullList(binaryUrlPlugins))
         .dependencyResolutionDepth(dependencyResolutionDepth)
+        .dependencyScopes(dependencyScopes())
         .enabledLanguages(enabledLanguages)
         .excludes(nonNullList(excludes))
         .jvmMavenPlugins(nonNullList(jvmMavenPlugins))
@@ -773,6 +791,12 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
       mojoFailureException.initCause(ex);
       throw mojoFailureException;
     }
+  }
+
+  private Set<String> dependencyScopes() {
+    return Optional.ofNullable(dependencyScopes)
+        .filter(not(Collection::isEmpty))
+        .orElseGet(this::defaultDependencyScopes);
   }
 
   private Path outputDirectory() {

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/MainGenerateMojo.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/MainGenerateMojo.java
@@ -18,6 +18,7 @@ package io.github.ascopes.protobufmavenplugin.mojo;
 
 import io.github.ascopes.protobufmavenplugin.generation.SourceRootRegistrar;
 import java.nio.file.Path;
+import java.util.Set;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
@@ -49,6 +50,11 @@ public final class MainGenerateMojo extends AbstractGenerateMojo {
   @Override
   SourceRootRegistrar sourceRootRegistrar() {
     return SourceRootRegistrar.MAIN;
+  }
+
+  @Override
+  Set<String> defaultDependencyScopes() {
+    return Set.of("compile", "provided", "system");
   }
 
   @Override

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/TestGenerateMojo.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/TestGenerateMojo.java
@@ -18,6 +18,7 @@ package io.github.ascopes.protobufmavenplugin.mojo;
 
 import io.github.ascopes.protobufmavenplugin.generation.SourceRootRegistrar;
 import java.nio.file.Path;
+import java.util.Set;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
@@ -53,6 +54,11 @@ public final class TestGenerateMojo extends AbstractGenerateMojo {
   @Override
   SourceRootRegistrar sourceRootRegistrar() {
     return SourceRootRegistrar.TEST;
+  }
+
+  @Override
+  Set<String> defaultDependencyScopes() {
+    return Set.of("compile", "provided", "system", "test");
   }
 
   @Override

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/JvmPluginResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/JvmPluginResolver.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 import javax.inject.Inject;
 import javax.inject.Named;
 import org.slf4j.Logger;
@@ -49,6 +50,7 @@ import org.slf4j.LoggerFactory;
 @Named
 public final class JvmPluginResolver {
 
+  private static final Set<String> ALLOWED_SCOPES = Set.of("compile", "runtime", "system");
   private static final Logger log = LoggerFactory.getLogger(BinaryPluginResolver.class);
 
   private final HostSystem hostSystem;
@@ -112,7 +114,12 @@ public final class JvmPluginResolver {
 
     // Resolve dependencies first.
     var dependencyIterator = artifactPathResolver
-        .resolveDependencies(List.of(plugin), DependencyResolutionDepth.TRANSITIVE, false)
+        .resolveDependencies(
+            List.of(plugin),
+            DependencyResolutionDepth.TRANSITIVE,
+            ALLOWED_SCOPES,
+            false
+        )
         .iterator();
 
     // First dependency is always the thing we actually want to execute,

--- a/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/ScopeDependencyFilterTest.java
+++ b/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/ScopeDependencyFilterTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2023 - 2024, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.ascopes.protobufmavenplugin.dependencies.aether;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Set;
+import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.graph.DependencyNode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Ashley Scopes
+ */
+@DisplayName("ScopeDependencyFilter tests")
+class ScopeDependencyFilterTest {
+  @DisplayName("Null dependencies return true to match the Eclipse implementation behaviour")
+  @Test
+  void nullDependenciesReturnTrueToMatchTheEclipseImplementationBehaviour() {
+    // Given
+    var node = mock(DependencyNode.class);
+    when(node.getDependency()).thenReturn(null);
+
+    var filter = new ScopeDependencyFilter(Set.of("compile", "runtime"));
+
+    // When
+    var result = filter.accept(node, List.of());
+
+    // Then
+    assertThat(result).isTrue();
+  }
+
+  @DisplayName("Dependencies without any of the given scopes are filtered out")
+  @Test
+  void dependenciesWithoutAnyOfTheGivenScopesAreFilteredOut() {
+    // Given
+    var dependency = mock(Dependency.class);
+    when(dependency.getScope()).thenReturn("test");
+
+    var node = mock(DependencyNode.class);
+    when(node.getDependency()).thenReturn(dependency);
+
+    var filter = new ScopeDependencyFilter(Set.of("compile", "runtime"));
+
+    // When
+    var result = filter.accept(node, List.of());
+
+    // Then
+    assertThat(result).isFalse();
+  }
+
+  @DisplayName("Dependencies with any of the given scopes are not filtered out")
+  @Test
+  void dependenciesWithAnyOfTheGivenScopesAreNotFilteredOut() {
+    // Given
+    var dependency = mock(Dependency.class);
+    when(dependency.getScope()).thenReturn("compile");
+
+    var node = mock(DependencyNode.class);
+    when(node.getDependency()).thenReturn(dependency);
+
+    var filter = new ScopeDependencyFilter(Set.of("compile", "runtime"));
+
+    // When
+    var result = filter.accept(node, List.of());
+
+    // Then
+    assertThat(result).isTrue();
+  }
+}

--- a/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/mojo/MainGenerateMojoTest.java
+++ b/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/mojo/MainGenerateMojoTest.java
@@ -18,6 +18,7 @@ package io.github.ascopes.protobufmavenplugin.mojo;
 
 import io.github.ascopes.protobufmavenplugin.generation.SourceRootRegistrar;
 import java.nio.file.Path;
+import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 
 @DisplayName("MainGenerateMojo tests")
@@ -46,5 +47,10 @@ class MainGenerateMojoTest extends AbstractGenerateMojoTestTemplate<MainGenerate
     return Path.of(mojo.mavenProject.getBuild().getDirectory())
         .resolve("generated-sources")
         .resolve("protobuf");
+  }
+
+  @Override
+  Set<String> expectedDefaultDependencyScopes() {
+    return Set.of("compile", "provided", "system");
   }
 }

--- a/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/mojo/TestGenerateMojoTest.java
+++ b/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/mojo/TestGenerateMojoTest.java
@@ -18,6 +18,7 @@ package io.github.ascopes.protobufmavenplugin.mojo;
 
 import io.github.ascopes.protobufmavenplugin.generation.SourceRootRegistrar;
 import java.nio.file.Path;
+import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 
 @DisplayName("TestGenerateMojo tests")
@@ -46,5 +47,10 @@ class TestGenerateMojoTest extends AbstractGenerateMojoTestTemplate<TestGenerate
     return Path.of(mojo.mavenProject.getBuild().getDirectory())
         .resolve("generated-test-sources")
         .resolve("protobuf");
+  }
+
+  @Override
+  Set<String> expectedDefaultDependencyScopes() {
+    return Set.of("compile", "provided", "system", "test");
   }
 }


### PR DESCRIPTION
- Fix a regression where we considered all dependencies recursively rather than only those matching the specific scopes we documented. This was resulting in the `generate` goal pulling in runtime dependencies erroneously.
- Implement the ability to override the scopes for dependencies to include on the import path, in case the user wishes to customise them for bespoke build configurations.

Fixes GH-302.

Discovered during the analysis of GH-299.
