### PR TITLE
Correctly mark the concurrent executor as a singleton

### DIFF
--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/utils/ConcurrentExecutor.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/utils/ConcurrentExecutor.java
@@ -38,6 +38,7 @@ import org.slf4j.LoggerFactory;
  * @author Ashley Scopes
  * @since 2.2.0
  */
+@Singleton
 @Named
 public final class ConcurrentExecutor {
 


### PR DESCRIPTION
Correctly mark the concurrent executor as a singleton to avoid excessive thread allocation. Without this, an instance can be allocated per component that depends on this object.