### PR TITLE
Retain stacktrace for MultipleFailuresException

### DIFF
--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/utils/MultipleFailuresException.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/utils/MultipleFailuresException.java
@@ -28,7 +28,7 @@ import java.util.NoSuchElementException;
 final class MultipleFailuresException extends RuntimeException {
 
   private MultipleFailuresException(String message, Throwable cause) {
-    super(message, cause, true, false);
+    super(message, cause);
   }
 
   /**

--- a/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/utils/MultipleFailuresExceptionTest.java
+++ b/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/utils/MultipleFailuresExceptionTest.java
@@ -47,21 +47,6 @@ class MultipleFailuresExceptionTest {
     assertThat(exception).hasMessage("Multiple failures occurred");
   }
 
-  @DisplayName("The exception has no stack trace")
-  @Test
-  void exceptionHasNoStackTrace() {
-    // Given
-    var cause = new Exception("blahblah");
-
-    // When
-    var exception = MultipleFailuresException.create(List.of(cause));
-
-    // Then
-    assertThat(exception.getStackTrace())
-        .as("stack trace")
-        .isNullOrEmpty();
-  }
-
   @DisplayName("The first exception is treated as the cause")
   @ValueSource(ints = {1, 5, 10})
   @ParameterizedTest(name = "for {0} exception(s)")


### PR DESCRIPTION
This will produce clearer stacktraces.