### PR TITLE
Improve MultipleFailureException message to include first cause

### DIFF
--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/utils/MultipleFailuresException.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/utils/MultipleFailuresException.java
@@ -40,7 +40,13 @@ final class MultipleFailuresException extends RuntimeException {
    */
   static MultipleFailuresException create(List<? extends Throwable> exceptions) {
     var causeIterator = exceptions.iterator();
-    var ex = new MultipleFailuresException("Multiple failures occurred", causeIterator.next());
+    var cause = causeIterator.next();
+    var message = causeIterator.hasNext()
+        ? exceptions.size() + " failures occurred during a concurrent task. The first was: "
+        : "A failure occured during a concurrent task: ";
+    message += cause.getClass().getName() + ": " + cause.getMessage();
+
+    var ex = new MultipleFailuresException(message, cause);
     causeIterator.forEachRemaining(ex::addSuppressed);
     return ex;
   }


### PR DESCRIPTION
This further improves error reporting to provide more details out of the box when users report issues.