### PR TITLE
Compute source and dependency hashes in parallel for incremental compilation

### DIFF
--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/sources/incremental/IncrementalCacheManager.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/sources/incremental/IncrementalCacheManager.java
@@ -171,26 +171,29 @@ public class IncrementalCacheManager {
   }
 
   private SerializedIncrementalCache buildIncrementalCache(ProjectInputListing listing) {
-    var dependencyDigests = listing.getDependencySources().stream()
-        .map(SourceListing::getSourceProtoFiles)
-        .flatMap(Collection::stream)
-        .map(this::createSerializedFileDigestAsync)
+    // Done this way for now to propagate errors correctly. Probably worth refactoring in the future
+    // to be less of a hack?
+    var results = Stream.of(listing.getDependencySources(), listing.getCompilableSources())
+        .map(this::createSerializedFileDigestsAsync)
         .collect(concurrentExecutor.awaiting())
-        .stream()
-        .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
-
-    var sourceDigests = listing.getCompilableSources().stream()
-        .map(SourceListing::getSourceProtoFiles)
-        .flatMap(Collection::stream)
-        .map(this::createSerializedFileDigestAsync)
-        .collect(concurrentExecutor.awaiting())
-        .stream()
-        .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+        .iterator();
 
     return ImmutableSerializedIncrementalCache.builder()
-        .dependencies(dependencyDigests)
-        .sources(sourceDigests)
+        .dependencies(results.next())
+        .sources(results.next())
         .build();
+  }
+
+  private FutureTask<Map<Path, String>> createSerializedFileDigestsAsync(
+      Collection<SourceListing> listings
+  ) {
+    return concurrentExecutor.submit(() -> listings.stream()
+        .map(SourceListing::getSourceProtoFiles)
+        .flatMap(Collection::stream)
+        .map(this::createSerializedFileDigestAsync)
+        .collect(concurrentExecutor.awaiting())
+        .stream()
+        .collect(Collectors.toMap(Entry::getKey, Entry::getValue)));
   }
 
   private FutureTask<Entry<Path, String>> createSerializedFileDigestAsync(Path file) {

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/sources/incremental/IncrementalCacheManager.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/sources/incremental/IncrementalCacheManager.java
@@ -41,6 +41,7 @@ import java.util.Optional;
 import java.util.concurrent.FutureTask;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.inject.Inject;
 import javax.inject.Named;
 import org.slf4j.Logger;

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/sources/incremental/IncrementalCacheManager.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/sources/incremental/IncrementalCacheManager.java
@@ -34,6 +34,7 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.Collection;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;


### PR DESCRIPTION
A small optimisation for projects that both have a large number of sources and a large number of dependencies.

Rather than computing all dependency hashes and then all source hashes separately, both are now computed at the same time.