### PR TITLE
GH-359: Pass module path to JVM plugins correctly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -358,7 +358,7 @@
 
           <configuration>
             <compilerArgs>
-              <compilerArg>-Xlint:all,-classfile,-processing,-serial</compilerArg>
+              <compilerArg>-Xlint:all,-classfile,-processing,-requires-automatic,-serial</compilerArg>
             </compilerArgs>
             <failOnWarning>true</failOnWarning>
             <showDeprecation>true</showDeprecation>

--- a/protobuf-maven-plugin/src/it/gh-359-modular-jar-plugin/invoker.properties
+++ b/protobuf-maven-plugin/src/it/gh-359-modular-jar-plugin/invoker.properties
@@ -1,0 +1,20 @@
+#
+# Copyright (C) 2023 - 2024, Ashley Scopes.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Install the plugin first, so it is accessible as a packaged JAR.
+invoker.goals.0 = clean
+invoker.goals.1 = install -pl protoc-plugin-frontend --also-make
+invoker.goals.2 = package -pl some-project

--- a/protobuf-maven-plugin/src/it/gh-359-modular-jar-plugin/pom.xml
+++ b/protobuf-maven-plugin/src/it/gh-359-modular-jar-plugin/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2023 - 2024, Ashley Scopes.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>@project.groupId@</groupId>
+    <artifactId>protobuf-maven-plugin-parent</artifactId>
+    <version>@project.version@</version>
+    <relativePath>../../../../pom.xml</relativePath>
+  </parent>
+
+  <groupId>gh-359-modular-jar-plugin</groupId>
+  <artifactId>parent</artifactId>
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>protoc-plugin-backend</module>
+    <module>protoc-plugin-frontend</module>
+    <module>some-project</module>
+  </modules>
+
+  <properties>
+    <protobuf.version>4.28.0</protobuf.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-java</artifactId>
+        <version>${protobuf.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+</project>

--- a/protobuf-maven-plugin/src/it/gh-359-modular-jar-plugin/protoc-plugin-backend/pom.xml
+++ b/protobuf-maven-plugin/src/it/gh-359-modular-jar-plugin/protoc-plugin-backend/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2023 - 2024, Ashley Scopes.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>gh-359-modular-jar-plugin</groupId>
+    <artifactId>parent</artifactId>
+    <version>@project.version@</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>protoc-plugin-backend</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/protobuf-maven-plugin/src/it/gh-359-modular-jar-plugin/protoc-plugin-backend/src/main/java/module-info.java
+++ b/protobuf-maven-plugin/src/it/gh-359-modular-jar-plugin/protoc-plugin-backend/src/main/java/module-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2023 - 2024, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+module org.example.protocplugin.backend {
+  requires com.google.protobuf;
+  exports org.example.protocplugin.backend;
+}

--- a/protobuf-maven-plugin/src/it/gh-359-modular-jar-plugin/protoc-plugin-backend/src/main/java/org/example/protocplugin/backend/ProtocPluginBackend.java
+++ b/protobuf-maven-plugin/src/it/gh-359-modular-jar-plugin/protoc-plugin-backend/src/main/java/org/example/protocplugin/backend/ProtocPluginBackend.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2023 - 2024, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.example.protocplugin.backend;
+
+import com.google.protobuf.compiler.PluginProtos.CodeGeneratorRequest;
+import com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Collectors;
+
+public final class ProtocPluginBackend {
+
+  public ProtocPluginBackend() {
+    // Nothing to do, but needed to make -Xlint be happy.
+  }
+
+  public void processCodeGenerationRequest(InputStream in, OutputStream out) throws IOException {
+    var request = CodeGeneratorRequest.parseFrom(in);
+
+    var inputFileNameList = request.getFileToGenerateList()
+        .asByteStringList()
+        .stream()
+        .map(buff -> buff.toString(StandardCharsets.UTF_8))
+        .sorted()
+        .collect(Collectors.joining("\n"));
+
+    var listingFile = CodeGeneratorResponse.File.newBuilder()
+        .setName("file-listing.txt")
+        .setContent(inputFileNameList)
+        .build();
+
+    CodeGeneratorResponse.newBuilder()
+        .addFile(listingFile)
+        .build()
+        .writeTo(out);
+  }
+}

--- a/protobuf-maven-plugin/src/it/gh-359-modular-jar-plugin/protoc-plugin-frontend/pom.xml
+++ b/protobuf-maven-plugin/src/it/gh-359-modular-jar-plugin/protoc-plugin-frontend/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2023 - 2024, Ashley Scopes.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>gh-359-modular-jar-plugin</groupId>
+    <artifactId>parent</artifactId>
+    <version>@project.version@</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>protoc-plugin-frontend</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>protoc-plugin-backend</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifest>
+              <mainClass>org.example.protocplugin.frontend.Main</mainClass>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/protobuf-maven-plugin/src/it/gh-359-modular-jar-plugin/protoc-plugin-frontend/src/main/java/org/example/protocplugin/frontend/Main.java
+++ b/protobuf-maven-plugin/src/it/gh-359-modular-jar-plugin/protoc-plugin-frontend/src/main/java/org/example/protocplugin/frontend/Main.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2023 - 2024, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.example.protocplugin.frontend;
+
+import org.example.protocplugin.backend.ProtocPluginBackend;
+
+public class Main {
+  public static void main(String[] args) throws Exception {
+    new ProtocPluginBackend().processCodeGenerationRequest(System.in, System.out);
+  }
+}

--- a/protobuf-maven-plugin/src/it/gh-359-modular-jar-plugin/protoc-plugin-frontend/src/main/module-info.java
+++ b/protobuf-maven-plugin/src/it/gh-359-modular-jar-plugin/protoc-plugin-frontend/src/main/module-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2023 - 2024, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+module org.example.protocplugin.frontend {
+  requires org.example.protocplugin.backend;
+  exports org.example.protocplugin.frontend;
+}

--- a/protobuf-maven-plugin/src/it/gh-359-modular-jar-plugin/selector.groovy
+++ b/protobuf-maven-plugin/src/it/gh-359-modular-jar-plugin/selector.groovy
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2023 - 2024, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+if ("uname -o".execute().text =~ /Android.*/) {
+  println("Skipping test as it uses incompatible binaries for Android")
+  return false
+} else {
+  return true
+}

--- a/protobuf-maven-plugin/src/it/gh-359-modular-jar-plugin/some-project/pom.xml
+++ b/protobuf-maven-plugin/src/it/gh-359-modular-jar-plugin/some-project/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2023 - 2024, Ashley Scopes.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>gh-359-modular-jar-plugin</groupId>
+    <artifactId>parent</artifactId>
+    <version>@project.version@</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>some-project</artifactId>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+
+        <configuration>
+          <jvmMavenPlugins>
+            <jvmMavenPlugin>
+              <groupId>${project.groupId}</groupId>
+              <artifactId>protoc-plugin-frontend</artifactId>
+              <version>${project.version}</version>
+            </jvmMavenPlugin>
+          </jvmMavenPlugins>
+
+          <javaEnabled>false</javaEnabled>
+          <protocVersion>${protobuf.version}</protocVersion>
+        </configuration>
+
+        <executions>
+          <execution>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/protobuf-maven-plugin/src/it/gh-359-modular-jar-plugin/some-project/src/main/protobuf/org/example/helloworld.proto
+++ b/protobuf-maven-plugin/src/it/gh-359-modular-jar-plugin/some-project/src/main/protobuf/org/example/helloworld.proto
@@ -1,0 +1,27 @@
+//
+// Copyright (C) 2023 - 2024, Ashley Scopes.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "org.example.helloworld";
+
+package org.example.helloworld;
+
+message GreetingRequest {
+  string name = 1;
+}
+

--- a/protobuf-maven-plugin/src/it/gh-359-modular-jar-plugin/test.groovy
+++ b/protobuf-maven-plugin/src/it/gh-359-modular-jar-plugin/test.groovy
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2023 - 2024, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+import org.assertj.core.api.InstanceOfAssertFactories
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.stream.Stream
+
+import static org.assertj.core.api.Assertions.assertThat
+
+Path baseProjectDir = basedir.toPath().toAbsolutePath()
+Path protocPluginFrontendTargetDir = baseProjectDir.resolve("protoc-plugin-frontend")
+    .resolve("target")
+Path expectedGeneratedFile = baseProjectDir.resolve("some-project")
+    .resolve("target")
+    .resolve("generated-sources")
+    .resolve("protobuf")
+    .resolve("file-listing.txt")
+Path expectedScriptsDirectory = baseProjectDir.resolve("some-project")
+    .resolve("target")
+    .resolve("protobuf-maven-plugin")
+    .resolve("plugins")
+    .resolve("jvm")
+
+// Verify compilation succeeded but that no JAR was created for the plugin itself.
+assertThat(protocPluginFrontendTargetDir).isDirectory()
+try (Stream<Path> fileStream = Files.list(protocPluginFrontendTargetDir)) {
+  assertThat(fileStream.filter { it.getFileName().toString().endsWith(".jar") })
+      .withFailMessage { "Expected a JARs to be created by the build in this reproduction" }
+      .isNotEmpty()
+}
+
+// Verify the JVM plugin produced the expected output file
+assertThat(expectedGeneratedFile)
+    .exists()
+    .isRegularFile()
+    .hasContent("org/example/helloworld.proto")
+
+// Verify we invoked the JVM with a module path.
+assertThat(Files.list(expectedScriptsDirectory))
+    .singleElement(InstanceOfAssertFactories.PATH)
+    .isRegularFile()
+    .content()
+    .contains("--module-path")
+
+return true


### PR DESCRIPTION
This PR implements changes to detect JPMS (Jigsaw) modules on the classpath for a given JVM plugin and dependencies.

All modules that are detected will be passed on the module path as well as the class path.

Fixes GH-359.