### PR TITLE
Internalize dependencies on aether

### DIFF
--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/MavenArtifactPathResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/MavenArtifactPathResolver.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2023 - 2024, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.ascopes.protobufmavenplugin.dependencies;
+
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Interface for an object that provides resolution of Maven artifacts and dependencies,
+ * emitting their paths.
+ *
+ * <p>This is abstracted such that the existing implementation can be easily changed in
+ * the future.
+ *
+ * @author Ashley Scopes
+ * @since 2.6.0
+ */
+public interface MavenArtifactPathResolver {
+
+  /**
+   * Resolve a single Maven artifact directly, and do not resolve any transitive dependencies.
+   *
+   * @param artifact the artifact to resolve.
+   * @return the path to the resolved artifact.
+   * @throws ResolutionException if resolution fails in the backend.
+   */
+  Path resolveArtifact(MavenArtifact artifact) throws ResolutionException;
+
+  /**
+   * Resolve all given dependencies based on their resolution depth semantics.
+   *
+   * @param artifacts                        the artifacts to resolve.
+   * @param defaultDependencyResolutionDepth the project default dependency resolution depth.
+   * @param dependencyScopes                 the allowed dependency scopes to resolve.
+   * @param includeProjectDependencies       whether to also resolve project dependencies and return
+   *                                         them in the result.
+   * @param failOnInvalidDependencies        if {@code false}, resolution of invalid dependencies
+   *                                         will result in errors being logged, but the build will
+   *                                         not be halted.
+   * @return the paths to each resolved artifact.
+   * @throws ResolutionException if resolution failed in the backend.
+   */
+  List<Path> resolveDependencies(
+      Collection<? extends MavenArtifact> artifacts,
+      DependencyResolutionDepth defaultDependencyResolutionDepth,
+      Set<String> dependencyScopes,
+      boolean includeProjectDependencies,
+      boolean failOnInvalidDependencies
+  ) throws ResolutionException;
+}

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherMavenArtifactPathResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherMavenArtifactPathResolver.java
@@ -20,6 +20,7 @@ import static java.util.Objects.requireNonNullElse;
 
 import io.github.ascopes.protobufmavenplugin.dependencies.DependencyResolutionDepth;
 import io.github.ascopes.protobufmavenplugin.dependencies.MavenArtifact;
+import io.github.ascopes.protobufmavenplugin.dependencies.MavenArtifactPathResolver;
 import io.github.ascopes.protobufmavenplugin.dependencies.ResolutionException;
 import io.github.ascopes.protobufmavenplugin.utils.FileUtils;
 import java.nio.file.Path;
@@ -61,7 +62,7 @@ import org.slf4j.LoggerFactory;
  * @since 2.0.3
  */
 @Named
-public class AetherMavenArtifactPathResolver {
+final class AetherMavenArtifactPathResolver implements MavenArtifactPathResolver {
 
   private static final String DEFAULT_EXTENSION = "jar";
   private static final String DEFAULT_SCOPE = "compile";
@@ -76,7 +77,7 @@ public class AetherMavenArtifactPathResolver {
   private final List<RemoteRepository> remoteRepositories;
 
   @Inject
-  public AetherMavenArtifactPathResolver(
+  AetherMavenArtifactPathResolver(
       MavenSession mavenSession,
       RepositorySystem repositorySystem,
       ArtifactHandler artifactHandler
@@ -98,13 +99,7 @@ public class AetherMavenArtifactPathResolver {
     log.debug("Detected remote repositories as {}", remoteRepositories);
   }
 
-  /**
-   * Resolve a single Maven artifact directly, and do not resolve any transitive dependencies.
-   *
-   * @param artifact the artifact to resolve.
-   * @return the path to the resolved artifact.
-   * @throws ResolutionException if resolution fails in the backend.
-   */
+  @Override
   public Path resolveArtifact(MavenArtifact artifact) throws ResolutionException {
     var repositorySession = mavenSession.getRepositorySession();
     var aetherArtifact = new DefaultArtifact(
@@ -133,20 +128,7 @@ public class AetherMavenArtifactPathResolver {
     }
   }
 
-  /**
-   * Resolve all given dependencies based on their resolution depth semantics.
-   *
-   * @param artifacts                        the artifacts to resolve.
-   * @param defaultDependencyResolutionDepth the project default dependency resolution depth.
-   * @param dependencyScopes                 the allowed dependency scopes to resolve.
-   * @param includeProjectDependencies       whether to also resolve project dependencies and return
-   *                                         them in the result.
-   * @param failOnInvalidDependencies        if {@code false}, resolution of invalid dependencies
-   *                                         will result in errors being logged, but the build will
-   *                                         not be halted.
-   * @return the paths to each resolved artifact.
-   * @throws ResolutionException if resolution failed in the backend.
-   */
+  @Override
   public List<Path> resolveDependencies(
       Collection<? extends MavenArtifact> artifacts,
       DependencyResolutionDepth defaultDependencyResolutionDepth,

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generation/SourceCodeGenerator.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generation/SourceCodeGenerator.java
@@ -16,8 +16,8 @@
 
 package io.github.ascopes.protobufmavenplugin.generation;
 
+import io.github.ascopes.protobufmavenplugin.dependencies.MavenArtifactPathResolver;
 import io.github.ascopes.protobufmavenplugin.dependencies.ResolutionException;
-import io.github.ascopes.protobufmavenplugin.dependencies.aether.AetherMavenArtifactPathResolver;
 import io.github.ascopes.protobufmavenplugin.plugins.BinaryPluginResolver;
 import io.github.ascopes.protobufmavenplugin.plugins.JvmPluginResolver;
 import io.github.ascopes.protobufmavenplugin.plugins.ResolvedProtocPlugin;
@@ -57,7 +57,7 @@ public final class SourceCodeGenerator {
   private static final Logger log = LoggerFactory.getLogger(SourceCodeGenerator.class);
 
   private final MavenSession mavenSession;
-  private final AetherMavenArtifactPathResolver artifactPathResolver;
+  private final MavenArtifactPathResolver artifactPathResolver;
   private final ProtocResolver protocResolver;
   private final BinaryPluginResolver binaryPluginResolver;
   private final JvmPluginResolver jvmPluginResolver;
@@ -67,7 +67,7 @@ public final class SourceCodeGenerator {
   @Inject
   public SourceCodeGenerator(
       MavenSession mavenSession,
-      AetherMavenArtifactPathResolver artifactPathResolver,
+      MavenArtifactPathResolver artifactPathResolver,
       ProtocResolver protocResolver,
       BinaryPluginResolver binaryPluginResolver,
       JvmPluginResolver jvmPluginResolver,

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/BinaryPluginResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/BinaryPluginResolver.java
@@ -16,11 +16,11 @@
 
 package io.github.ascopes.protobufmavenplugin.plugins;
 
+import io.github.ascopes.protobufmavenplugin.dependencies.MavenArtifactPathResolver;
 import io.github.ascopes.protobufmavenplugin.dependencies.PlatformClassifierFactory;
 import io.github.ascopes.protobufmavenplugin.dependencies.ResolutionException;
 import io.github.ascopes.protobufmavenplugin.dependencies.SystemPathBinaryResolver;
 import io.github.ascopes.protobufmavenplugin.dependencies.UrlResourceFetcher;
-import io.github.ascopes.protobufmavenplugin.dependencies.aether.AetherMavenArtifactPathResolver;
 import io.github.ascopes.protobufmavenplugin.utils.Digests;
 import io.github.ascopes.protobufmavenplugin.utils.FileUtils;
 import java.io.IOException;
@@ -43,14 +43,14 @@ public final class BinaryPluginResolver {
 
   private static final Logger log = LoggerFactory.getLogger(BinaryPluginResolver.class);
 
-  private final AetherMavenArtifactPathResolver artifactPathResolver;
+  private final MavenArtifactPathResolver artifactPathResolver;
   private final PlatformClassifierFactory platformClassifierFactory;
   private final SystemPathBinaryResolver systemPathResolver;
   private final UrlResourceFetcher urlResourceFetcher;
 
   @Inject
   public BinaryPluginResolver(
-      AetherMavenArtifactPathResolver artifactPathResolver,
+      MavenArtifactPathResolver artifactPathResolver,
       PlatformClassifierFactory platformClassifierFactory,
       SystemPathBinaryResolver systemPathResolver,
       UrlResourceFetcher urlResourceFetcher

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/JvmPluginResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/JvmPluginResolver.java
@@ -17,8 +17,8 @@
 package io.github.ascopes.protobufmavenplugin.plugins;
 
 import io.github.ascopes.protobufmavenplugin.dependencies.DependencyResolutionDepth;
+import io.github.ascopes.protobufmavenplugin.dependencies.MavenArtifactPathResolver;
 import io.github.ascopes.protobufmavenplugin.dependencies.ResolutionException;
-import io.github.ascopes.protobufmavenplugin.dependencies.aether.AetherMavenArtifactPathResolver;
 import io.github.ascopes.protobufmavenplugin.generation.TemporarySpace;
 import io.github.ascopes.protobufmavenplugin.utils.Digests;
 import io.github.ascopes.protobufmavenplugin.utils.FileUtils;
@@ -61,13 +61,13 @@ public final class JvmPluginResolver {
   private static final Logger log = LoggerFactory.getLogger(BinaryPluginResolver.class);
 
   private final HostSystem hostSystem;
-  private final AetherMavenArtifactPathResolver artifactPathResolver;
+  private final MavenArtifactPathResolver artifactPathResolver;
   private final TemporarySpace temporarySpace;
 
   @Inject
   public JvmPluginResolver(
       HostSystem hostSystem,
-      AetherMavenArtifactPathResolver artifactPathResolver,
+      MavenArtifactPathResolver artifactPathResolver,
       TemporarySpace temporarySpace
   ) {
     this.hostSystem = hostSystem;

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/protoc/ProtocResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/protoc/ProtocResolver.java
@@ -17,11 +17,11 @@
 package io.github.ascopes.protobufmavenplugin.protoc;
 
 import io.github.ascopes.protobufmavenplugin.dependencies.ImmutableMavenDependency;
+import io.github.ascopes.protobufmavenplugin.dependencies.MavenArtifactPathResolver;
 import io.github.ascopes.protobufmavenplugin.dependencies.PlatformClassifierFactory;
 import io.github.ascopes.protobufmavenplugin.dependencies.ResolutionException;
 import io.github.ascopes.protobufmavenplugin.dependencies.SystemPathBinaryResolver;
 import io.github.ascopes.protobufmavenplugin.dependencies.UrlResourceFetcher;
-import io.github.ascopes.protobufmavenplugin.dependencies.aether.AetherMavenArtifactPathResolver;
 import io.github.ascopes.protobufmavenplugin.utils.FileUtils;
 import io.github.ascopes.protobufmavenplugin.utils.HostSystem;
 import java.io.IOException;
@@ -48,7 +48,7 @@ public final class ProtocResolver {
   private static final Logger log = LoggerFactory.getLogger(ProtocResolver.class);
 
   private final HostSystem hostSystem;
-  private final AetherMavenArtifactPathResolver artifactPathResolver;
+  private final MavenArtifactPathResolver artifactPathResolver;
   private final PlatformClassifierFactory platformClassifierFactory;
   private final SystemPathBinaryResolver systemPathResolver;
   private final UrlResourceFetcher urlResourceFetcher;
@@ -56,7 +56,7 @@ public final class ProtocResolver {
   @Inject
   public ProtocResolver(
       HostSystem hostSystem,
-      AetherMavenArtifactPathResolver artifactPathResolver,
+      MavenArtifactPathResolver artifactPathResolver,
       PlatformClassifierFactory platformClassifierFactory,
       SystemPathBinaryResolver systemPathResolver,
       UrlResourceFetcher urlResourceFetcher


### PR DESCRIPTION
This allows swapping implementations out in the future, and keeps concerns separated more clearly.