### PR TITLE
GH-299: Do not fail if we have partial dependency resolution failures

### DIFF
--- a/protobuf-maven-plugin/src/it/gh-299-ehcache-jaxb-resolution-failure/invoker.properties
+++ b/protobuf-maven-plugin/src/it/gh-299-ehcache-jaxb-resolution-failure/invoker.properties
@@ -1,0 +1,17 @@
+#
+# Copyright (C) 2023 - 2024, Ashley Scopes.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+invoker.goals = clean package

--- a/protobuf-maven-plugin/src/it/gh-299-ehcache-jaxb-resolution-failure/pom.xml
+++ b/protobuf-maven-plugin/src/it/gh-299-ehcache-jaxb-resolution-failure/pom.xml
@@ -58,7 +58,6 @@
 
       <exclusions>
         <exclusion>
-          <!-- This points to blocked repositories. -->
           <groupId>org.glassfish.jaxb</groupId>
           <artifactId>jaxb-runtime</artifactId>
         </exclusion>

--- a/protobuf-maven-plugin/src/it/gh-299-ehcache-jaxb-resolution-failure/pom.xml
+++ b/protobuf-maven-plugin/src/it/gh-299-ehcache-jaxb-resolution-failure/pom.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2023 - 2024, Ashley Scopes.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>@project.groupId@</groupId>
+    <artifactId>protobuf-maven-plugin-parent</artifactId>
+    <version>@project.version@</version>
+    <relativePath>../../../../pom.xml</relativePath>
+  </parent>
+
+  <groupId>gh-299-ehcache-jaxb-resolution-failure</groupId>
+  <artifactId>gh-299-ehcache-jaxb-resolution-failure</artifactId>
+
+  <properties>
+    <protobuf.version>4.27.2</protobuf.version>
+    <ehcache.version>3.10.8</ehcache.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>${protobuf.version}</version>
+    </dependency>
+
+    <dependency>
+      <!-- This version of ehcache pulls in an invalid system-path JAXB dependency that does not
+           exist on newer JDKs. In GH-299, we were erroneously trying to resolve that dependency,
+           despite it only being marked with the `runtime' scope, which we should have been
+           ignoring.
+
+           If this build succeeds, it means we no longer have an issue with this specific dependency
+           and that GH-299 has been fixed. -->
+      <groupId>org.ehcache</groupId>
+      <artifactId>ehcache</artifactId>
+      <version>${ehcache.version}</version>
+      <classifier>jakarta</classifier>
+
+      <exclusions>
+        <exclusion>
+          <!-- This points to blocked repositories. -->
+          <groupId>org.glassfish.jaxb</groupId>
+          <artifactId>jaxb-runtime</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+
+        <configuration>
+          <protocVersion>${protobuf.version}</protocVersion>
+        </configuration>
+
+        <executions>
+          <execution>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/protobuf-maven-plugin/src/it/gh-299-ehcache-jaxb-resolution-failure/pom.xml
+++ b/protobuf-maven-plugin/src/it/gh-299-ehcache-jaxb-resolution-failure/pom.xml
@@ -78,6 +78,7 @@
         <version>@project.version@</version>
 
         <configuration>
+          <ignoreInvalidDependencies>true</ignoreInvalidDependencies>
           <protocVersion>${protobuf.version}</protocVersion>
         </configuration>
 

--- a/protobuf-maven-plugin/src/it/gh-299-ehcache-jaxb-resolution-failure/selector.groovy
+++ b/protobuf-maven-plugin/src/it/gh-299-ehcache-jaxb-resolution-failure/selector.groovy
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2023 - 2024, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+if ("uname -o".execute().text =~ /Android.*/) {
+  println("Skipping test as it uses incompatible binaries for Android")
+  return false
+} else {
+  return true
+}

--- a/protobuf-maven-plugin/src/it/gh-299-ehcache-jaxb-resolution-failure/src/main/protobuf/org/example/helloworld.proto
+++ b/protobuf-maven-plugin/src/it/gh-299-ehcache-jaxb-resolution-failure/src/main/protobuf/org/example/helloworld.proto
@@ -1,0 +1,27 @@
+//
+// Copyright (C) 2023 - 2024, Ashley Scopes.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "org.example.helloworld";
+
+package org.example.helloworld;
+
+message GreetingRequest {
+  string name = 1;
+}
+

--- a/protobuf-maven-plugin/src/it/gh-299-ehcache-jaxb-resolution-failure/test.groovy
+++ b/protobuf-maven-plugin/src/it/gh-299-ehcache-jaxb-resolution-failure/test.groovy
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2023 - 2024, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.nio.file.Path
+
+import static org.assertj.core.api.Assertions.assertThat
+
+Path expectedClass = basedir.toPath().toAbsolutePath().resolve("target")
+    .resolve("classes")
+    .resolve("org")
+    .resolve("example")
+    .resolve("helloworld")
+    .resolve("GreetingRequest.class")
+
+// Verify compilation succeeded.
+assertThat(expectedClass)
+    .isRegularFile()
+
+return true

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherMavenArtifactPathResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherMavenArtifactPathResolver.java
@@ -135,6 +135,9 @@ public class AetherMavenArtifactPathResolver {
    * @param dependencyScopes                 the allowed dependency scopes to resolve.
    * @param includeProjectDependencies       whether to also resolve project dependencies and return
    *                                         them in the result.
+   * @param failOnInvalidDependencies        if {@code false}, resolution of invalid dependencies
+   *                                         will result in errors being logged, but the build will
+   *                                         not be halted.
    * @return the paths to each resolved artifact.
    * @throws ResolutionException if resolution failed in the backend.
    */
@@ -142,7 +145,8 @@ public class AetherMavenArtifactPathResolver {
       Collection<? extends MavenArtifact> artifacts,
       DependencyResolutionDepth defaultDependencyResolutionDepth,
       Set<String> dependencyScopes,
-      boolean includeProjectDependencies
+      boolean includeProjectDependencies,
+      boolean failOnInvalidDependencies
   ) throws ResolutionException {
     DependencyResult dependencyResult;
 
@@ -173,14 +177,15 @@ public class AetherMavenArtifactPathResolver {
       // If we didn't get any result, then something more fatal has occurred, so raise.
       dependencyResult = ex.getResult();
 
-      if (dependencyResult == null) {
+      if (dependencyResult == null || failOnInvalidDependencies) {
         throw new ResolutionException("Failed to resolve dependencies", ex);
       }
 
       // Log the message as well here as we omit it by default if `--errors' is not passed to Maven.
       log.error(
           "Error resolving one or more dependencies, dependencies may be missing during "
-              + "protobuf compilation! {}", ex.getMessage(), ex);
+              + "protobuf compilation! {}", ex.getMessage(), ex
+      );
     }
 
     return dependencyResult

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherMavenArtifactPathResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherMavenArtifactPathResolver.java
@@ -182,7 +182,7 @@ public class AetherMavenArtifactPathResolver {
       }
 
       // Log the message as well here as we omit it by default if `--errors' is not passed to Maven.
-      log.error(
+      log.warn(
           "Error resolving one or more dependencies, dependencies may be missing during "
               + "protobuf compilation! {}", ex.getMessage(), ex
       );

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generation/GenerationRequest.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generation/GenerationRequest.java
@@ -69,6 +69,8 @@ public interface GenerationRequest {
 
   boolean isEmbedSourcesInClassOutputs();
 
+  boolean isFailOnInvalidDependencies();
+
   boolean isFailOnMissingSources();
 
   boolean isFailOnMissingTargets();

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generation/SourceCodeGenerator.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generation/SourceCodeGenerator.java
@@ -185,7 +185,8 @@ public final class SourceCodeGenerator {
         request.getImportDependencies(),
         request.getDependencyResolutionDepth(),
         request.getDependencyScopes(),
-        !request.isIgnoreProjectDependencies()
+        !request.isIgnoreProjectDependencies(),
+        request.isFailOnInvalidDependencies()
     );
 
     var filter = new ProtoFileFilter();
@@ -219,7 +220,8 @@ public final class SourceCodeGenerator {
         request.getSourceDependencies(),
         request.getDependencyResolutionDepth(),
         request.getDependencyScopes(),
-        false
+        false,
+        request.isFailOnInvalidDependencies()
     );
 
     var sourceDependencyListings = protoListingResolver.createProtoFileListings(

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/AbstractGenerateMojo.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/AbstractGenerateMojo.java
@@ -304,6 +304,23 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
   @Nullable List<String> excludes;
 
   /**
+   * Whether to fail if any invalid direct or transitive dependencies are encountered.
+   *
+   * <p>If {@code true}, the build will be aborted with an error if any invalid dependency is
+   * encountered.
+   *
+   * <p>If {@code false}, then the build will report any invalid dependencies as errors in the logs,
+   * before proceeding with the build. Any invalid dependencies will be discarded.
+   *
+   * <p>Prior to {@code v2.4.0}, any invalid dependencies would result in an error being raised
+   * and the build being aborted. In {@code v2.4.0}, this has been relaxed.
+   *
+   * @since 2.4.0
+   */
+  @Parameter(defaultValue = DEFAULT_FALSE)
+  boolean failOnInvalidDependencies;
+
+  /**
    * Whether to fail on missing sources.
    *
    * <p>If no sources are detected, it is usually a sign that this plugin
@@ -769,6 +786,7 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
         .importPaths(importPaths())
         .includes(nonNullList(includes))
         .isEmbedSourcesInClassOutputs(embedSourcesInClassOutputs)
+        .isFailOnInvalidDependencies(failOnInvalidDependencies)
         .isFailOnMissingSources(failOnMissingSources)
         .isFailOnMissingTargets(failOnMissingTargets)
         .isFatalWarnings(fatalWarnings)

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/JvmPluginResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/JvmPluginResolver.java
@@ -118,7 +118,8 @@ public final class JvmPluginResolver {
             List.of(plugin),
             DependencyResolutionDepth.TRANSITIVE,
             ALLOWED_SCOPES,
-            false
+            false,
+            true
         )
         .iterator();
 

--- a/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/mojo/AbstractGenerateMojoTestTemplate.java
+++ b/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/mojo/AbstractGenerateMojoTestTemplate.java
@@ -395,8 +395,30 @@ abstract class AbstractGenerateMojoTestTemplate<A extends AbstractGenerateMojo> 
       var captor = ArgumentCaptor.forClass(GenerationRequest.class);
       verify(mojo.sourceCodeGenerator).generate(captor.capture());
       var actualRequest = captor.getValue();
+
       assertThat(actualRequest.getDependencyScopes())
           .containsExactlyInAnyOrderElementsOf(combination);
+    }
+  }
+
+  @DisplayName("failOnInvalidDependencies tests")
+  @Nested
+  class FailOnInvalidDependenciesTest {
+
+    @DisplayName("failOnInvalidDependencies is set to the specified value")
+    @ValueSource(booleans = {true, false})
+    @ParameterizedTest(name = "for {0}")
+    void failOnInvalidDependenciesIsSetToSpecifiedValue(boolean value) throws Throwable {
+      mojo.failOnInvalidDependencies = value;
+
+      // When
+      mojo.execute();
+
+      // Then
+      var captor = ArgumentCaptor.forClass(GenerationRequest.class);
+      verify(mojo.sourceCodeGenerator).generate(captor.capture());
+      var actualRequest = captor.getValue();
+      assertThat(actualRequest.isFailOnInvalidDependencies()).isEqualTo(value);
     }
   }
 
@@ -953,6 +975,7 @@ abstract class AbstractGenerateMojoTestTemplate<A extends AbstractGenerateMojo> 
     return sourceCodeGenerator;
   }
 
+  @SuppressWarnings("unused")  // Used by JUnit, IntelliJ bug is marking as unused.
   static Stream<Set<String>> scopeCombinations() {
     return combinations("compile", "runtime", "test", "provided", "system");
   }


### PR DESCRIPTION
Do not fail if we have a partial dependency resolution failure
    
If we only have a partial dependency resolution failure, log the error
details and continue with the dependencies that we do have access to.
This prevents us having immediate issues with erroneous transitive
dependencies that we do not care about, letting Maven fail later
if the resources were actually required.
    
This change makes builds more resillient to poorly configured
dependencies, such as the JAXB dependency used in ehcache.

Fixes GH-299.