### PR TITLE
GH-397: implement ability to specify JVM arguments to plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>io.github.ascopes</groupId>
   <artifactId>protobuf-maven-plugin-parent</artifactId>
-  <version>2.5.1-SNAPSHOT</version>
+  <version>2.6.0-SNAPSHOT</version>
 
   <name>Protobuf Maven Plugin Parent</name>
   <description>Parent POM for the Protobuf Maven Plugin.</description>

--- a/protobuf-maven-plugin/pom.xml
+++ b/protobuf-maven-plugin/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes</groupId>
     <artifactId>protobuf-maven-plugin-parent</artifactId>
-    <version>2.5.1-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>protobuf-maven-plugin</artifactId>

--- a/protobuf-maven-plugin/src/it/gh-397-jvm-plugin-commandline-args/invoker.properties
+++ b/protobuf-maven-plugin/src/it/gh-397-jvm-plugin-commandline-args/invoker.properties
@@ -1,0 +1,17 @@
+#
+# Copyright (C) 2023 - 2024, Ashley Scopes.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+invoker.goals = clean package

--- a/protobuf-maven-plugin/src/it/gh-397-jvm-plugin-commandline-args/pom.xml
+++ b/protobuf-maven-plugin/src/it/gh-397-jvm-plugin-commandline-args/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2023 - 2024, Ashley Scopes.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>@project.groupId@</groupId>
+    <artifactId>protobuf-maven-plugin-parent</artifactId>
+    <version>@project.version@</version>
+    <relativePath>../../../../pom.xml</relativePath>
+  </parent>
+
+  <groupId>gh-397-jvm-plugin-commandline-args</groupId>
+  <artifactId>parent</artifactId>
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>protoc-plugin</module>
+    <module>some-project</module>
+  </modules>
+
+  <properties>
+    <protobuf.version>4.28.2</protobuf.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-java</artifactId>
+        <version>${protobuf.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+</project>

--- a/protobuf-maven-plugin/src/it/gh-397-jvm-plugin-commandline-args/protoc-plugin/pom.xml
+++ b/protobuf-maven-plugin/src/it/gh-397-jvm-plugin-commandline-args/protoc-plugin/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2023 - 2024, Ashley Scopes.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>gh-397-jvm-plugin-commandline-args</groupId>
+    <artifactId>parent</artifactId>
+    <version>@project.version@</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>protoc-plugin</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifest>
+              <mainClass>org.example.protocplugin.ProtocPlugin</mainClass>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/protobuf-maven-plugin/src/it/gh-397-jvm-plugin-commandline-args/protoc-plugin/src/main/java/org/example/protocplugin/ProtocPlugin.java
+++ b/protobuf-maven-plugin/src/it/gh-397-jvm-plugin-commandline-args/protoc-plugin/src/main/java/org/example/protocplugin/ProtocPlugin.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2023 - 2024, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.example.protocplugin;
+
+import com.google.protobuf.compiler.PluginProtos.CodeGeneratorRequest;
+import com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Collectors;
+
+public class ProtocPlugin {
+  public static void main(String[] args) throws Throwable {
+    var request = CodeGeneratorRequest.parseFrom(System.in);
+
+    var listingFile = CodeGeneratorResponse.File.newBuilder()
+        .setName("commandline-args.txt")
+        .setContent(String.join("\n", args))
+        .build();
+
+    CodeGeneratorResponse.newBuilder()
+        .addFile(listingFile)
+        .build()
+        .writeTo(System.out);
+  }
+}

--- a/protobuf-maven-plugin/src/it/gh-397-jvm-plugin-commandline-args/some-project/pom.xml
+++ b/protobuf-maven-plugin/src/it/gh-397-jvm-plugin-commandline-args/some-project/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2023 - 2024, Ashley Scopes.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>gh-397-jvm-plugin-commandline-args</groupId>
+    <artifactId>parent</artifactId>
+    <version>@project.version@</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>some-project</artifactId>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+
+        <configuration>
+          <jvmMavenPlugins>
+            <jvmMavenPlugin>
+              <groupId>${project.groupId}</groupId>
+              <artifactId>protoc-plugin</artifactId>
+              <version>${project.version}</version>
+              <jvmArgs>
+                <jvmArg>foo</jvmArg>
+                <jvmArg>bar</jvmArg>
+                <jvmArg>baz</jvmArg>
+              </jvmArgs>
+            </jvmMavenPlugin>
+          </jvmMavenPlugins>
+
+          <javaEnabled>false</javaEnabled>
+          <protocVersion>${protobuf.version}</protocVersion>
+        </configuration>
+
+        <executions>
+          <execution>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/protobuf-maven-plugin/src/it/gh-397-jvm-plugin-commandline-args/some-project/src/main/protobuf/org/example/helloworld.proto
+++ b/protobuf-maven-plugin/src/it/gh-397-jvm-plugin-commandline-args/some-project/src/main/protobuf/org/example/helloworld.proto
@@ -1,0 +1,27 @@
+//
+// Copyright (C) 2023 - 2024, Ashley Scopes.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "org.example.helloworld";
+
+package org.example.helloworld;
+
+message GreetingRequest {
+  string name = 1;
+}
+

--- a/protobuf-maven-plugin/src/it/gh-397-jvm-plugin-commandline-args/test.groovy
+++ b/protobuf-maven-plugin/src/it/gh-397-jvm-plugin-commandline-args/test.groovy
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2023 - 2024, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.stream.Stream
+
+import static org.assertj.core.api.Assertions.assertThat
+
+Path baseProjectDir = basedir.toPath().toAbsolutePath()
+Path protocPluginTargetDir = baseProjectDir.resolve("protoc-plugin")
+    .resolve("target")
+Path expectedGeneratedFile = baseProjectDir.resolve("some-project")
+    .resolve("target")
+    .resolve("generated-sources")
+    .resolve("protobuf")
+    .resolve("commandline-args.txt")
+
+// Verify the JVM plugin produced the expected output file
+assertThat(expectedGeneratedFile)
+    .exists()
+    .isRegularFile()
+    .hasContent("foo\nbar\nbaz")
+
+return true

--- a/protobuf-maven-plugin/src/it/gh-397-jvm-plugin-jvm-args/invoker.properties
+++ b/protobuf-maven-plugin/src/it/gh-397-jvm-plugin-jvm-args/invoker.properties
@@ -1,0 +1,17 @@
+#
+# Copyright (C) 2023 - 2024, Ashley Scopes.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+invoker.goals = clean package

--- a/protobuf-maven-plugin/src/it/gh-397-jvm-plugin-jvm-args/pom.xml
+++ b/protobuf-maven-plugin/src/it/gh-397-jvm-plugin-jvm-args/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2023 - 2024, Ashley Scopes.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>@project.groupId@</groupId>
+    <artifactId>protobuf-maven-plugin-parent</artifactId>
+    <version>@project.version@</version>
+    <relativePath>../../../../pom.xml</relativePath>
+  </parent>
+
+  <groupId>gh-397-jvm-plugin-jvm-args</groupId>
+  <artifactId>parent</artifactId>
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>protoc-plugin</module>
+    <module>some-project</module>
+  </modules>
+
+  <properties>
+    <protobuf.version>4.28.2</protobuf.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-java</artifactId>
+        <version>${protobuf.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+</project>

--- a/protobuf-maven-plugin/src/it/gh-397-jvm-plugin-jvm-args/protoc-plugin/pom.xml
+++ b/protobuf-maven-plugin/src/it/gh-397-jvm-plugin-jvm-args/protoc-plugin/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2023 - 2024, Ashley Scopes.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>gh-397-jvm-plugin-jvm-args</groupId>
+    <artifactId>parent</artifactId>
+    <version>@project.version@</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>protoc-plugin</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifest>
+              <mainClass>org.example.protocplugin.ProtocPlugin</mainClass>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/protobuf-maven-plugin/src/it/gh-397-jvm-plugin-jvm-args/protoc-plugin/src/main/java/org/example/protocplugin/ProtocPlugin.java
+++ b/protobuf-maven-plugin/src/it/gh-397-jvm-plugin-jvm-args/protoc-plugin/src/main/java/org/example/protocplugin/ProtocPlugin.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2023 - 2024, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.example.protocplugin;
+
+import com.google.protobuf.compiler.PluginProtos.CodeGeneratorRequest;
+import com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Collectors;
+
+public class ProtocPlugin {
+  public static void main(String[] args) throws Throwable {
+    var request = CodeGeneratorRequest.parseFrom(System.in);
+
+    var jvmArgs = new StringBuilder();
+    System.getProperties()
+        .forEach((k, v) -> jvmArgs.append(k).append("=").append(v).append("\n"));
+
+    var listingFile = CodeGeneratorResponse.File.newBuilder()
+        .setName("jvm-args.txt")
+        .setContent(jvmArgs.toString())
+        .build();
+
+    CodeGeneratorResponse.newBuilder()
+        .addFile(listingFile)
+        .build()
+        .writeTo(System.out);
+  }
+}

--- a/protobuf-maven-plugin/src/it/gh-397-jvm-plugin-jvm-args/some-project/pom.xml
+++ b/protobuf-maven-plugin/src/it/gh-397-jvm-plugin-jvm-args/some-project/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2023 - 2024, Ashley Scopes.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>gh-397-jvm-plugin-jvm-args</groupId>
+    <artifactId>parent</artifactId>
+    <version>@project.version@</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>some-project</artifactId>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+
+        <configuration>
+          <jvmMavenPlugins>
+            <jvmMavenPlugin>
+              <groupId>${project.groupId}</groupId>
+              <artifactId>protoc-plugin</artifactId>
+              <version>${project.version}</version>
+              <jvmConfigArgs>
+                <jvmConfigArg>this-should-be-warned-as-invalid</jvmConfigArg>
+                <jvmConfigArg>-Xms100m</jvmConfigArg>
+                <jvmConfigArg>-Xmx128m</jvmConfigArg>
+                <jvmConfigArg>-Dthis.should.be.set=if it works</jvmConfigArg>
+              </jvmConfigArgs>
+            </jvmMavenPlugin>
+          </jvmMavenPlugins>
+
+          <javaEnabled>false</javaEnabled>
+          <protocVersion>${protobuf.version}</protocVersion>
+        </configuration>
+
+        <executions>
+          <execution>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/protobuf-maven-plugin/src/it/gh-397-jvm-plugin-jvm-args/some-project/src/main/protobuf/org/example/helloworld.proto
+++ b/protobuf-maven-plugin/src/it/gh-397-jvm-plugin-jvm-args/some-project/src/main/protobuf/org/example/helloworld.proto
@@ -1,0 +1,27 @@
+//
+// Copyright (C) 2023 - 2024, Ashley Scopes.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "org.example.helloworld";
+
+package org.example.helloworld;
+
+message GreetingRequest {
+  string name = 1;
+}
+

--- a/protobuf-maven-plugin/src/it/gh-397-jvm-plugin-jvm-args/test.groovy
+++ b/protobuf-maven-plugin/src/it/gh-397-jvm-plugin-jvm-args/test.groovy
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2023 - 2024, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.stream.Stream
+
+import static org.assertj.core.api.Assertions.assertThat
+
+Path baseProjectDir = basedir.toPath().toAbsolutePath()
+Path protocPluginTargetDir = baseProjectDir.resolve("protoc-plugin")
+    .resolve("target")
+Path expectedGeneratedFile = baseProjectDir.resolve("some-project")
+    .resolve("target")
+    .resolve("generated-sources")
+    .resolve("protobuf")
+    .resolve("jvm-args.txt")
+
+// Verify the JVM plugin produced the expected output file
+assertThat(expectedGeneratedFile)
+    .exists()
+    .isRegularFile()
+    .content()
+    .containsOnlyOnce("this.should.be.set=if it works\n")
+
+return true

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/AbstractGenerateMojo.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/AbstractGenerateMojo.java
@@ -465,7 +465,8 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    *   <li>{@code version} - the version - required</li>
    *   <li>{@code type} - the artifact type - optional</li>
    *   <li>{@code classifier} - the artifact classifier - optional</li>
-   *   <li>{@code options} - a string of options to pass to the plugin
+   *   <li>{@code options} - a string of options to pass to the plugin. This
+   *       uses the standard {@code protoc} interface for specifying options
    *       - optional.</li>
    *   <li>{@code order} - an integer order to run the plugins in. Defaults
    *       to 100,000. Higher numbers run later than lower numbers.</li>
@@ -479,6 +480,13 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    *       same project. If the plugin is an assembled JAR, then this option is
    *       optional, the {@code Main-Class} manifest entry will be used when
    *       present if this is not provided.</li>
+   *   <li>{@code jvmArgs} - a list of commandline arguments to pass to the
+   *       plugin process - optional.</li>
+   *   <li>{@code jvmConfigArgs} - a list of commandline arguments to configure
+   *       the JVM itself. This is used to control factors such as JIT compilation,
+   *       JVM properties, heap size, etc. Users should leave this as the default
+   *       value (which optimises for short-lived processes) unless they know
+   *       exactly what they are doing - optional.
    * </ul>
    *
    * @since 0.3.0

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/MavenProtocPlugin.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/MavenProtocPlugin.java
@@ -18,6 +18,7 @@ package io.github.ascopes.protobufmavenplugin.plugins;
 
 import io.github.ascopes.protobufmavenplugin.dependencies.DependencyResolutionDepth;
 import io.github.ascopes.protobufmavenplugin.dependencies.MavenArtifact;
+import java.util.List;
 import org.immutables.value.Value.Derived;
 import org.immutables.value.Value.Immutable;
 import org.immutables.value.Value.Modifiable;
@@ -35,12 +36,40 @@ import org.jspecify.annotations.Nullable;
 @Modifiable
 public interface MavenProtocPlugin extends MavenArtifact, ProtocPlugin {
 
+  /**
+   * Get the command line arguments to pass to the JVM.
+   *
+   * <p>This defaults to an empty list.
+   *
+   * @return the list of command line arguments to pass to the JVM.
+   * @since 2.6.0
+   */
+  @Nullable List<String> getJvmArgs();
+
+  /**
+   * The dependency resolution depth.
+   *
+   * <p>This cannot be changed for this type of plugin.
+   *
+   * @return {@code null}, always.
+   */
   @Derived
   @Override
   default @Nullable DependencyResolutionDepth getDependencyResolutionDepth() {
     // We never allow this to be specified for protoc plugins.
     return null;
   }
+
+  /**
+   * Get the arguments to pass to the JVM to configure it.
+   *
+   * <p>Users can use this to control concerns such as heap memory controls,
+   * GC and JIT settings, and specifying additional JVM options.
+   *
+   * @return the list of command line arguments to pass to the JVM.
+   * @since 2.6.0
+   */
+  @Nullable List<String> getJvmConfigArgs();
 
   /**
    * The main class entrypoint to use if the plugin is not an assembled JAR.


### PR DESCRIPTION
Adds two new attributes to the `jvmMavenPlugin` option:

- `jvmArgs` - a list of command line arguments
- `jvmConfigArgs` - a list of JVM arguments (such as `-Xmx300m` or `-Dfoo.bar=baz`).

Closes GH-397.