### PR TITLE
GH-481: Fix bug where large builds crash on Windows 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,7 @@
     <maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version>
     <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
     <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
+    <maven-dependency-plugin.version>3.8.1</maven-dependency-plugin.version>
     <maven-gpg-plugin.version>3.2.7</maven-gpg-plugin.version>
     <maven-install-plugin.version>3.1.3</maven-install-plugin.version>
     <maven-invoker-plugin.version>3.8.1</maven-invoker-plugin.version>
@@ -321,6 +322,13 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-assembly-plugin</artifactId>
           <version>${maven-assembly-plugin.version}</version>
+        </plugin>
+
+        <plugin>
+          <!-- Used for Mockito agent support in JDK21+. We have to know the JAR path of the dependency. -->
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <version>${maven-dependency-plugin.version}</version>
         </plugin>
 
         <plugin>

--- a/protobuf-maven-plugin/pom.xml
+++ b/protobuf-maven-plugin/pom.xml
@@ -144,6 +144,21 @@
       </plugin>
 
       <plugin>
+        <!-- Used for Mockito agent support in JDK21+. We have to know the JAR path of the dependency. -->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+
+        <executions>
+          <execution>
+            <phase>initialize</phase>
+            <goals>
+              <goal>properties</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
         <!-- Runs integration tests. -->
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-invoker-plugin</artifactId>
@@ -219,6 +234,10 @@
         <!-- Unit testing. -->
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
+
+        <configuration>
+          <argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar}</argLine>
+        </configuration>
       </plugin>
 
       <plugin>

--- a/protobuf-maven-plugin/src/it/gh-481-command-length/invoker.properties
+++ b/protobuf-maven-plugin/src/it/gh-481-command-length/invoker.properties
@@ -1,0 +1,22 @@
+#
+# Copyright (C) 2023 - 2024, Ashley Scopes.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Package twice to trigger incremental compilation on the second run. This
+# allows us to test passing large numbers of files through the incremental compilation
+# cache as well.
+invoker.goals.0 = clean
+invoker.goals.1 = package -Dmaven.jar.skip -Dmaven.test.skip
+invoker.goals.2 = package -Dmaven.jar.skip -Dmaven.test.skip

--- a/protobuf-maven-plugin/src/it/gh-481-command-length/pom.xml
+++ b/protobuf-maven-plugin/src/it/gh-481-command-length/pom.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2023 - 2024, Ashley Scopes.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>@project.groupId@.it</groupId>
+    <artifactId>integration-test-parent</artifactId>
+    <version>@project.version@</version>
+    <relativePath>../setup/pom.xml</relativePath>
+  </parent>
+
+  <groupId>gh-481-command-length</groupId>
+  <artifactId>gh-481-command-length</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+
+        <configuration>
+          <!-- Speed up the builds a little bit -->
+          <debug>false</debug>
+          <fork>true</fork>
+          <meminitial>256</meminitial>
+          <maxmem>256</maxmem>
+          <proc>none</proc>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+
+        <configuration>
+          <incrementalCompilation>true</incrementalCompilation>
+        </configuration>
+
+        <executions>
+          <execution>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/protobuf-maven-plugin/src/it/gh-481-command-length/prebuild.groovy
+++ b/protobuf-maven-plugin/src/it/gh-481-command-length/prebuild.groovy
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2023 - 2024, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import groovy.transform.Field
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.Executors
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Future
+
+static final @Field String ALPHA = "abcdefghijklmnopqrstuvwxyz"
+static final @Field String ALPHA_NUMERIC = ALPHA + "0123456789"
+static final @Field String ALPHA_NUMERIC_UNDERSCORE = ALPHA_NUMERIC + "_"
+static final @Field List<String> PROTO_TYPES = [
+    "double", "float", "int32", "int64", "uint32", "uint64", "sint32", "sint64",
+    "fixed32", "fixed64", "sfixed32", "sfixed64", "bool", "string", "bytes",
+]
+
+@Field Random rng = new Random()
+
+int randomInt(int min, int max) {
+  return min + rng.nextInt(max - min)
+}
+
+char randomChar(String dictionary) {
+  return dictionary[rng.nextInt(dictionary.length())]
+}
+
+void addRandomMessageName(Appendable sb) {
+  int length = randomInt(5, 10)
+  sb.append(Character.toUpperCase(randomChar(ALPHA)))
+  for (int i = 1; i < length; ++i) {
+    sb.append(randomChar(ALPHA_NUMERIC))
+  }
+}
+
+void addRandomIdentifier(Appendable sb) {
+  int length = randomInt(5, 10)
+  sb.append(randomChar(ALPHA))
+  for (int i = 1; i < length; ++i) {
+    sb.append(randomChar(ALPHA_NUMERIC_UNDERSCORE))
+  }
+}
+
+void addRandomMessage(Appendable sb) {
+  sb.append("\nmessage ")
+  addRandomMessageName(sb)
+  sb.append(" {\n")
+  int fieldCount = randomInt(1, 5)
+  for (int i = 1; i <= fieldCount; ++i) {
+    sb.append("  ")
+        .append(PROTO_TYPES[rng.nextInt(PROTO_TYPES.size())])
+        .append(" ")
+    addRandomIdentifier(sb)
+    sb.append(" = ")
+        .append(i.toString())
+        .append(";\n")
+  }
+  sb.append("}\n")
+}
+
+void addRandomProtoFile(int index, Appendable sb) {
+  // File header
+  sb.append('syntax = "proto3";\n')
+      .append('option java_multiple_files = true;\n')
+      .append('option java_package = "')
+
+  sb.append("javapackage_").append(index.toString()).append(".")
+  int javaPackageLength = randomInt(1, 5)
+  addRandomIdentifier(sb)
+  for (int i = 1; i < javaPackageLength; ++i) {
+    sb.append(".")
+    addRandomIdentifier(sb)
+  }
+
+  sb.append('";\n\n')
+    .append("package ")
+
+  sb.append("protopackage_").append(index.toString()).append(".")
+  int protoPackageLength = randomInt(1, 5)
+  addRandomIdentifier(sb)
+  for (int i = 1; i < protoPackageLength; ++i) {
+    sb.append(".")
+    addRandomIdentifier(sb)
+  }
+  sb.append(';\n')
+
+  // File contents, one to two messages each.
+  int messageCount = randomInt(1, 2)
+  for (int i = 0; i < messageCount; ++i) {
+    addRandomMessage(sb)
+  }
+}
+
+String randomFileName(int index) {
+  StringBuilder fileName = new StringBuilder()
+  // Ensure the file names remain unique.
+  fileName.append(Character.toUpperCase(randomChar(ALPHA)))
+  int length = randomInt(1, 10)
+  for (int i = 1; i < length; ++i) {
+    fileName.append(randomChar(ALPHA_NUMERIC))
+  }
+  return fileName.append("_${index}.proto").toString()
+}
+
+@SuppressWarnings('GroovyAssignabilityCheck')
+Future<Void> generateRandomFile(int index, Path baseDir, ExecutorService executor) {
+  executor.submit {
+    Path path = baseDir.resolve(randomFileName(index))
+    try (BufferedWriter writer = Files.newBufferedWriter(path, StandardCharsets.UTF_8)) {
+      addRandomProtoFile(index, writer)
+    }
+    return null
+  }
+}
+
+void generateRandomFiles(int count, ExecutorService executor) {
+  println("Generating ${count} random proto files files for this test...")
+  Path baseDir = basedir.toPath().resolve("src").resolve("main").resolve("protobuf")
+  Files.createDirectories(baseDir)
+  List<Future<Void>> futures = []
+  for (int i = 0; i < count; ++i) {
+    futures.add(generateRandomFile(i, baseDir, executor))
+  }
+  for (Future<Void> future : futures) {
+    future.get()
+  }
+}
+
+ExecutorService executor = Executors.newFixedThreadPool(30)
+generateRandomFiles(500, executor)
+executor.shutdown()

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/JvmPluginResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/JvmPluginResolver.java
@@ -34,7 +34,6 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -314,20 +313,27 @@ public final class JvmPluginResolver {
       ArgumentFileBuilder argFileBuilder
   ) throws ResolutionException {
     var sh = pathResolver.resolve("sh").orElseThrow();
-    var argFile = writeArgFile(StandardCharsets.UTF_8, scratchDir, argFileBuilder);
+    var argumentFile = writeArgumentFile(StandardCharsets.UTF_8, scratchDir, argFileBuilder);
 
-    var script = new StringBuilder()
-        .append("#!").append(sh).append('\n')
-        .append("set -o errexit\n");
+    var script = scratchDir.resolve("invoke.sh");
+    try {
+      try (var writer = Files.newBufferedWriter(script, StandardCharsets.UTF_8)) {
+        writer.append("#!").append(sh.toString()).append('\n')
+            .append("set -o errexit\n");
+        quoteShellArg(writer, javaExecutable.toString());
+        writer.append(' ');
+        quoteShellArg(writer, "@" + argumentFile);
+        writer.append('\n');
+      }
 
-    quoteShellArg(script, javaExecutable.toString());
-    script.append(' ');
-    quoteShellArg(script, "@" + argFile);
-    script.append('\n');
-
-    var scriptFile = scratchDir.resolve("invoke.sh");
-    writeFile(scriptFile, script.toString(), StandardCharsets.UTF_8, true);
-    return scriptFile;
+      FileUtils.makeExecutable(script);
+    } catch (IOException ex) {
+      throw new ResolutionException(
+          "Failed to create plugin invocation shell script at " + script + ": an IO error occurred",
+          ex
+      );
+    }
+    return script;
   }
 
   private Path writeWindowsScripts(
@@ -335,88 +341,80 @@ public final class JvmPluginResolver {
       Path scratchDir,
       ArgumentFileBuilder argFileBuilder
   ) throws ResolutionException {
-    var argFile = writeArgFile(StandardCharsets.ISO_8859_1, scratchDir, argFileBuilder);
+    var argumentFile = writeArgumentFile(StandardCharsets.ISO_8859_1, scratchDir, argFileBuilder);
 
-    var script = new StringBuilder()
-        .append("@echo off\r\n");
-
-    quoteBatchArg(script, javaExecutable.toString());
-    script.append(' ');
-    quoteBatchArg(script, "@" + argFile);
-    script.append("\r\n");
-
-    var scriptFile = scratchDir.resolve("invoke.bat");
-    writeFile(scriptFile, script.toString(), StandardCharsets.ISO_8859_1, false);
-    return scriptFile;
-  }
-
-  private Path writeArgFile(
-      Charset charset,
-      Path scratchDir,
-      ArgumentFileBuilder argFileBuilder
-  ) throws ResolutionException {
-    var argFile = scratchDir.resolve("args.txt");
-    writeFile(argFile, argFileBuilder.toString(), charset, false);
-    return argFile;
-  }
-
-  private void writeFile(
-      Path file,
-      String content,
-      Charset charset,
-      boolean makeExecutable
-  ) throws ResolutionException {
-    try {
-      Files.writeString(file, content, charset, StandardOpenOption.CREATE);
-
-      if (makeExecutable) {
-        FileUtils.makeExecutable(file);
-      }
+    var script = scratchDir.resolve("invoke.bat");
+    try (var writer = Files.newBufferedWriter(script, StandardCharsets.ISO_8859_1)) {
+      writer.append("@echo off\r\n");
+      quoteBatchArg(writer, javaExecutable.toString());
+      writer.append(" ");
+      quoteBatchArg(writer, "@" + argumentFile);
+      writer.append("\r\n");
     } catch (IOException ex) {
       throw new ResolutionException(
-          "Failed to write file " + file + ": an unexpected IO error occurred",
+          "Failed to create plugin invocation batch script at " + script + ": an IO error occurred",
           ex
       );
     }
+
+    return script;
   }
 
-  private void quoteShellArg(StringBuilder sb, String arg) {
+  private Path writeArgumentFile(
+      Charset charset,
+      Path scratchDir,
+      ArgumentFileBuilder argumentFileBuilder
+  ) throws ResolutionException {
+    var argumentFile = scratchDir.resolve("args.txt");
+
+    try (var writer = Files.newBufferedWriter(argumentFile, charset)) {
+      argumentFileBuilder.writeTo(writer);
+    } catch (IOException ex) {
+      throw new ResolutionException(
+          "Failed to write argument file at " + argumentFile + ": an IO error occurred",
+          ex
+      );
+    }
+    return argumentFile;
+  }
+
+  private void quoteShellArg(Appendable appendable, String arg) throws IOException {
     // POSIX file names can be a bit more complicated and may need escaping
     // in certain edge cases to remain valid.
-    sb.append('\'');
+    appendable.append('\'');
     for (var i = 0; i < arg.length(); ++i) {
       var c = arg.charAt(i);
       switch (c) {
         case '\\':
-          sb.append("\\\\");
+          appendable.append("\\\\");
           break;
         case '\'':
-          sb.append("'\"'\"'");
+          appendable.append("'\"'\"'");
           break;
         case '\n':
-          sb.append("'$'\\n''");
+          appendable.append("'$'\\n''");
           break;
         case '\r':
-          sb.append("'$'\\r''");
+          appendable.append("'$'\\r''");
           break;
         case '\t':
-          sb.append("'$'\\t''");
+          appendable.append("'$'\\t''");
           break;
         default:
-          sb.append(c);
+          appendable.append(c);
           break;
       }
     }
-    sb.append('\'');
+    appendable.append('\'');
   }
 
-  private void quoteBatchArg(StringBuilder sb, String arg) {
+  private void quoteBatchArg(Appendable appendable, String arg) throws IOException {
     // All the escapable characters in batch files other than quotes
     // are considered to be illegal characters in Windows file names,
     // so we can make the assumption that we don't need to change much
     // here.
-    sb.append('"')
+    appendable.append("\"")
         .append(arg.replaceAll("\"", "\"\"\""))
-        .append('"');
+        .append("\"");
   }
 }

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/JvmPluginResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/JvmPluginResolver.java
@@ -317,8 +317,7 @@ public final class JvmPluginResolver {
     var argumentFile = writeArgumentFile(StandardCharsets.UTF_8, scratchDir, argFileBuilder);
 
     var script = scratchDir.resolve("invoke.sh");
-
-    writeAndPropagateExceptions(argumentFile, StandardCharsets.UTF_8, true, writer -> {
+    writeAndPropagateExceptions(script, StandardCharsets.UTF_8, true, writer -> {
       writer.append("#!")
           .append(sh.toString())
           .append('\n')
@@ -340,8 +339,7 @@ public final class JvmPluginResolver {
     var argumentFile = writeArgumentFile(StandardCharsets.ISO_8859_1, scratchDir, argFileBuilder);
 
     var script = scratchDir.resolve("invoke.bat");
-
-    writeAndPropagateExceptions(argumentFile, StandardCharsets.ISO_8859_1, false, writer -> {
+    writeAndPropagateExceptions(script, StandardCharsets.ISO_8859_1, false, writer -> {
       writer.append("@echo off\r\n");
       quoteBatchArg(writer, javaExecutable.toString());
       writer.append(" ");

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/utils/ArgumentFileBuilder.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/utils/ArgumentFileBuilder.java
@@ -16,6 +16,7 @@
 
 package io.github.ascopes.protobufmavenplugin.utils;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -42,46 +43,41 @@ public final class ArgumentFileBuilder {
     return this;
   }
 
-  @Override
-  public String toString() {
-    var sb = new StringBuilder();
-
+  public void writeTo(Appendable appendable) throws IOException {
     for (var argument : arguments) {
       if (argument.chars().noneMatch(c -> " \n\r\t'\"".indexOf(c) >= 0)) {
-        sb.append(argument).append("\n");
+        appendable.append(argument).append("\n");
         continue;
       }
 
-      sb.append('"');
+      appendable.append('"');
       for (var i = 0; i < argument.length(); ++i) {
         var nextChar = argument.charAt(i);
         switch (nextChar) {
           case '"':
-            sb.append("\\\"");
+            appendable.append("\\\"");
             break;
           case '\'':
-            sb.append("\\'");
+            appendable.append("\\'");
             break;
           case '\\':
-            sb.append("\\\\");
+            appendable.append("\\\\");
             break;
           case '\n':
-            sb.append("\\n");
+            appendable.append("\\n");
             break;
           case '\r':
-            sb.append("\\r");
+            appendable.append("\\r");
             break;
           case '\t':
-            sb.append("\\t");
+            appendable.append("\\t");
             break;
           default:
-            sb.append(nextChar);
+            appendable.append(nextChar);
             break;
         }
       }
-      sb.append("\"\n");
+      appendable.append("\"\n");
     }
-
-    return sb.toString();
   }
 }

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/utils/TeeWriter.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/utils/TeeWriter.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2023 - 2024, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.ascopes.protobufmavenplugin.utils;
+
+import java.io.IOException;
+import java.io.Writer;
+
+/**
+ * A writer that also writes to an in-memory buffer to enable the content to be replayed.
+ *
+ * @author Ashley Scopes
+ * @since 2.7.3
+ */
+public final class TeeWriter extends Writer {
+
+  private final StringBuilder stringBuilder;
+  private final Writer writer;
+
+  public TeeWriter(Writer writer) {
+    stringBuilder = new StringBuilder();
+    this.writer = writer;
+  }
+
+  @Override
+  public void close() throws IOException {
+    writer.close();
+  }
+
+  @Override
+  public void flush() throws IOException {
+    writer.flush();
+  }
+
+  @Override
+  public String toString() {
+    return stringBuilder.toString();
+  }
+
+  @Override
+  public void write(char[] buffer, int offset, int length) throws IOException {
+    writer.write(buffer, offset, length);
+    stringBuilder.append(buffer, offset, length);
+  }
+}

--- a/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/utils/ArgumentFileBuilderTest.java
+++ b/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/utils/ArgumentFileBuilderTest.java
@@ -19,6 +19,7 @@ package io.github.ascopes.protobufmavenplugin.utils;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
@@ -35,7 +36,7 @@ class ArgumentFileBuilderTest {
   void argumentsAreConvertedToStringArgumentFileInExpectedFormat(
       List<Object> givenArguments,
       String expectedResult
-  ) {
+  ) throws IOException  {
     // Given
     var builder = new ArgumentFileBuilder();
 
@@ -44,10 +45,11 @@ class ArgumentFileBuilderTest {
       builder.add(argument);
     }
 
-    var actualResult = builder.toString();
+    var actualResult = new StringBuilder();
+    builder.writeTo(actualResult);
 
     // Then
-    assertThat(actualResult).isEqualTo(expectedResult);
+    assertThat(actualResult).asString().isEqualTo(expectedResult);
   }
 
   static Stream<Arguments> argumentFileCases() {

--- a/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/utils/TeeWriterTest.java
+++ b/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/utils/TeeWriterTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2023 - 2024, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.ascopes.protobufmavenplugin.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+@DisplayName("TeeWriter tests")
+class TeeWriterTest {
+
+  @DisplayName("The expected content is written to the file")
+  @Test
+  void expectedContentWrittenToFile(@TempDir Path tempDir) throws IOException {
+    // Given
+    var text = Stream.generate(UUID::randomUUID)
+        .map(UUID::toString)
+        .limit(10)
+        .collect(Collectors.joining("\n"));
+    var file = tempDir.resolve(UUID.randomUUID() + ".txt");
+
+    // When
+    try (var writer = new TeeWriter(Files.newBufferedWriter(file, StandardCharsets.UTF_8))) {
+      writer.append(text);
+    }
+
+    // Then
+    assertThat(file).hasContent(text);
+  }
+
+  @DisplayName("The expected content is written to the buffer")
+  @Test
+  void expectedContentWrittenToBuffer(@TempDir Path tempDir) throws IOException {
+    // Given
+    var text = Stream.generate(UUID::randomUUID)
+        .map(UUID::toString)
+        .limit(10)
+        .collect(Collectors.joining("\n"));
+    var file = tempDir.resolve(UUID.randomUUID().toString() + ".txt");
+
+    // When
+    var writer = new TeeWriter(Files.newBufferedWriter(file, StandardCharsets.UTF_8));
+    try (writer) {
+      writer.append(text);
+    }
+
+    // Then
+    assertThat(writer).asString().isEqualTo(text);
+  }
+
+  @DisplayName(".close() closes the underlying writer")
+  @Test
+  void closeClosesWriter() throws IOException {
+    // Given
+    var innerWriter = mock(Writer.class);
+    var writer = new TeeWriter(innerWriter);
+
+    // When
+    writer.close();
+
+    // Then
+    verify(innerWriter).close();
+    verifyNoMoreInteractions(innerWriter);
+  }
+
+  @DisplayName(".flush() flushes the underlying writer")
+  @Test
+  void flushFlushesWriter() throws IOException {
+    // Given
+    var innerWriter = mock(Writer.class);
+    var writer = new TeeWriter(innerWriter);
+
+    // When
+    writer.flush();
+
+    // Then
+    verify(innerWriter).flush();
+    verifyNoMoreInteractions(innerWriter);
+  }
+}


### PR DESCRIPTION
This change implements the argument file mechanism for protoc
command line flags, like we do already for Java invocations. This
helps avoid build failures on Windows when a large number of files
are being generated, since Windows has somewhat esoteric limits
on the command line length. Offloading this to a file works around
this constraint.

A reproduction of the issue for Windows is also included in the test
pack, which generates a large number of random protobuf sources on
each build and feeds them into the Maven plugin.

<small>A fix for Mockito has also been included in this change to squelch
warnings about agent attachments that I was encountering on Java 21
builds.</small>

Fixes GH-481.