### PR TITLE
GH-392: Use tiered level-1 compilation when running JVM subprocesses

### DIFF
--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/JvmPluginResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/JvmPluginResolver.java
@@ -133,6 +133,11 @@ public final class JvmPluginResolver {
     var args = new ArrayList<String>();
     args.add(hostSystem.getJavaExecutablePath().toString());
 
+    // JVM tuning flags to improve the performance of short-lived processes.
+    args.add("-Xshare:auto");
+    args.add("-XX:+TieredCompilation");
+    args.add("-XX:TieredStopAtLevel=1");
+
     // Caveat: we currently ignore the Class-Path JAR manifest entry. Not sure why we would want
     // to be using that here though, so I am leaving it unimplemented until such a time that someone
     // requests it.


### PR DESCRIPTION
This PR introduces a couple of new flags in the JVM plugin scripts that enables tiered compilation that only runs at level 1 (client)
rather than level 2 (server) mode for JIT.

The idea here is to reduce the startup times for short-lived processes invoking JVM plugins internally.

Closes GH-392.