### PR TITLE
GH-358: Support the use of unpackaged JVM plugins

### DIFF
--- a/protobuf-maven-plugin/src/it/gh-358-unpackaged-jar-plugin/invoker.properties
+++ b/protobuf-maven-plugin/src/it/gh-358-unpackaged-jar-plugin/invoker.properties
@@ -1,0 +1,18 @@
+#
+# Copyright (C) 2023 - 2024, Ashley Scopes.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Do not package anything as we want to avoid creating any kind of JAR to replicate this issue.
+invoker.goals = clean compile

--- a/protobuf-maven-plugin/src/it/gh-358-unpackaged-jar-plugin/pom.xml
+++ b/protobuf-maven-plugin/src/it/gh-358-unpackaged-jar-plugin/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2023 - 2024, Ashley Scopes.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>@project.groupId@</groupId>
+    <artifactId>protobuf-maven-plugin-parent</artifactId>
+    <version>@project.version@</version>
+    <relativePath>../../../../pom.xml</relativePath>
+  </parent>
+
+  <groupId>gh-358-unpackaged-jar-plugin</groupId>
+  <artifactId>parent</artifactId>
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>protoc-plugin</module>
+    <module>some-project</module>
+  </modules>
+
+  <properties>
+    <protobuf.version>4.28.0</protobuf.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-java</artifactId>
+        <version>${protobuf.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+</project>

--- a/protobuf-maven-plugin/src/it/gh-358-unpackaged-jar-plugin/protoc-plugin/pom.xml
+++ b/protobuf-maven-plugin/src/it/gh-358-unpackaged-jar-plugin/protoc-plugin/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2023 - 2024, Ashley Scopes.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>gh-358-unpackaged-jar-plugin</groupId>
+    <artifactId>parent</artifactId>
+    <version>@project.version@</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>protoc-plugin</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/protobuf-maven-plugin/src/it/gh-358-unpackaged-jar-plugin/protoc-plugin/src/main/java/org/example/protocplugin/ProtocPlugin.java
+++ b/protobuf-maven-plugin/src/it/gh-358-unpackaged-jar-plugin/protoc-plugin/src/main/java/org/example/protocplugin/ProtocPlugin.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2023 - 2024, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.example.protocplugin;
+
+import com.google.protobuf.compiler.PluginProtos.CodeGeneratorRequest;
+import com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Collectors;
+
+public class ProtocPlugin {
+  public static void main(String[] args) throws Throwable {
+    var request = CodeGeneratorRequest.parseFrom(System.in);
+
+    var inputFileNameList = request.getFileToGenerateList()
+        .asByteStringList()
+        .stream()
+        .map(buff -> buff.toString(StandardCharsets.UTF_8))
+        .sorted()
+        .collect(Collectors.joining("\n"));
+
+    var listingFile = CodeGeneratorResponse.File.newBuilder()
+        .setName("file-listing.txt")
+        .setContent(inputFileNameList)
+        .build();
+
+    CodeGeneratorResponse.newBuilder()
+        .addFile(listingFile)
+        .build()
+        .writeTo(System.out);
+  }
+}

--- a/protobuf-maven-plugin/src/it/gh-358-unpackaged-jar-plugin/selector.groovy
+++ b/protobuf-maven-plugin/src/it/gh-358-unpackaged-jar-plugin/selector.groovy
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2023 - 2024, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+if ("uname -o".execute().text =~ /Android.*/) {
+  println("Skipping test as it uses incompatible binaries for Android")
+  return false
+} else {
+  return true
+}

--- a/protobuf-maven-plugin/src/it/gh-358-unpackaged-jar-plugin/some-project/pom.xml
+++ b/protobuf-maven-plugin/src/it/gh-358-unpackaged-jar-plugin/some-project/pom.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2023 - 2024, Ashley Scopes.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>gh-358-unpackaged-jar-plugin</groupId>
+    <artifactId>parent</artifactId>
+    <version>@project.version@</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>some-project</artifactId>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+
+        <configuration>
+          <jvmMavenPlugins>
+            <jvmMavenPlugin>
+              <groupId>${project.groupId}</groupId>
+              <artifactId>protoc-plugin</artifactId>
+              <version>${project.version}</version>
+            </jvmMavenPlugin>
+          </jvmMavenPlugins>
+
+          <javaEnabled>false</javaEnabled>
+          <protocVersion>${protobuf.version}</protocVersion>
+        </configuration>
+
+        <executions>
+          <execution>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+          </execution>
+        </executions>
+
+        <dependencies>
+          <dependency>
+            <!-- Keep the plugin as a build dependency to enforce build ordering... -->
+            <groupId>${project.groupId}</groupId>
+            <artifactId>protoc-plugin</artifactId>
+            <version>${project.version}</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/protobuf-maven-plugin/src/it/gh-358-unpackaged-jar-plugin/some-project/pom.xml
+++ b/protobuf-maven-plugin/src/it/gh-358-unpackaged-jar-plugin/some-project/pom.xml
@@ -43,6 +43,7 @@
               <groupId>${project.groupId}</groupId>
               <artifactId>protoc-plugin</artifactId>
               <version>${project.version}</version>
+              <mainClass>org.example.protocplugin.ProtocPlugin</mainClass>
             </jvmMavenPlugin>
           </jvmMavenPlugins>
 

--- a/protobuf-maven-plugin/src/it/gh-358-unpackaged-jar-plugin/some-project/src/main/protobuf/org/example/helloworld.proto
+++ b/protobuf-maven-plugin/src/it/gh-358-unpackaged-jar-plugin/some-project/src/main/protobuf/org/example/helloworld.proto
@@ -1,0 +1,27 @@
+//
+// Copyright (C) 2023 - 2024, Ashley Scopes.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "org.example.helloworld";
+
+package org.example.helloworld;
+
+message GreetingRequest {
+  string name = 1;
+}
+

--- a/protobuf-maven-plugin/src/it/gh-358-unpackaged-jar-plugin/test.groovy
+++ b/protobuf-maven-plugin/src/it/gh-358-unpackaged-jar-plugin/test.groovy
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2023 - 2024, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.stream.Stream
+
+import static org.assertj.core.api.Assertions.assertThat
+
+Path baseProjectDir = basedir.toPath().toAbsolutePath()
+Path protocPluginTargetDir = baseProjectDir.resolve("protoc-plugin", "target")
+Path someProjectTargetDir = baseProjectDir.resolve("some-project", "target")
+
+// Verify compilation succeeded but that no JAR was created for the plugin itself.
+assertThat(protocPluginTargetDir).isDirectory()
+try (Stream<Path> fileStream = Files.list(protocPluginTargetDir)) {
+  assertThat(fileStream.filter { it.getFileName().toString().endsWith(".jar") })
+      .withFailMessage { "Did not expect any JARs to be created by the build in this reproduction" }
+      .isEmpty()
+}
+
+return true

--- a/protobuf-maven-plugin/src/it/gh-358-unpackaged-jar-plugin/test.groovy
+++ b/protobuf-maven-plugin/src/it/gh-358-unpackaged-jar-plugin/test.groovy
@@ -21,8 +21,14 @@ import java.util.stream.Stream
 import static org.assertj.core.api.Assertions.assertThat
 
 Path baseProjectDir = basedir.toPath().toAbsolutePath()
-Path protocPluginTargetDir = baseProjectDir.resolve("protoc-plugin", "target")
-Path someProjectTargetDir = baseProjectDir.resolve("some-project", "target")
+Path protocPluginTargetDir = baseProjectDir.resolve("protoc-plugin")
+    .resolve("target")
+Path expectedGeneratedFile = baseProjectDir.resolve("some-project")
+    .resolve("target")
+    .resolve("generated-sources")
+    .resolve("protobuf")
+    .resolve("file-listing.txt")
+
 
 // Verify compilation succeeded but that no JAR was created for the plugin itself.
 assertThat(protocPluginTargetDir).isDirectory()
@@ -33,7 +39,7 @@ try (Stream<Path> fileStream = Files.list(protocPluginTargetDir)) {
 }
 
 // Verify the JVM plugin produced the expected output file
-assertThat(someProjectTargetDir.resolve("generated-sources", "protobuf", "file-listing.txt"))
+assertThat(expectedGeneratedFile)
     .exists()
     .isRegularFile()
     .hasContent("org/example/helloworld.proto")

--- a/protobuf-maven-plugin/src/it/gh-358-unpackaged-jar-plugin/test.groovy
+++ b/protobuf-maven-plugin/src/it/gh-358-unpackaged-jar-plugin/test.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.stream.Stream
@@ -32,5 +31,11 @@ try (Stream<Path> fileStream = Files.list(protocPluginTargetDir)) {
       .withFailMessage { "Did not expect any JARs to be created by the build in this reproduction" }
       .isEmpty()
 }
+
+// Verify the JVM plugin produced the expected output file
+assertThat(someProjectTargetDir.resolve("generated-sources", "protobuf", "file-listing.txt"))
+    .exists()
+    .isRegularFile()
+    .hasContent("org/example/helloworld.proto")
 
 return true

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherMavenArtifactPathResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherMavenArtifactPathResolver.java
@@ -147,7 +147,7 @@ public class AetherMavenArtifactPathResolver {
    * @return the paths to each resolved artifact.
    * @throws ResolutionException if resolution failed in the backend.
    */
-  public Collection<Path> resolveDependencies(
+  public List<Path> resolveDependencies(
       Collection<? extends MavenArtifact> artifacts,
       DependencyResolutionDepth defaultDependencyResolutionDepth,
       Set<String> dependencyScopes,

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/AbstractGenerateMojo.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/AbstractGenerateMojo.java
@@ -165,7 +165,7 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    *       property - optional.</li>
    * </ul>
    *
-   * <p>On Linux, Mac OS, and other POSIX-like systems, resolution looks for an executable
+   * <p>On Linux, MacOS, and other POSIX-like systems, resolution looks for an executable
    * binary matching the exact name in any directory in the {@code $PATH} environment variable.
    *
    * <p>On Windows, the case-insensitive {@code %PATH%} environment variable is searched for an
@@ -472,6 +472,12 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    *   <li>{@code skip} - set to {@code true} to skip invoking this plugin -
    *       useful if you want to control whether the plugin runs via a
    *       property - optional.</li>
+   *   <li>{@code mainClass} - if the plugin is not an assembled JAR at the time
+   *       the {@code protobuf-maven-plugin} is run, then you will need to provide
+   *       the fully qualified class name of the plugin entrypoint here. This is
+   *       usually only needed if you are creating the JVM plugin within the
+   *       same project. If the plugin is an assembled JAR, then this option is
+   *       ignored - optional.</li>
    * </ul>
    *
    * @since 0.3.0

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/JvmPluginResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/JvmPluginResolver.java
@@ -144,6 +144,12 @@ public final class JvmPluginResolver {
     } else {
       log.debug("Treating JVM plugin at {} as a bundled JAR", pluginPath);
 
+      if (plugin.getMainClass() != null) {
+        log.warn("The plugin at {} has been provided with a 'mainClass' attribute, but this is "
+            + "not applicable for packaged JARs. Please remove this argument. This may be promoted "
+            + "to an error in a future release.", pluginPath);
+      }
+
       if (dependencies.size() > 1) {
         args.add("-classpath");
         args.add(buildJavaPath(dependencies.stream().skip(1)));

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/MavenProtocPlugin.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/MavenProtocPlugin.java
@@ -41,4 +41,14 @@ public interface MavenProtocPlugin extends MavenArtifact, ProtocPlugin {
     // We never allow this to be specified for protoc plugins.
     return null;
   }
+
+  /**
+   * The main class entrypoint to use if the plugin is not an assembled JAR.
+   *
+   * <p>Ignored in all other cases.
+   *
+   * @return the main class name.
+   * @since 2.5.0
+   */
+  @Nullable String getMainClass();
 }

--- a/protobuf-maven-plugin/src/site/markdown/usage.md
+++ b/protobuf-maven-plugin/src/site/markdown/usage.md
@@ -345,7 +345,6 @@ as `PATH`.
 ```xml
 <plugin>
   <groupId>io.github.ascopes</groupId>
-  <artifactId>protobuf-maven-plugin</artifactId>
   <version>...</version>
 
   <configuration>
@@ -599,6 +598,25 @@ dependencies to execute.
 
 Currently, you are required to be able to execute `*.bat` files on Windows, or have 
 `sh` available on the system `$PATH` for any other platform.
+
+If you are building your own protoc plugin, you may want to use the `protobuf-maven-plugin` to test
+that it works correctly. If you do this, then the recommended way to test things out is to invoke
+projects using the `maven-invoker-plugin`, as this will ensure your project is packaged as a JAR
+correctly when it comes to running the tests. If you _do not_ want to do this, you will potentially
+need to provide the `mainClass` attribute on your plugin reference if your tests run before Maven
+has produced a JAR for the given project, as there is no way of the `protobuf-maven-plugin` knowing
+where the entrypoint is. If this is required, you will be notified of this via a build error.
+
+```xml
+<jvmMavenPlugins>
+  <jvmMavenPlugin>
+    <groupId>${project.parent.groupId}</groupId>
+    <artifactId>my-super-awesome-plugin</artifactId>
+    <version>${project.parent.version}</version>
+    <mainClass>org.example.protocplugin.MySuperAwesomePluginMainClass</mainClass>
+  </jvmMavenPlugin>
+</jvmMavenPlugins>
+```
 
 ### Mixing plugins
 


### PR DESCRIPTION
The current solution to providing JVM plugins does not support the use of non-JAR projects. This poses a problem because we currently pass the JAR to the `java` executable via the `-jar` flag, and this will not work for class directory trees.

The main case where this is problematic is when "dogfooding" a new JVM plugin within the same Maven project and binding the test artifact to consume the plugin during the `compile` phase, which occurs before a JAR has been packaged by Maven.

Ideally, users should be using something like `maven-invoker-plugin` for this kind of testing to enable keeping the runtime environment as close to the real runtime environment as possible, but this fix is applied as a workaround for places where this is not possible or desired.

In the case that users use this workaround, they must provide a new attribute `mainClass` to instruct the protobuf-maven-plugin where to find the application entrypoint.

Example existing generated script for packaged JARs (no change):

```shell
#!/usr/bin/env sh

##################################################
### Generated by ascopes/protobuf-maven-plugin ###
###   Users should not invoke this script      ###
###   directly unless they know what they are  ###
###   doing.                                   ###
##################################################

set -eu

/home/ashley/.sdkman/candidates/java/current/bin/java -jar \
    /home/ashley/code/protobuf-maven-plugin/protobuf-maven-plugin/target/it-repo/com/salesforce/servicelibs/reactor-grpc/1.2.4/reactor-grpc-1.2.4.jar
```

Example new generated script for unpackaged class trees:

```shell
#!/usr/bin/env sh

##################################################
### Generated by ascopes/protobuf-maven-plugin ###
###   Users should not invoke this script      ###
###   directly unless they know what they are  ###
###   doing.                                   ###
##################################################

set -eu

/home/ashley/.sdkman/candidates/java/current/bin/java -classpath \
    '/home/ashley/code/protobuf-maven-plugin/protobuf-maven-plugin/target/it/gh-358-unpackaged-jar-plugin/protoc-plugin/target/classes:/home/ashley/code/protobuf-maven-plugin/protobuf-maven-plugin/target/it-repo/com/google/protobuf/protobuf-java/4.28.0/protobuf-java-4.28.0.jar' \
    org.example.protocplugin.ProtocPlugin
```

---

Fixes GH-358.