### PR TITLE
GH-419: Do not complain if generated files already exist

### DIFF
--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/JvmPluginResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/JvmPluginResolver.java
@@ -313,7 +313,7 @@ public final class JvmPluginResolver {
         scriptFile,
         script,
         StandardCharsets.UTF_8,
-        StandardOpenOption.CREATE_NEW
+        StandardOpenOption.CREATE
     );
     FileUtils.makeExecutable(scriptFile);
     return scriptFile;
@@ -340,7 +340,7 @@ public final class JvmPluginResolver {
         scriptFile,
         script.toString(),
         StandardCharsets.ISO_8859_1,
-        StandardOpenOption.CREATE_NEW
+        StandardOpenOption.CREATE
     );
     return scriptFile;
   }
@@ -352,7 +352,7 @@ public final class JvmPluginResolver {
       ArgumentFileBuilder argFileBuilder
   ) throws IOException {
     var argFile = scratchDir.resolve("args.txt");
-    Files.writeString(argFile, argFileBuilder.toString(), charset, StandardOpenOption.CREATE_NEW);
+    Files.writeString(argFile, argFileBuilder.toString(), charset, StandardOpenOption.CREATE);
     return argFile;
   }
 


### PR DESCRIPTION
Allow overwriting existing generated files to temporarily work around a bug.

Currently, if you reuse the same plugin in multiple executions, the same generated files are created in the same path. The plugin is configured to fail if the file already exists. I have turned that failure flag off for now to attempt to unblock existing builds while a better solution is implemented.