### PR TITLE
feat: improved jvm plugin subprocess handling

### DIFF
--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/JvmPluginResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/JvmPluginResolver.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
@@ -128,7 +129,13 @@ public final class JvmPluginResolver {
     // about the distance between declaration and usage.
     final var pluginPath = dependencyIterator.next();
     var args = new ArrayList<String>();
-    args.add("java");
+
+    var javaExecutablePath = Paths.get(
+        System.getProperty("java.home"),
+        "bin",
+        hostSystem.isProbablyWindows() ? "java.exe" : "java"
+    );
+    args.add(javaExecutablePath.toAbsolutePath().toString());
 
     if (dependencyIterator.hasNext()) {
       args.add("-classpath");


### PR DESCRIPTION
Resolve java executable using absolute path as per the `java.home` system property instead of relying on java being present on the system PATH.

Closes GH-312.