### PR TITLE
Reduce log noise for large numbers of protoc sources

### DIFF
--- a/protobuf-maven-plugin/src/it/gh-277-plugin-ordering/invoker.properties
+++ b/protobuf-maven-plugin/src/it/gh-277-plugin-ordering/invoker.properties
@@ -14,4 +14,5 @@
 # limitations under the License.
 #
 
-invoker.goals = clean package
+# Use trace log level to see the order the arguments are printed in.
+invoker.goals = clean package -Dorg.slf4j.simpleLogger.log.io.github.ascopes.protobufmavenplugin=trace

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/protoc/CommandLineExecutor.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/protoc/CommandLineExecutor.java
@@ -45,7 +45,13 @@ public final class CommandLineExecutor {
 
   public boolean execute(List<String> args) throws IOException {
     log.info("Invoking protoc");
-    log.debug("Protoc invocation will occur with the following arguments: {}", args);
+
+    // Note that this order and format matters... we use it in a couple of the integration tests
+    // to verify the build ordering.
+    log.debug("Protoc invocation will occur with the following arguments:");
+    args.stream()
+        .map(" ".repeat(4)::concat)
+        .forEach(log::debug);
 
     var procBuilder = new ProcessBuilder(args);
     procBuilder.environment().putAll(System.getenv());

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/protoc/CommandLineExecutor.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/protoc/CommandLineExecutor.java
@@ -44,7 +44,8 @@ public final class CommandLineExecutor {
   }
 
   public boolean execute(List<String> args) throws IOException {
-    reportInvocation(args);
+    log.info("Invoking protoc");
+    log.debug("Protoc invocation will occur with the following arguments: {}", args);
 
     var procBuilder = new ProcessBuilder(args);
     procBuilder.environment().putAll(System.getenv());
@@ -57,14 +58,6 @@ public final class CommandLineExecutor {
       newEx.initCause(ex);
       throw newEx;
     }
-  }
-
-  private void reportInvocation(List<String> args) {
-    log.info("Calling protoc with the following arguments:");
-    args.stream()
-        .map("  "::concat)
-        .map(String::stripTrailing)
-        .forEach(log::info);
   }
 
   private boolean run(ProcessBuilder procBuilder) throws InterruptedException, IOException {


### PR DESCRIPTION
- Reduce the argline log entry to be a debug log rather than info.
- Log a simple 'invoking protoc' message as info instead.