### PR TITLE
GH-334: remove duplicate "--proto_path" logs

### DIFF
--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generation/SourceCodeGenerator.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generation/SourceCodeGenerator.java
@@ -118,11 +118,11 @@ public final class SourceCodeGenerator {
 
     var argLineBuilder = new ArgLineBuilder(protocPath)
         .fatalWarnings(request.isFatalWarnings())
-        .importPaths(importPaths
-            .stream()
-            .map(ProtoFileListing::getProtoFilesRoot)
-            .collect(Collectors.toCollection(LinkedHashSet::new)))
-        .importPaths(request.getSourceRoots());
+        .importPaths(
+            importPaths.stream()
+                .map(ProtoFileListing::getProtoFilesRoot)
+                .collect(Collectors.toCollection(LinkedHashSet::new))
+        );
 
     request.getEnabledLanguages()
         .forEach(language -> argLineBuilder.generateCodeFor(


### PR DESCRIPTION
issue - duplicate "/src/main/protobuf" in argline

fix - there was a redundant setting of `importPaths` that overwrote the previous logic which filtered duplicates.

Fixes GH-334.