### PR TITLE
GH-438: Change unique name digest generation for archives to use full URIs

### DIFF
--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/sources/ProtoSourceResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/sources/ProtoSourceResolver.java
@@ -179,7 +179,9 @@ public final class ProtoSourceResolver {
   }
 
   private String generateUniqueName(Path path) {
-    var digest = Digests.sha1(path.toAbsolutePath().toString());
+    // Use a URI here as the URI will correctly encapsulate archives within archives. Paths may have
+    // name collisions between archives using the same relative file paths internally.
+    var digest = Digests.sha1(FileUtils.normalize(path).toUri().toASCIIString());
     return FileUtils.getFileNameWithoutExtension(path) + "-" + digest;
   }
 }


### PR DESCRIPTION
Currently we use absolute paths to generate unique names for archives to avoid name collision, but since we now support resolution of archives internally and recursively as part of optimisations for GH-438, there is now a potential edge case where an archive within an archive can collide with a different file tree by reusing the same name in a legal context.

Switching to using URIs to generate the digests reduces this risk, as URIs encapsulate the full source of the file tree recursively.