### PR TITLE
GH-438: Rename components to be clearer for their intention

### DIFF
--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generation/ProtobufBuildOrchestrator.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generation/ProtobufBuildOrchestrator.java
@@ -52,9 +52,9 @@ import org.slf4j.LoggerFactory;
  * @author Ashley Scopes
  */
 @Named
-public final class SourceCodeGenerator {
+public final class ProtobufBuildOrchestrator {
 
-  private static final Logger log = LoggerFactory.getLogger(SourceCodeGenerator.class);
+  private static final Logger log = LoggerFactory.getLogger(ProtobufBuildOrchestrator.class);
 
   private final MavenSession mavenSession;
   private final MavenArtifactPathResolver artifactPathResolver;
@@ -65,7 +65,7 @@ public final class SourceCodeGenerator {
   private final CommandLineExecutor commandLineExecutor;
 
   @Inject
-  public SourceCodeGenerator(
+  public ProtobufBuildOrchestrator(
       MavenSession mavenSession,
       MavenArtifactPathResolver artifactPathResolver,
       ProtocResolver protocResolver,

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generation/SourceRootRegistrar.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generation/SourceRootRegistrar.java
@@ -16,7 +16,7 @@
 
 package io.github.ascopes.protobufmavenplugin.generation;
 
-import io.github.ascopes.protobufmavenplugin.sources.ProtoFileListing;
+import io.github.ascopes.protobufmavenplugin.sources.SourceListing;
 import io.github.ascopes.protobufmavenplugin.utils.FileUtils;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -71,7 +71,7 @@ public final class SourceRootRegistrar {
     sourceRootRegistrar.accept(session.getCurrentProject(), path.toString());
   }
 
-  public void embedListing(MavenSession session, ProtoFileListing listing) throws IOException {
+  public void embedListing(MavenSession session, SourceListing listing) throws IOException {
     log.info("Embedding sources from {} in {} class outputs", listing.getProtoFilesRoot(), this);
     var targetDirectory = classOutputDirectoryGetter.andThen(Path::of)
         .apply(session.getCurrentProject().getBuild());

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/AbstractGenerateMojo.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/AbstractGenerateMojo.java
@@ -25,7 +25,7 @@ import io.github.ascopes.protobufmavenplugin.dependencies.MavenDependencyBean;
 import io.github.ascopes.protobufmavenplugin.dependencies.ResolutionException;
 import io.github.ascopes.protobufmavenplugin.generation.ImmutableGenerationRequest;
 import io.github.ascopes.protobufmavenplugin.generation.Language;
-import io.github.ascopes.protobufmavenplugin.generation.SourceCodeGenerator;
+import io.github.ascopes.protobufmavenplugin.generation.ProtobufBuildOrchestrator;
 import io.github.ascopes.protobufmavenplugin.generation.SourceRootRegistrar;
 import io.github.ascopes.protobufmavenplugin.plugins.MavenProtocPluginBean;
 import io.github.ascopes.protobufmavenplugin.plugins.PathProtocPluginBean;
@@ -76,7 +76,7 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    * The source code generator.
    */
   @Inject
-  SourceCodeGenerator sourceCodeGenerator;
+  ProtobufBuildOrchestrator sourceCodeGenerator;
 
   /**
    * The active Maven project.

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/sources/SourceGlobFilter.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/sources/SourceGlobFilter.java
@@ -26,20 +26,20 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 /**
- * Filter for files.
+ * Filter for source files to allow including and excluding based on glob patterns.
  *
  * @author Ashley Scopes
  */
-public final class ProtoFileFilter {
+public final class SourceGlobFilter {
 
   private final List<PathMatcher> includes;
   private final List<PathMatcher> excludes;
 
-  public ProtoFileFilter() {
+  public SourceGlobFilter() {
     this(List.of(), List.of());
   }
 
-  public ProtoFileFilter(List<String> includes, List<String> excludes) {
+  public SourceGlobFilter(List<String> includes, List<String> excludes) {
     this.includes = compileMatchers(includes);
     this.excludes = compileMatchers(excludes);
   }
@@ -48,7 +48,6 @@ public final class ProtoFileFilter {
     var relativeFile = relativeRoot.relativize(file);
 
     var excluded = !excludes.isEmpty() && excludes.stream().anyMatch(checking(relativeFile));
-
     var notIncluded = !includes.isEmpty() && includes.stream().noneMatch(checking(relativeFile));
 
     if (excluded || notIncluded) {
@@ -59,16 +58,6 @@ public final class ProtoFileFilter {
         && FileUtils.getFileExtension(file)
             .filter(".proto"::equalsIgnoreCase)
             .isPresent();
-  }
-
-  @Override
-  public String toString() {
-    // Used for debug logs only.
-    return "ProtoFileFilter{"
-        + "isProtoFile=true, "
-        + "includes=" + includes + ", "
-        + "excludes=" + excludes
-        + "}";
   }
 
   private static List<PathMatcher> compileMatchers(List<String> patterns) {

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/sources/SourceListing.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/sources/SourceListing.java
@@ -26,7 +26,7 @@ import org.immutables.value.Value.Immutable;
  * @author Ashley Scopes
  */
 @Immutable
-public interface ProtoFileListing {
+public interface SourceListing {
 
   Path getProtoFilesRoot();
 

--- a/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/mojo/AbstractGenerateMojoTestTemplate.java
+++ b/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/mojo/AbstractGenerateMojoTestTemplate.java
@@ -34,7 +34,7 @@ import io.github.ascopes.protobufmavenplugin.dependencies.ResolutionException;
 import io.github.ascopes.protobufmavenplugin.fixtures.UsesSystemProperties;
 import io.github.ascopes.protobufmavenplugin.generation.GenerationRequest;
 import io.github.ascopes.protobufmavenplugin.generation.Language;
-import io.github.ascopes.protobufmavenplugin.generation.SourceCodeGenerator;
+import io.github.ascopes.protobufmavenplugin.generation.ProtobufBuildOrchestrator;
 import io.github.ascopes.protobufmavenplugin.generation.SourceRootRegistrar;
 import io.github.ascopes.protobufmavenplugin.plugins.MavenProtocPluginBean;
 import io.github.ascopes.protobufmavenplugin.plugins.PathProtocPluginBean;
@@ -955,9 +955,9 @@ abstract class AbstractGenerateMojoTestTemplate<A extends AbstractGenerateMojo> 
     return consumer;
   }
 
-  static SourceCodeGenerator sourceCodeGenerator(boolean result) throws Throwable {
+  static ProtobufBuildOrchestrator sourceCodeGenerator(boolean result) throws Throwable {
     var sourceCodeGenerator = mock(
-        SourceCodeGenerator.class,
+        ProtobufBuildOrchestrator.class,
         withSettings().strictness(Strictness.LENIENT)
     );
     when(sourceCodeGenerator.generate(any()))
@@ -965,9 +965,9 @@ abstract class AbstractGenerateMojoTestTemplate<A extends AbstractGenerateMojo> 
     return sourceCodeGenerator;
   }
 
-  static SourceCodeGenerator erroringSourceCodeGenerator(Throwable cause) throws Throwable {
+  static ProtobufBuildOrchestrator erroringSourceCodeGenerator(Throwable cause) throws Throwable {
     var sourceCodeGenerator = mock(
-        SourceCodeGenerator.class,
+        ProtobufBuildOrchestrator.class,
         withSettings().strictness(Strictness.LENIENT)
     );
     when(sourceCodeGenerator.generate(any()))


### PR DESCRIPTION
Tidy up prior to the crux of GH-438's implementation to avoid confusion and ambiguity.

- Rename components relating to proto files to be clear they are operating on source files.
- Rename the SourceCodeGenerator "monolith" to ProtobufBuildOrchestrator, which more accurately describes what this component really does.