### PR TITLE
GH-299: Recover from partial dependency resolution failures where possible

### DIFF
--- a/protobuf-maven-plugin/src/it/gh-299-ehcache-jaxb-resolution-failure/invoker.properties
+++ b/protobuf-maven-plugin/src/it/gh-299-ehcache-jaxb-resolution-failure/invoker.properties
@@ -1,0 +1,17 @@
+#
+# Copyright (C) 2023 - 2024, Ashley Scopes.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+invoker.goals = clean package

--- a/protobuf-maven-plugin/src/it/gh-299-ehcache-jaxb-resolution-failure/pom.xml
+++ b/protobuf-maven-plugin/src/it/gh-299-ehcache-jaxb-resolution-failure/pom.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2023 - 2024, Ashley Scopes.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>@project.groupId@</groupId>
+    <artifactId>protobuf-maven-plugin-parent</artifactId>
+    <version>@project.version@</version>
+    <relativePath>../../../../pom.xml</relativePath>
+  </parent>
+
+  <groupId>gh-299-ehcache-jaxb-resolution-failure</groupId>
+  <artifactId>gh-299-ehcache-jaxb-resolution-failure</artifactId>
+
+  <properties>
+    <protobuf.version>4.27.2</protobuf.version>
+    <ehcache.version>3.10.8</ehcache.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>${protobuf.version}</version>
+    </dependency>
+
+    <dependency>
+      <!-- This version of ehcache pulls in an invalid system-path JAXB dependency that does not
+           exist on newer JDKs. In GH-299, we were erroneously trying to resolve that dependency,
+           despite it only being marked with the `runtime' scope, which we should have been
+           ignoring.
+
+           If this build succeeds, it means we no longer have an issue with this specific dependency
+           and that GH-299 has been fixed. -->
+      <groupId>org.ehcache</groupId>
+      <artifactId>ehcache</artifactId>
+      <version>${ehcache.version}</version>
+      <classifier>jakarta</classifier>
+
+      <exclusions>
+        <exclusion>
+          <!-- This points to blocked repositories. -->
+          <groupId>org.glassfish.jaxb</groupId>
+          <artifactId>jaxb-runtime</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+
+        <configuration>
+          <protocVersion>${protobuf.version}</protocVersion>
+        </configuration>
+
+        <executions>
+          <execution>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/protobuf-maven-plugin/src/it/gh-299-ehcache-jaxb-resolution-failure/selector.groovy
+++ b/protobuf-maven-plugin/src/it/gh-299-ehcache-jaxb-resolution-failure/selector.groovy
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2023 - 2024, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+if ("uname -o".execute().text =~ /Android.*/) {
+  println("Skipping test as it uses incompatible binaries for Android")
+  return false
+} else {
+  return true
+}

--- a/protobuf-maven-plugin/src/it/gh-299-ehcache-jaxb-resolution-failure/src/main/protobuf/org/example/helloworld.proto
+++ b/protobuf-maven-plugin/src/it/gh-299-ehcache-jaxb-resolution-failure/src/main/protobuf/org/example/helloworld.proto
@@ -1,0 +1,27 @@
+//
+// Copyright (C) 2023 - 2024, Ashley Scopes.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "org.example.helloworld";
+
+package org.example.helloworld;
+
+message GreetingRequest {
+  string name = 1;
+}
+

--- a/protobuf-maven-plugin/src/it/gh-299-ehcache-jaxb-resolution-failure/test.groovy
+++ b/protobuf-maven-plugin/src/it/gh-299-ehcache-jaxb-resolution-failure/test.groovy
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2023 - 2024, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.nio.file.Path
+
+import static org.assertj.core.api.Assertions.assertThat
+
+Path expectedClass = basedir.toPath().toAbsolutePath().resolve("target")
+    .resolve("classes")
+    .resolve("org")
+    .resolve("example")
+    .resolve("helloworld")
+    .resolve("GreetingRequest.class")
+
+// Verify compilation succeeded.
+assertThat(expectedClass)
+    .isRegularFile()
+
+return true

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherMavenArtifactPathResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherMavenArtifactPathResolver.java
@@ -47,6 +47,7 @@ import org.eclipse.aether.resolution.ArtifactResolutionException;
 import org.eclipse.aether.resolution.ArtifactResult;
 import org.eclipse.aether.resolution.DependencyRequest;
 import org.eclipse.aether.resolution.DependencyResolutionException;
+import org.eclipse.aether.resolution.DependencyResult;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -140,6 +141,8 @@ public class AetherMavenArtifactPathResolver {
       DependencyResolutionDepth defaultDependencyResolutionDepth,
       boolean includeProjectDependencies
   ) throws ResolutionException {
+    DependencyResult dependencyResult;
+
     try {
       var dependenciesToResolve = Stream
           .concat(
@@ -154,18 +157,35 @@ public class AetherMavenArtifactPathResolver {
       );
 
       var collectRequest = new CollectRequest(dependenciesToResolve, null, remoteRepositories);
-      var dependencyRequest = new DependencyRequest(collectRequest, null);
 
-      return repositorySystem.resolveDependencies(repositorySession, dependencyRequest)
-          .getArtifactResults()
-          .stream()
-          .map(ArtifactResult::getArtifact)
-          .map(this::determinePath)
-          .collect(Collectors.toUnmodifiableList());
+      var dependencyRequest = new DependencyRequest(collectRequest, null);
+      dependencyResult = repositorySystem.resolveDependencies(repositorySession, dependencyRequest);
 
     } catch (DependencyResolutionException ex) {
-      throw new ResolutionException("Failed to resolve dependencies", ex);
+      // GH-299: if this exception is raised, we may still have some results we can use. If this is
+      // the case then resolution only partially failed, so continue for now unless strict
+      // resolution is enabled. We do not fail-fast here anymore (since 2.4.0) as any resolution
+      // errors should be dealt with by the maven-compiler-plugin later on if needed.
+      //
+      // If we didn't get any result, then something more fatal has occurred, so raise.
+      dependencyResult = ex.getResult();
+
+      if (dependencyResult == null) {
+        throw new ResolutionException("Failed to resolve dependencies", ex);
+      }
+
+      // Log the message as well here as we omit it by default if `--errors' is not passed to Maven.
+      log.error(
+          "Error resolving one or more dependencies, dependencies may be missing during "
+              + "protobuf compilation! {}", ex.getMessage(), ex);
     }
+
+    return dependencyResult
+        .getArtifactResults()
+        .stream()
+        .map(ArtifactResult::getArtifact)
+        .map(this::determinePath)
+        .collect(Collectors.toUnmodifiableList());
   }
 
   private Stream<org.eclipse.aether.graph.Dependency> getProjectDependencies() {


### PR DESCRIPTION
Do not fail if we have a partial dependency resolution failure
    
If we only have a partial dependency resolution failure, log the error
details and continue with the dependencies that we do have access to.
This prevents us having immediate issues with erroneous transitive
dependencies that we do not care about, letting Maven fail later
if the resources were actually required.
    
This change makes builds more resillient to poorly configured
dependencies, such as the JAXB dependency used in ehcache.

