### PR TITLE
Use interfaces for all immutables-generated types

### DIFF
--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/MavenDependency.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/MavenDependency.java
@@ -29,5 +29,5 @@ import org.immutables.value.Value.Modifiable;
  */
 @Immutable
 @Modifiable
-public abstract class MavenDependency implements MavenArtifact {
+public interface MavenDependency extends MavenArtifact {
 }

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/MavenProtocPlugin.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/MavenProtocPlugin.java
@@ -33,11 +33,11 @@ import org.jspecify.annotations.Nullable;
  */
 @Immutable
 @Modifiable
-public abstract class MavenProtocPlugin implements MavenArtifact, ProtocPlugin {
+public interface MavenProtocPlugin extends MavenArtifact, ProtocPlugin {
 
   @Derived
   @Override
-  public @Nullable DependencyResolutionDepth getDependencyResolutionDepth() {
+  default @Nullable DependencyResolutionDepth getDependencyResolutionDepth() {
     // We never allow this to be specified for protoc plugins.
     return null;
   }

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/PathProtocPlugin.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/PathProtocPlugin.java
@@ -30,7 +30,7 @@ import org.immutables.value.Value.Modifiable;
  * @since 2.0.0
  */
 @Modifiable
-public abstract class PathProtocPlugin implements OptionalProtocPlugin {
+public interface PathProtocPlugin extends OptionalProtocPlugin {
 
-  public abstract String getName();
+  String getName();
 }

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/UrlProtocPlugin.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/UrlProtocPlugin.java
@@ -30,7 +30,7 @@ import org.immutables.value.Value.Modifiable;
  * @since 2.0.0
  */
 @Modifiable
-public abstract class UrlProtocPlugin implements OptionalProtocPlugin {
+public interface UrlProtocPlugin extends OptionalProtocPlugin {
 
-  public abstract URL getUrl();
+  URL getUrl();
 }


### PR DESCRIPTION
Replace usage of abstract classes with interfaces.