### PR TITLE
GH-421: Ensure temporary spaces and plugin scratches cannot collide

### DIFF
--- a/protobuf-maven-plugin/src/it/gh-134-multiple-artifact-versions/test.groovy
+++ b/protobuf-maven-plugin/src/it/gh-134-multiple-artifact-versions/test.groovy
@@ -26,6 +26,8 @@ Path dependencyDirectory = baseDirectory
     .resolve("some-project")
     .resolve("target")
     .resolve("protobuf-maven-plugin")
+    .resolve("generate")
+    .resolve("default")
     .resolve("archives")
 
 assertThat(dependencyDirectory).isDirectory()

--- a/protobuf-maven-plugin/src/it/gh-135-compile-dependencies/test.groovy
+++ b/protobuf-maven-plugin/src/it/gh-135-compile-dependencies/test.groovy
@@ -26,6 +26,8 @@ Path dependencyDirectory = baseDirectory
     .resolve("some-project")
     .resolve("target")
     .resolve("protobuf-maven-plugin")
+    .resolve("generate")
+    .resolve("default")
     .resolve("archives")
 
 assertThat(dependencyDirectory).isDirectory()

--- a/protobuf-maven-plugin/src/it/gh-302-runtime-scope-direct-resolution/test.groovy
+++ b/protobuf-maven-plugin/src/it/gh-302-runtime-scope-direct-resolution/test.groovy
@@ -20,29 +20,45 @@ import java.nio.file.Path
 
 import static org.assertj.core.api.Assertions.assertThat
 
-static Path resolve(Path path, String... bits) {
-  for (String bit : bits) {
-    path = path.resolve(bit)
-  }
-  return path
-}
-
 Path baseDirectory = basedir.toPath().toAbsolutePath()
-Path runtimeDependencyTargetDir = resolve(baseDirectory,"runtime-dependency", "target")
-Path projectTargetDir = resolve(baseDirectory, "project", "target")
+Path runtimeDependencyTargetDir = baseDirectory
+    .resolve("runtime-dependency")
+    .resolve("target")
+Path projectTargetDir = baseDirectory
+    .resolve("project")
+    .resolve("target")
 
 /////////////////////////////////////////////////////////
-// `transitive-runtime-dependency' output expectations //
+// `runtime-dependency' output expectations //
 /////////////////////////////////////////////////////////
+
+Path runtimeDependenciesRuntimeClass = runtimeDependencyTargetDir
+    .resolve("classes")
+    .resolve("org")
+    .resolve("example")
+    .resolve("runtime")
+    .resolve("Runtime.class")
+Path runtimeDependenciesRuntimeProto = runtimeDependencyTargetDir
+    .resolve("classes")
+    .resolve("org")
+    .resolve("example")
+    .resolve("runtime")
+    .resolve("runtime.proto")
 
 assertThat(runtimeDependencyTargetDir).isDirectory()
-assertThat(resolve(runtimeDependencyTargetDir,"classes", "org", "example", "runtime", "Runtime.class"))
+assertThat(runtimeDependenciesRuntimeClass)
     .isRegularFile()
-assertThat(resolve(runtimeDependencyTargetDir,"classes", "org", "example", "runtime", "runtime.proto"))
+assertThat(runtimeDependenciesRuntimeProto)
     .isRegularFile()
 
 // Compile dependencies are included in the archives directory.
-assertThat(Files.list(resolve(runtimeDependencyTargetDir, "protobuf-maven-plugin", "archives")))
+Path runtimeDependenciesArchivesDir = runtimeDependencyTargetDir
+    .resolve("protobuf-maven-plugin")
+    .resolve("generate")
+    .resolve("default")
+    .resolve("archives")
+
+assertThat(Files.list(runtimeDependenciesArchivesDir))
     .withFailMessage { "Expected protobuf-java-* directory to be present" }
     .filteredOn { it.getFileName().toString().startsWith("protobuf-java-") }
     .hasSize(1)
@@ -51,19 +67,38 @@ assertThat(Files.list(resolve(runtimeDependencyTargetDir, "protobuf-maven-plugin
 // `project' output expectations //
 ///////////////////////////////////
 
+Path projectTargetCompilerClass = projectTargetDir
+    .resolve("classes")
+    .resolve("org")
+    .resolve("example")
+    .resolve("compiler")
+    .resolve("Compiler.class")
+Path projectTargetCompilerProto = projectTargetDir
+    .resolve("classes")
+    .resolve("org")
+    .resolve("example")
+    .resolve("compiler")
+    .resolve("compiler.proto")
+
 assertThat(projectTargetDir).isDirectory()
-assertThat(resolve(projectTargetDir,"classes", "org", "example", "compiler", "Compiler.class"))
+assertThat(projectTargetCompilerClass)
     .isRegularFile()
-assertThat(resolve(projectTargetDir,"classes", "org", "example", "compiler", "compiler.proto"))
+assertThat(projectTargetCompilerProto)
     .isRegularFile()
 
 // Compile dependencies are included in the archives directory.
-assertThat(Files.list(resolve(projectTargetDir,"protobuf-maven-plugin", "archives")))
+Path projectTargetDirArchives = projectTargetDir
+    .resolve("protobuf-maven-plugin")
+    .resolve("generate")
+    .resolve("default")
+    .resolve("archives")
+
+assertThat(Files.list(projectTargetDirArchives))
     .filteredOn { it.getFileName().toString().startsWith("protobuf-java-") }
     .isNotEmpty()
 
 // Transitive runtime dependencies are not included in the archives directory.
-assertThat(Files.list(resolve(projectTargetDir,"protobuf-maven-plugin", "archives")))
+assertThat(Files.list(projectTargetDirArchives))
     .withFailMessage {
       "Expected runtime-dependency-* directory to not be present, this means " +
           "direct runtime dependencies are being included erroneously!"

--- a/protobuf-maven-plugin/src/it/gh-302-runtime-scope-transitive-resolution/test.groovy
+++ b/protobuf-maven-plugin/src/it/gh-302-runtime-scope-transitive-resolution/test.groovy
@@ -20,29 +20,45 @@ import java.nio.file.Path
 
 import static org.assertj.core.api.Assertions.assertThat
 
-static Path resolve(Path path, String... bits) {
-  for (String bit : bits) {
-    path = path.resolve(bit)
-  }
-  return path
-}
-
 Path baseDirectory = basedir.toPath().toAbsolutePath()
-Path transitiveRuntimeDependencyTargetDir = resolve(baseDirectory,"transitive-runtime-dependency", "target")
-Path projectTargetDir = resolve(baseDirectory, "project", "target")
+Path transitiveRuntimeDependencyTargetDir = baseDirectory
+    .resolve("transitive-runtime-dependency")
+    .resolve("target")
+Path projectTargetDir = baseDirectory
+    .resolve("project")
+    .resolve("target")
 
 /////////////////////////////////////////////////////////
 // `transitive-runtime-dependency' output expectations //
 /////////////////////////////////////////////////////////
 
+Path transitiveRuntimeDependenciesRuntimeClass = transitiveRuntimeDependencyTargetDir
+    .resolve("classes")
+    .resolve("org")
+    .resolve("example")
+    .resolve("runtime")
+    .resolve("Runtime.class")
+Path transitiveRuntimeDependenciesRuntimeProto = transitiveRuntimeDependencyTargetDir
+    .resolve("classes")
+    .resolve("org")
+    .resolve("example")
+    .resolve("runtime")
+    .resolve("runtime.proto")
+
 assertThat(transitiveRuntimeDependencyTargetDir).isDirectory()
-assertThat(resolve(transitiveRuntimeDependencyTargetDir, "classes", "org", "example", "runtime", "Runtime.class"))
+assertThat(transitiveRuntimeDependenciesRuntimeClass)
     .isRegularFile()
-assertThat(resolve(transitiveRuntimeDependencyTargetDir, "classes", "org", "example", "runtime", "runtime.proto"))
+assertThat(transitiveRuntimeDependenciesRuntimeProto)
     .isRegularFile()
 
 // Compile dependencies are included in the archives directory.
-assertThat(Files.list(resolve(transitiveRuntimeDependencyTargetDir, "protobuf-maven-plugin", "archives")))
+Path transitiveRuntimeDependenciesArchivesDir = transitiveRuntimeDependencyTargetDir
+    .resolve("protobuf-maven-plugin")
+    .resolve("generate")
+    .resolve("default")
+    .resolve("archives")
+
+assertThat(Files.list(transitiveRuntimeDependenciesArchivesDir))
     .withFailMessage { "Expected protobuf-java-* directory to be present" }
     .filteredOn { it.getFileName().toString().startsWith("protobuf-java-") }
     .hasSize(1)
@@ -51,19 +67,38 @@ assertThat(Files.list(resolve(transitiveRuntimeDependencyTargetDir, "protobuf-ma
 // `project' output expectations //
 ///////////////////////////////////
 
+Path projectTargetCompilerClass = projectTargetDir
+    .resolve("classes")
+    .resolve("org")
+    .resolve("example")
+    .resolve("compiler")
+    .resolve("Compiler.class")
+Path projectTargetCompilerProto = projectTargetDir
+    .resolve("classes")
+    .resolve("org")
+    .resolve("example")
+    .resolve("compiler")
+    .resolve("compiler.proto")
+
 assertThat(projectTargetDir).isDirectory()
-assertThat(resolve(projectTargetDir, "classes", "org", "example", "compiler", "Compiler.class"))
+assertThat(projectTargetCompilerClass)
     .isRegularFile()
-assertThat(resolve(projectTargetDir, "classes", "org", "example", "compiler", "compiler.proto"))
+assertThat(projectTargetCompilerProto)
     .isRegularFile()
 
 // Compile dependencies are included in the archives directory.
-assertThat(Files.list(resolve(projectTargetDir, "protobuf-maven-plugin", "archives")))
+Path projectTargetDirArchives = projectTargetDir
+    .resolve("protobuf-maven-plugin")
+    .resolve("generate")
+    .resolve("default")
+    .resolve("archives")
+
+assertThat(Files.list(projectTargetDirArchives))
     .filteredOn { it.getFileName().toString().startsWith("protobuf-java-") }
     .isNotEmpty()
 
 // Transitive runtime dependencies are not included in the archives directory.
-assertThat(Files.list(resolve(projectTargetDir, "protobuf-maven-plugin", "archives")))
+assertThat(Files.list(projectTargetDirArchives))
     .withFailMessage {
       "Expected transitive-runtime-dependency-* directory to not be present, this means " +
           "transitive runtime dependencies are being included erroneously!"

--- a/protobuf-maven-plugin/src/it/gh-359-modular-jar-plugin/test.groovy
+++ b/protobuf-maven-plugin/src/it/gh-359-modular-jar-plugin/test.groovy
@@ -34,6 +34,8 @@ Path expectedGeneratedFile = baseProjectDir.resolve("some-project")
 Path expectedScriptsDirectory = baseProjectDir.resolve("some-project")
     .resolve("target")
     .resolve("protobuf-maven-plugin")
+    .resolve("generate")
+    .resolve("default")
     .resolve("plugins")
     .resolve("jvm")
 

--- a/protobuf-maven-plugin/src/it/test-dependency-resolution/test.groovy
+++ b/protobuf-maven-plugin/src/it/test-dependency-resolution/test.groovy
@@ -41,7 +41,7 @@ assertThat(resolve(testDependencyTargetDir, "classes", "org", "example", "test",
     .isRegularFile()
 assertThat(resolve(testDependencyTargetDir, "classes", "org", "example", "test", "test.proto"))
     .isRegularFile()
-assertThat(Files.list(resolve(testDependencyTargetDir, "protobuf-maven-plugin", "archives")))
+assertThat(Files.list(resolve(testDependencyTargetDir, "protobuf-maven-plugin", "generate", "default", "archives")))
     .withFailMessage { "Expected protobuf-java-* directory to be present" }
     .filteredOn { it.getFileName().toString().startsWith("protobuf-java-") }
     .hasSize(1)
@@ -55,12 +55,12 @@ assertThat(resolve(testProjectTargetDir, "test-classes", "org", "example", "comp
     .isRegularFile()
 assertThat(resolve(testProjectTargetDir, "test-classes", "org", "example", "compiler", "compiler.proto"))
     .isRegularFile()
-assertThat(Files.list(resolve(testProjectTargetDir, "protobuf-maven-plugin", "archives")))
+assertThat(Files.list(resolve(testProjectTargetDir, "protobuf-maven-plugin", "generate-test", "default", "archives")))
     .withFailMessage { "Expected protobuf-java-* directory to be present" }
     .filteredOn { it.getFileName().toString().startsWith("protobuf-java-") }
     .hasSize(1)
 // We should include test sources in the test goal execution.
-assertThat(Files.list(resolve(testProjectTargetDir, "protobuf-maven-plugin", "archives")))
+assertThat(Files.list(resolve(testProjectTargetDir, "protobuf-maven-plugin", "generate-test", "default", "archives")))
     .withFailMessage { "Expected test-dependency-* directory to be present" }
     .filteredOn { it.getFileName().toString().startsWith("test-dependency-") }
     .hasSize(1)
@@ -74,12 +74,12 @@ assertThat(resolve(mainProjectTargetDir,"classes", "org", "example", "compiler",
     .isRegularFile()
 assertThat(resolve(mainProjectTargetDir,"classes", "org", "example", "compiler", "compiler.proto"))
     .isRegularFile()
-assertThat(Files.list(resolve(mainProjectTargetDir, "protobuf-maven-plugin", "archives")))
+assertThat(Files.list(resolve(mainProjectTargetDir, "protobuf-maven-plugin", "generate", "default", "archives")))
     .withFailMessage { "Expected protobuf-java-* directory to be present" }
     .filteredOn { it.getFileName().toString().startsWith("protobuf-java-") }
     .hasSize(1)
 // We should exclude test sources in the main goal execution.
-assertThat(Files.list(resolve(mainProjectTargetDir, "protobuf-maven-plugin", "archives")))
+assertThat(Files.list(resolve(mainProjectTargetDir, "protobuf-maven-plugin", "generate", "default", "archives")))
     .withFailMessage { "Expected test-dependency-* directory to not be present" }
     .filteredOn { it.getFileName().toString().startsWith("test-dependency-") }
     .isEmpty()

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generation/TemporarySpace.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generation/TemporarySpace.java
@@ -22,6 +22,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import javax.inject.Inject;
 import javax.inject.Named;
+import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.project.MavenProject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,14 +39,22 @@ public final class TemporarySpace {
   private static final Logger log = LoggerFactory.getLogger(TemporarySpace.class);
 
   private final MavenProject mavenProject;
+  private final MojoExecution mojoExecution;
 
   @Inject
-  public TemporarySpace(MavenProject mavenProject) {
+  public TemporarySpace(MavenProject mavenProject, MojoExecution mojoExecution) {
     this.mavenProject = mavenProject;
+    this.mojoExecution = mojoExecution;
   }
 
   public Path createTemporarySpace(String... bits) {
-    var dir = Path.of(mavenProject.getBuild().getDirectory()).resolve(FRAG);
+    var dir = Path.of(mavenProject.getBuild().getDirectory())
+        .resolve(FRAG)
+        // GH-421: Include the execution ID and goal to keep file paths unique
+        // between invocations in multiple goals.
+        .resolve(mojoExecution.getGoal())
+        .resolve(mojoExecution.getExecutionId());
+
     for (var bit : bits) {
       dir = dir.resolve(bit);
     }


### PR DESCRIPTION
- Temporary spaces are now scoped to the current goal and execution ID.
- JVM plugin hashes now include an increasing index to prevent duplicate plugins in the same execution overwriting the same files in the scratch space.

Fixes GH-421.