### PR TITLE
Add support for proto descriptor options

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>io.github.ascopes</groupId>
   <artifactId>protobuf-maven-plugin-parent</artifactId>
-  <version>2.9.3-SNAPSHOT</version>
+  <version>2.10.0-SNAPSHOT</version>
 
   <name>Protobuf Maven Plugin Parent</name>
   <description>Parent POM for the Protobuf Maven Plugin.</description>

--- a/protobuf-maven-plugin/pom.xml
+++ b/protobuf-maven-plugin/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes</groupId>
     <artifactId>protobuf-maven-plugin-parent</artifactId>
-    <version>2.9.3-SNAPSHOT</version>
+    <version>2.10.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>protobuf-maven-plugin</artifactId>

--- a/protobuf-maven-plugin/src/it/protoc-descriptor-file-options/invoker.properties
+++ b/protobuf-maven-plugin/src/it/protoc-descriptor-file-options/invoker.properties
@@ -1,0 +1,17 @@
+#
+# Copyright (C) 2023 - 2025, Ashley Scopes.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+invoker.goals = clean package

--- a/protobuf-maven-plugin/src/it/protoc-descriptor-file-options/pom.xml
+++ b/protobuf-maven-plugin/src/it/protoc-descriptor-file-options/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2023 - 2025, Ashley Scopes.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>@project.groupId@.it</groupId>
+    <artifactId>integration-test-parent</artifactId>
+    <version>@project.version@</version>
+    <relativePath>../setup/pom.xml</relativePath>
+  </parent>
+
+  <groupId>protoc-descriptor-file-options</groupId>
+  <artifactId>protoc-descriptor-file-options</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <scope>compile</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+
+        <configuration>
+          <javaEnabled>false</javaEnabled>
+          <outputDescriptorFile>${project.build.directory}/protobin.desc</outputDescriptorFile>
+          <outputDescriptorIncludeImports>true</outputDescriptorIncludeImports>
+          <outputDescriptorIncludeSourceInfo>true</outputDescriptorIncludeSourceInfo>
+          <outputDescriptorRetainOptions>true</outputDescriptorRetainOptions>
+        </configuration>
+
+        <executions>
+          <execution>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/protobuf-maven-plugin/src/it/protoc-descriptor-file-options/src/main/protobuf/helloworld.proto
+++ b/protobuf-maven-plugin/src/it/protoc-descriptor-file-options/src/main/protobuf/helloworld.proto
@@ -1,0 +1,27 @@
+//
+// Copyright (C) 2023 - 2025, Ashley Scopes.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "org.example.helloworld";
+
+package org.example.helloworld;
+
+message GreetingRequest {
+  string name = 1;
+}
+

--- a/protobuf-maven-plugin/src/it/protoc-descriptor-file-options/test.groovy
+++ b/protobuf-maven-plugin/src/it/protoc-descriptor-file-options/test.groovy
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2023 - 2025, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import java.nio.file.Path
+
+import static org.assertj.core.api.Assertions.assertThat
+
+Path baseProjectDir = basedir.toPath().toAbsolutePath()
+Path expectedGeneratedFile = baseProjectDir.resolve("target/protobin.desc")
+
+// Verify the protoc produced the expected output file
+assertThat(expectedGeneratedFile)
+    .exists()
+    .isRegularFile()
+
+return true

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generation/GenerationRequest.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generation/GenerationRequest.java
@@ -86,5 +86,11 @@ public interface GenerationRequest {
 
   boolean isLiteEnabled();
 
+  boolean isOutputDescriptorIncludeImports();
+
+  boolean isOutputDescriptorIncludeSourceInfo();
+
+  boolean isOutputDescriptorRetainOptions();
+
   boolean isRegisterAsCompilationRoot();
 }

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/AbstractGenerateMojo.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/AbstractGenerateMojo.java
@@ -574,10 +574,49 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    * defined in descriptor.proto) containing all the input files in
    * {@code outputDescriptorFile}.</p>
    *
+   * <p>If this is specified, then
+   * {@link #incrementalCompilationEnabled incremental compilation}
+   * will always be disabled to prevent issues with inconsistent build
+   * results.
+   *
    * @since 2.9.0
    */
   @Parameter
   @Nullable File outputDescriptorFile;
+
+  /**
+   * Enable including imports in generated protobin descriptor files.
+   *
+   * <p>This is ignored if {@link #outputDescriptorFile} is not provided.
+   *
+   * @see #outputDescriptorFile
+   * @since 2.10.0
+   */
+  @Parameter(defaultValue = DEFAULT_FALSE)
+  boolean outputDescriptorIncludeImports;
+
+  /**
+   * Enable including source information in generated protobin descriptor
+   * files.
+   *
+   * <p>This is ignored if {@link #outputDescriptorFile} is not provided.
+   *
+   * @see #outputDescriptorFile
+   * @since 2.10.0
+   */
+  @Parameter(defaultValue = DEFAULT_FALSE)
+  boolean outputDescriptorIncludeSourceInfo;
+
+  /**
+   * Enable retaining option details in generated protobin descriptors.
+   *
+   * <p>This is ignored if {@link #outputDescriptorFile} is not provided.
+   *
+   * @see #outputDescriptorFile
+   * @since 2.10.0
+   */
+  @Parameter(defaultValue = DEFAULT_FALSE)
+  boolean outputDescriptorRetainOptions;
 
   /**
    * Override the directory to output generated code to.
@@ -834,6 +873,9 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
         .isIncrementalCompilationEnabled(incrementalCompilation)
         .isIgnoreProjectDependencies(ignoreProjectDependencies)
         .isLiteEnabled(liteOnly)
+        .isOutputDescriptorIncludeImports(outputDescriptorIncludeImports)
+        .isOutputDescriptorIncludeSourceInfo(outputDescriptorIncludeSourceInfo)
+        .isOutputDescriptorRetainOptions(outputDescriptorRetainOptions)
         .isRegisterAsCompilationRoot(registerAsCompilationRoot)
         .outputDescriptorFile(outputDescriptorFile())
         .outputDirectory(outputDirectory())

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/protoc/ProtocArgumentFileBuilderBuilder.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/protoc/ProtocArgumentFileBuilderBuilder.java
@@ -78,8 +78,18 @@ public final class ProtocArgumentFileBuilderBuilder {
     return this;
   }
 
-  public ProtocArgumentFileBuilderBuilder setOutputDescriptorFile(Path outputDescriptorFile) {
-    targets.add(new ProtoDescriptorTarget(outputDescriptorFile));
+  public ProtocArgumentFileBuilderBuilder setOutputDescriptorFile(
+      Path outputDescriptorFile,
+      boolean includeImports,
+      boolean includeSourceInfo,
+      boolean retainOptions
+  ) {
+    targets.add(new ProtoDescriptorTarget(
+        outputDescriptorFile,
+        includeImports,
+        includeSourceInfo,
+        retainOptions
+    ));
     return this;
   }
 
@@ -162,14 +172,37 @@ public final class ProtocArgumentFileBuilderBuilder {
   private static final class ProtoDescriptorTarget implements Target {
 
     private final Path outputDescriptorFile;
+    private final boolean includeImports;
+    private final boolean includeSourceInfo;
+    private final boolean retainOptions;
 
-    private ProtoDescriptorTarget(Path outputDescriptorFile) {
+    private ProtoDescriptorTarget(
+        Path outputDescriptorFile,
+        boolean includeImports,
+        boolean includeSourceInfo,
+        boolean retainOptions
+    ) {
       this.outputDescriptorFile = outputDescriptorFile;
+      this.includeImports = includeImports;
+      this.includeSourceInfo = includeSourceInfo;
+      this.retainOptions = retainOptions;
     }
 
     @Override
     public void addArgsTo(ArgumentFileBuilder argumentFileBuilder) {
       argumentFileBuilder.add("--descriptor_set_out=" + outputDescriptorFile);
+
+      if (includeImports) {
+        argumentFileBuilder.add("--include_imports");
+      }
+
+      if (includeSourceInfo) {
+        argumentFileBuilder.add("--include_source_info");
+      }
+
+      if (retainOptions) {
+        argumentFileBuilder.add("--retain_options");
+      }
     }
   }
 }

--- a/protobuf-maven-plugin/src/site/markdown/basic-usage.md
+++ b/protobuf-maven-plugin/src/site/markdown/basic-usage.md
@@ -217,28 +217,4 @@ configure their paths individually.
 
 ---
 
-## Generating proto descriptor
-
-Descriptors essentially contain exactly the information found in one or more .proto files.
-If you need to generate a FileDescriptorSet (a protocol buffer, defined in 
-[descriptor.proto](https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/descriptor.proto))
-containing all the input files you can provide an outputDescriptorFile configuration option.
-
-```xml
-<plugin>
-  <groupId>io.github.ascopes</groupId>
-  <artifactId>protobuf-maven-plugin</artifactId>
-  <version>%VERSION%</version>
-
-  <configuration>
-    <outputDescriptorFile>path/to/descriptor/file.desc</outputDescriptorFile>
-  </configuration>
-
-</plugin>
-```
-For more information see [Descriptor production](https://protobuf.com/docs/descriptors#descriptor-production)
-
-
----
-
 For more complex configuration, visit the Goals page or the other guide pages.

--- a/protobuf-maven-plugin/src/site/markdown/descriptor-files.md
+++ b/protobuf-maven-plugin/src/site/markdown/descriptor-files.md
@@ -1,0 +1,30 @@
+# Descriptor files
+
+Descriptors essentially contain exactly the information found in one or more `.proto` files.
+
+## Generating proto descriptor files
+
+If you need to generate a `FileDescriptorSet` (a protocol buffer, defined in 
+[descriptor.proto](https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/descriptor.proto))
+containing all the input files you can provide an `outputDescriptorFile` configuration option.
+
+```xml
+<plugin>
+  <groupId>io.github.ascopes</groupId>
+  <artifactId>protobuf-maven-plugin</artifactId>
+  <version>%VERSION%</version>
+
+  <configuration>
+    <outputDescriptorFile>${project.basedir}/target/protos.desc</outputDescriptorFile>
+  </configuration>
+
+</plugin>
+```
+
+You can also specify the following boolean options:
+
+- `outputDescriptorIncludeImports` - passes the `--include_imports` flag to `protoc`.
+- `outputDescriptorIncludeSourceInfo` - passes the `--include_source_info` flag to `protoc`.
+- `outputDescriptorRetainOptions` - passes the `--retain_options` flag to `protoc`.
+
+For more information see [descriptor production](https://protobuf.com/docs/descriptors#descriptor-production).

--- a/protobuf-maven-plugin/src/site/markdown/known-issues.md
+++ b/protobuf-maven-plugin/src/site/markdown/known-issues.md
@@ -62,7 +62,10 @@ The workaround for now appears to be to include `plexus-utils` explicitly as a d
 
 - See https://github.com/ascopes/protobuf-maven-plugin/issues/472 for tracking this issue.
 
-## Descriptor support
+## Incremental compilation with descriptor files
 
-Protobuf descriptors are currently unsupported. Please raise an issue on GitHub if you wish
-to request this feature, along with details of your use case.
+Using incremental compilation when creating descriptor files is not supported due to limitations
+with `protoc`. The entire descriptor must be rebuilt on each build to remain valid.
+
+As of 2.10.0, incremental compilation will be disabled automatically if this condition is
+detected.

--- a/protobuf-maven-plugin/src/site/site.xml
+++ b/protobuf-maven-plugin/src/site/site.xml
@@ -54,6 +54,7 @@
       <item name="Requirements" href="requirements.html"/>
       <item name="Basic Usage" href="basic-usage.html"/>
       <item name="Additional Language Support" href="additional-language-support.html"/>
+      <item name="Descriptor Files" href="descriptor-files.html"/>
       <item name="Changing Protoc Versions" href="changing-protoc-versions.html"/>
       <item name="Using Protoc Plugins" href="using-protoc-plugins.html"/>
       <item name="Faster Builds" href="faster-builds.html"/>

--- a/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/mojo/AbstractGenerateMojoTestTemplate.java
+++ b/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/mojo/AbstractGenerateMojoTestTemplate.java
@@ -652,6 +652,111 @@ abstract class AbstractGenerateMojoTestTemplate<A extends AbstractGenerateMojo> 
     }
   }
 
+  @DisplayName("outputDescriptorFile tests")
+  @Nested
+  class OutputDescriptorFileTest {
+
+    @DisplayName("when outputDescriptorFile is provided, expect the provided file to be used")
+    @Test
+    void whenDescriptorFileProvidedExpectProvidedDirectoryToBeUsed(
+        @TempDir Path tempDir
+    ) throws Throwable {
+      var expectedDescriptorFile = Files.createFile(tempDir.resolve("protobin.desc"));
+      // Given
+      mojo.outputDescriptorFile = expectedDescriptorFile.toFile();
+
+      // When
+      mojo.execute();
+
+      // Then
+      var captor = ArgumentCaptor.forClass(GenerationRequest.class);
+      verify(mojo.sourceCodeGenerator).generate(captor.capture());
+      var actualRequest = captor.getValue();
+      assertThat(actualRequest.getOutputDescriptorFile())
+          .isEqualTo(expectedDescriptorFile);
+    }
+
+    @DisplayName("when outputDescriptorFile is not provided, expect no file to be used")
+    @Test
+    void whenDescriptorFileNotProvidedExpectNoFileToBeUsed() throws Throwable {
+      // Given
+      mojo.outputDescriptorFile = null;
+
+      // When
+      mojo.execute();
+
+      // Then
+      var captor = ArgumentCaptor.forClass(GenerationRequest.class);
+      verify(mojo.sourceCodeGenerator).generate(captor.capture());
+      var actualRequest = captor.getValue();
+      assertThat(actualRequest.getOutputDescriptorFile())
+          .isNull();
+    }
+  }
+
+  @DisplayName("outputDescriptorIncludeImports tests")
+  @Nested
+  class OutputDescriptorIncludeImportsTest {
+
+    @DisplayName("outputDescriptorIncludeImports is set to the specified value")
+    @ValueSource(booleans = {true, false})
+    @ParameterizedTest(name = "for {0}")
+    void outputDescriptorIncludeImportsIsSetToSpecifiedValue(boolean value) throws Throwable {
+      mojo.outputDescriptorIncludeImports = value;
+
+      // When
+      mojo.execute();
+
+      // Then
+      var captor = ArgumentCaptor.forClass(GenerationRequest.class);
+      verify(mojo.sourceCodeGenerator).generate(captor.capture());
+      var actualRequest = captor.getValue();
+      assertThat(actualRequest.isOutputDescriptorIncludeImports()).isEqualTo(value);
+    }
+  }
+
+  @DisplayName("outputDescriptorIncludeSourceInfo tests")
+  @Nested
+  class OutputDescriptorIncludeSourceInfoTest {
+
+    @DisplayName("outputDescriptorIncludeSourceInfo is set to the specified value")
+    @ValueSource(booleans = {true, false})
+    @ParameterizedTest(name = "for {0}")
+    void outputDescriptorIncludeSourceInfoIsSetToSpecifiedValue(boolean value) throws Throwable {
+      mojo.outputDescriptorIncludeSourceInfo = value;
+
+      // When
+      mojo.execute();
+
+      // Then
+      var captor = ArgumentCaptor.forClass(GenerationRequest.class);
+      verify(mojo.sourceCodeGenerator).generate(captor.capture());
+      var actualRequest = captor.getValue();
+      assertThat(actualRequest.isOutputDescriptorIncludeSourceInfo()).isEqualTo(value);
+    }
+  }
+
+  @DisplayName("outputDescriptorRetainOptions tests")
+  @Nested
+  class OutputDescriptorRetainOptionsTest {
+
+    @DisplayName("outputDescriptorIncludeImports is set to the specified value")
+    @ValueSource(booleans = {true, false})
+    @ParameterizedTest(name = "for {0}")
+    void outputDescriptorRetainOptionsIsSetToSpecifiedValue(boolean value) throws Throwable {
+      mojo.outputDescriptorRetainOptions = value;
+
+      // When
+      mojo.execute();
+
+      // Then
+      var captor = ArgumentCaptor.forClass(GenerationRequest.class);
+      verify(mojo.sourceCodeGenerator).generate(captor.capture());
+      var actualRequest = captor.getValue();
+      assertThat(actualRequest.isOutputDescriptorRetainOptions()).isEqualTo(value);
+    }
+  }
+
   @DisplayName("outputDirectory tests")
   @Nested
   class OutputDirectoryTest {
@@ -881,34 +986,9 @@ abstract class AbstractGenerateMojoTestTemplate<A extends AbstractGenerateMojo> 
     }
   }
 
-  @DisplayName("outputDescriptorFile tests")
-  @Nested
-  class DescriptorFileTest {
-
-    @DisplayName("when outputDescriptorFile is provided, expect the provided file to be used")
-    @Test
-    void whenDescriptorFileProvidedExpectProvidedDirectoryToBeUsed(
-        @TempDir Path tempDir
-    ) throws Throwable {
-      var expectedDescriptorFile = Files.createFile(tempDir.resolve("protobin.desc"));
-      // Given
-      mojo.outputDescriptorFile = expectedDescriptorFile.toFile();
-
-      // When
-      mojo.execute();
-
-      // Then
-      var captor = ArgumentCaptor.forClass(GenerationRequest.class);
-      verify(mojo.sourceCodeGenerator).generate(captor.capture());
-      var actualRequest = captor.getValue();
-      assertThat(actualRequest.getOutputDescriptorFile())
-          .isEqualTo(expectedDescriptorFile);
-    }
-  }
-
   @DisplayName("languages are enabled and disabled as expected")
   @MethodSource("languageEnablingCases")
-  @ParameterizedTest(name = "when {0}, then expect {2} to be enabled")
+  @ParameterizedTest(name = "when {0} is true, then expect {2} to be enabled")
   void languagesAreEnabledAndDisabledAsExpected(
       String description,
       Consumer<A> languageConfigurer,
@@ -946,7 +1026,7 @@ abstract class AbstractGenerateMojoTestTemplate<A extends AbstractGenerateMojo> 
         arguments("Rust", consumer(a -> a.rustEnabled = true), EnumSet.of(Language.RUST)),
         // Combined cases
         arguments(
-            "Java and Kotlin",
+            "Java, Kotlin",
             consumer(a -> {
               a.javaEnabled = true;
               a.kotlinEnabled = true;
@@ -954,7 +1034,7 @@ abstract class AbstractGenerateMojoTestTemplate<A extends AbstractGenerateMojo> 
             EnumSet.of(Language.JAVA, Language.KOTLIN)
         ),
         arguments(
-            "Python and PYI",
+            "Python, PYI",
             consumer(a -> {
               a.pythonEnabled = true;
               a.pythonStubsEnabled = true;
@@ -962,7 +1042,7 @@ abstract class AbstractGenerateMojoTestTemplate<A extends AbstractGenerateMojo> 
             EnumSet.of(Language.PYTHON, Language.PYI)
         ),
         arguments(
-            "C++, C#, Rust, and ObjC",
+            "C++, C#, Rust, Objective C",
             consumer(a -> {
               a.cppEnabled = true;
               a.csharpEnabled = true;
@@ -972,7 +1052,7 @@ abstract class AbstractGenerateMojoTestTemplate<A extends AbstractGenerateMojo> 
             EnumSet.of(Language.CPP, Language.C_SHARP, Language.OBJECTIVE_C, Language.RUST)
         ),
         arguments(
-            "all languages",
+            "everything",
             consumer(a -> {
               a.cppEnabled = true;
               a.csharpEnabled = true;


### PR DESCRIPTION
Extends GH-506 with support for descriptor configuration parameters that can be passed to protoc.

- Add three new options:
  - outputDescriptorIncludeImports - pass the --include_imports flag to protoc.
  - outputDescriptorIncludeSourceInfo - pass the --include_source_info flag to protoc.
  - outputDescriprorRetainOptions - pass the --retain_options flag to protoc.
- Moved the documentation for descriptor files to a separate location.
- Fixed an edge case where incremental compilation could cause inconsistent descriptor file outputs. Enabling descriptor files will now disable incremental compilation.