### PR TITLE
Tweak UsesSystemProperties.java

### DIFF
--- a/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/fixtures/UsesSystemProperties.java
+++ b/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/fixtures/UsesSystemProperties.java
@@ -51,7 +51,7 @@ public @interface UsesSystemProperties {
   final class UsesSystemPropertiesExtension
       implements BeforeEachCallback, AfterEachCallback {
 
-    private final Logger log = LoggerFactory.getLogger(Extension.class);
+    private final Logger log = LoggerFactory.getLogger(UsesSystemProperties.class);
     private Properties originalProperties;
 
     @Override


### PR DESCRIPTION
- Demote logging to debug level
- Rename inner extension class to be clearer
- Remove self-referential import
- Mark extension as final
- Update JavaDocs
- Unmark field as volatile as it is not synchronized anyway
- Mark annotation as "Inherited"