### PR TITLE
Drop weird injection

### DIFF
--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherArtifactMapper.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherArtifactMapper.java
@@ -21,8 +21,9 @@ import io.github.ascopes.protobufmavenplugin.dependencies.DependencyResolutionDe
 import io.github.ascopes.protobufmavenplugin.utils.FileUtils;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.stream.Collectors;
-import org.eclipse.aether.artifact.DefaultArtifact;
+import java.util.Map;
+import org.apache.maven.RepositoryUtils;
+import org.eclipse.aether.artifact.ArtifactType;
 import org.eclipse.aether.graph.Exclusion;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -44,20 +45,12 @@ final class AetherArtifactMapper {
 
   private static final Logger log = LoggerFactory.getLogger(AetherArtifactMapper.class);
 
-  private final org.apache.maven.artifact.handler.ArtifactHandler artifactHandler;
   private final org.eclipse.aether.artifact.ArtifactTypeRegistry artifactTypeRegistry;
 
   AetherArtifactMapper(
-      org.apache.maven.artifact.handler.ArtifactHandler artifactHandler,
       org.eclipse.aether.artifact.ArtifactTypeRegistry artifactTypeRegistry
   ) {
-    this.artifactHandler = artifactHandler;
     this.artifactTypeRegistry = artifactTypeRegistry;
-  }
-
-  // Visible for testing only.
-  org.apache.maven.artifact.handler.ArtifactHandler getArtifactHandler() {
-    return artifactHandler;
   }
 
   org.eclipse.aether.artifact.ArtifactTypeRegistry getArtifactTypeRegistry() {
@@ -75,11 +68,13 @@ final class AetherArtifactMapper {
   org.eclipse.aether.artifact.Artifact mapPmpArtifactToEclipseArtifact(
       io.github.ascopes.protobufmavenplugin.dependencies.MavenArtifact mavenArtifact
   ) {
+    var type = dependencyTypeToEclipseArtifactType(mavenArtifact.getType());
     return new org.eclipse.aether.artifact.DefaultArtifact(
         mavenArtifact.getGroupId(),
         mavenArtifact.getArtifactId(),
-        classifierOrDefault(mavenArtifact.getClassifier()),
-        extensionOrDefault(mavenArtifact.getType()),
+        mavenArtifact.getClassifier() == null || mavenArtifact.getClassifier().trim().isEmpty()
+            ? type.getClassifier() : mavenArtifact.getClassifier(),
+        type.getExtension(),
         mavenArtifact.getVersion()
     );
   }
@@ -110,53 +105,43 @@ final class AetherArtifactMapper {
   org.eclipse.aether.graph.Dependency mapMavenDependencyToEclipseDependency(
       org.apache.maven.model.Dependency mavenDependency
   ) {
-    var artifact = new DefaultArtifact(
-        mavenDependency.getGroupId(),
-        mavenDependency.getArtifactId(),
-        classifierOrDefault(mavenDependency.getClassifier()),
-        null,  // Inferred elsewhere.
-        mavenDependency.getVersion(),
-        extensionToEclipseArtifactType(mavenDependency.getType())
-    );
-
-    var exclusions = mavenDependency.getExclusions()
-        .stream()
-        .map(mavenExclusion -> new Exclusion(
-            mavenExclusion.getGroupId(),
-            mavenExclusion.getArtifactId(),
-            null,  // Any
-            null   // Any
-        ))
-        .collect(Collectors.toUnmodifiableList());
-
-    return new org.eclipse.aether.graph.Dependency(
-        artifact,
-        mavenDependency.getScope(),
-        mavenDependency.isOptional(),
-        exclusions
-    );
+    // maven-core recommended tool to perform these kind of conversions
+    return RepositoryUtils.toDependency(mavenDependency, artifactTypeRegistry);
   }
 
-  private @Nullable String classifierOrDefault(@Nullable String classifier) {
-    // .getClassifier can return null in this case to imply a default classifier to Aether.
-    if (classifier == null) {
-      classifier = artifactHandler.getClassifier();
-    }
-    return classifier;
-  }
-
-  private org.eclipse.aether.artifact.@Nullable ArtifactType extensionToEclipseArtifactType(
-      @Nullable String extension
+  private org.eclipse.aether.artifact.ArtifactType dependencyTypeToEclipseArtifactType(
+      @Nullable String depType
   ) {
-    extension = extensionOrDefault(extension);
-    var type = artifactTypeRegistry.get(extension);
+    final String adjustedType = depType == null ? DEFAULT_EXTENSION : depType;
+    var type = artifactTypeRegistry.get(adjustedType);
 
     if (type == null) {
-      log.debug("Could not resolve extension {} to any known Aether artifact type", extension);
+      log.debug("Could not resolve extension {} to any known Aether artifact type", adjustedType);
+      type = new ArtifactType() {
+        @Override
+        public String getId() {
+          return adjustedType;
+        }
+
+        @Override
+        public String getExtension() {
+          return adjustedType;
+        }
+
+        @Override
+        public String getClassifier() {
+          return "";
+        }
+
+        @Override
+        public Map<String, String> getProperties() {
+          return Map.of();
+        }
+      };
     } else {
       log.debug(
           "Resolved extension {} to Aether artifact type (classifier: {}, type: {}, id: {}, {})",
-          extension,
+          adjustedType,
           type.getClassifier(),
           type.getExtension(),
           type.getId(),
@@ -164,16 +149,5 @@ final class AetherArtifactMapper {
       );
     }
     return type;
-  }
-
-  private String extensionOrDefault(@Nullable String extension) {
-    // We have to provide a sensible default here if it isn't provided by the artifact
-    // handler, otherwise we fall over in a heap because Maven implicitly infers this information
-    // whereas Aether does not. For some reason, this is mandatory whereas classifiers can be
-    // totally inferred if null.
-    if (extension == null) {
-      extension = requireNonNullElse(artifactHandler.getExtension(), DEFAULT_EXTENSION);
-    }
-    return extension;
   }
 }

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherMavenArtifactPathResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherMavenArtifactPathResolver.java
@@ -28,7 +28,6 @@ import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.inject.Named;
 import org.apache.maven.RepositoryUtils;
-import org.apache.maven.artifact.handler.ArtifactHandler;
 import org.apache.maven.execution.MavenSession;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.graph.Dependency;
@@ -49,8 +48,7 @@ final class AetherMavenArtifactPathResolver implements MavenArtifactPathResolver
   @Inject
   AetherMavenArtifactPathResolver(
       MavenSession mavenSession,
-      RepositorySystem repositorySystem,
-      ArtifactHandler artifactHandler
+      RepositorySystem repositorySystem
   ) {
     var artifactRepositories = mavenSession.getProjectBuildingRequest().getRemoteRepositories();
     var remoteRepositories = RepositoryUtils.toRepos(artifactRepositories);
@@ -61,7 +59,7 @@ final class AetherMavenArtifactPathResolver implements MavenArtifactPathResolver
         mavenSession.getRepositorySession());
 
     aetherMapper = new AetherArtifactMapper(
-        artifactHandler, repositorySystemSession.getArtifactTypeRegistry());
+        repositorySystemSession.getArtifactTypeRegistry());
 
     aetherResolver = new AetherResolver(
         repositorySystem, repositorySystemSession, remoteRepositories);

--- a/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherMavenArtifactPathResolverTest.java
+++ b/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherMavenArtifactPathResolverTest.java
@@ -22,7 +22,6 @@ import static org.mockito.Mockito.withSettings;
 
 import java.util.List;
 import org.apache.maven.RepositoryUtils;
-import org.apache.maven.artifact.handler.ArtifactHandler;
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.project.ProjectBuildingRequest;
@@ -51,8 +50,6 @@ class AetherMavenArtifactPathResolverTest {
 
   RepositorySystem repositorySystem;
 
-  ArtifactHandler artifactHandler;
-
   AetherMavenArtifactPathResolver underTest;
 
   @BeforeEach
@@ -69,10 +66,9 @@ class AetherMavenArtifactPathResolverTest {
     when(repositorySystemSession.getArtifactTypeRegistry()).thenReturn(artifactTypeRegistry);
 
     repositorySystem = mock();
-    artifactHandler = mock();
 
     underTest = new AetherMavenArtifactPathResolver(
-        mavenSession, repositorySystem, artifactHandler);
+        mavenSession, repositorySystem);
   }
 
   @DisplayName("the MavenSession is initialised as expected")
@@ -87,8 +83,6 @@ class AetherMavenArtifactPathResolverTest {
   @Test
   void aetherMapperIsInitialisedAsExpected() {
     // Then
-    assertThat(underTest.getAetherMapper().getArtifactHandler())
-        .isSameAs(artifactHandler);
     assertThat(underTest.getAetherMapper().getArtifactTypeRegistry())
         .isSameAs(artifactTypeRegistry);
   }


### PR DESCRIPTION
The injected `ArtifactHandler` is empty one, moreover the "old" ArtifatHandler usage was mixed with Resolver `ArtifactType`. Dropped all that, using `maven-core` offered utility class instead, and redo properly the logic in case of custom class being converted to Resolver `Artifact`.

Locally all the build works and passes OK with latest Maven 4.