### PR TITLE
Enable incremental compilation by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ A scratch-built and modern Maven plugin for seamless protoc integration, with su
 - Additional support for generating sources targeting C++, C#, Objective C, Python (including optional static typechecking stubs),
   PHP, Ruby, and Rust.
 - Aims to keep builds reproducible and easily debuggable where possible.
-- Incremental compilation (experimental).
+- Incremental compilation.
 
 ## Usage
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>io.github.ascopes</groupId>
   <artifactId>protobuf-maven-plugin-parent</artifactId>
-  <version>2.7.4-SNAPSHOT</version>
+  <version>2.8.0-SNAPSHOT</version>
 
   <name>Protobuf Maven Plugin Parent</name>
   <description>Parent POM for the Protobuf Maven Plugin.</description>

--- a/protobuf-maven-plugin/pom.xml
+++ b/protobuf-maven-plugin/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes</groupId>
     <artifactId>protobuf-maven-plugin-parent</artifactId>
-    <version>2.7.4-SNAPSHOT</version>
+    <version>2.8.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>protobuf-maven-plugin</artifactId>

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/AbstractGenerateMojo.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/AbstractGenerateMojo.java
@@ -432,20 +432,13 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
   /**
    * Whether to enable "incremental" compilation.
    *
-   * <p>When enabled, this plugin will track changes to sources and importable protobuf 
-   * dependencies between builds, making a best-effort attempt to only rebuild files that
-   * have changed since the last build. This will reduce the time that large projects take
-   * to build when repeatedly rebuilt during development.
-   *
-   * <p><strong>Warning:</strong> this is highly experimental, and may change or be removed
-   * in a future release.
-   *
-   * <p>By default, this is set to {@code false}, although it may be changed to {@code true}
-   * eventually.
+   * <p>When enabled, this plugin will track changes to sources and importable protobuf
+   * dependencies between builds, making a best-effort attempt to only rebuild files when
+   * changes have been made since the last build.
    *
    * @since 2.7.0
    */
-  @Parameter(defaultValue = DEFAULT_FALSE, property = PROTOBUF_COMPILER_INCREMENTAL)
+  @Parameter(defaultValue = DEFAULT_TRUE, property = PROTOBUF_COMPILER_INCREMENTAL)
   boolean incrementalCompilation;
 
   /**

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/AbstractGenerateMojo.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/AbstractGenerateMojo.java
@@ -771,12 +771,6 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
       return;
     }
 
-    if (incrementalCompilation) {
-      // TODO(ascopes): remove this warning once we're happy with the stability.
-      log.warn("You have enabled incremental compilation. This is highly experimental and subject "
-          + "to change between minor versions. Please report any bugs you encounter on GitHub.");
-    }
-
     var enabledLanguages = Language.languageSet()
         .addIf(cppEnabled, Language.CPP)
         .addIf(csharpEnabled, Language.C_SHARP)

--- a/protobuf-maven-plugin/src/site/markdown/faster-builds.md
+++ b/protobuf-maven-plugin/src/site/markdown/faster-builds.md
@@ -5,30 +5,11 @@ around this, there are a few things you can do.
 
 ## Incremental compilation
 
-By default, this plugin will regenerate all protobuf sources each time it runs.
-This is usually fine, but may slow builds down if you are rebuilding a lot or
-have a large number of `*.proto` files.
+As of v2.7.0, an incremental compilation feature has been added that enables the
+plugin to detect whether sources and dependencies have changed since the last build.
+If sources and dependencies have not changed, then `protoc` will not be re-invoked.
 
-As of v2.7.0, an experimental incremental compilation feature has been added that
-enables the plugin to detect whether sources and dependencies have changed since
-the last build. If sources and dependencies have not changed, then `protoc` will
-not be re-invoked. Likewise, if only a subset of sources have changed, then only
-those sources will be generated again.
-
-To enable this feature, use the following plugin configuration:
-
-```xml
-<configuration>
-  <incrementalCompilation>true</incrementalCompilation>
-</configuration>
-```
-
-You can alternatively set the `protobuf.compiler.incremental` property to `true`
-on the commandline or via the Maven properties.
-
-Remember that this feature is experimental and subject to change in future
-releases. It may not work correctly with custom `protoc` plugins that expect
-all sources to be passed to `protoc` on every single build.
+As of v2.8.0, this feature is enabled by default.
 
 ## Including/excluding file patterns
 

--- a/protobuf-maven-plugin/src/site/markdown/known-issues.md
+++ b/protobuf-maven-plugin/src/site/markdown/known-issues.md
@@ -62,20 +62,6 @@ The workaround for now appears to be to include `plexus-utils` explicitly as a d
 
 - See https://github.com/ascopes/protobuf-maven-plugin/issues/472 for tracking this issue.
 
-## Incremental compilation edge cases
-
-The experimental incremental compilation feature is known to have some edge cases
-where a `mvn clean` is required to rebuild the entire source tree. This is due to
-the somewhat coarse way that changes are monitored between builds. If this becomes
-overly problematic, please raise an issue on GitHub with details of how to reproduce
-the issue you are seeing.
-
-Incremental compilation only currently considers if an entire file has changed. No attempt
-is made to parse a dependency graph of all sources to determine whether a change impacts
-other files. This may be implemented in the future if the performance overhead is
-not too high. For now, it is best to disable incremental compilation, use includes/excludes,
-or perform clean builds if you are actively changing protobuf sources.
-
 ## Descriptor support
 
 Protobuf descriptors are currently unsupported. Please raise an issue on GitHub if you wish


### PR DESCRIPTION
This changes incremental compilation to be more aggressive by forcing a full rebuild if any source files change. This will work around
some of the potential edge cases that currently exist, and allow enabling this feature by default.