### PR TITLE
Implement initial eclipse artifact mapper tests

### DIFF
--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/FallbackEclipseArtifactType.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/FallbackEclipseArtifactType.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2023 - 2025, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.ascopes.protobufmavenplugin.dependencies.aether;
+
+import java.util.Map;
+import org.eclipse.aether.artifact.ArtifactType;
+
+/**
+ * Default artifact type for Eclipse artifacts.
+ *
+ * @author Ashley Scopes, Tamas Cservenak (for the original implementation in 2.10.1).
+ * @since 2.10.2
+ */
+final class FallbackEclipseArtifactType implements ArtifactType {
+  private static final Map<String, String> NO_PROPERTIES = Map.of();
+  private static final String NO_CLASSIFIER = "";
+
+  private final String dependencyExtension;
+
+  FallbackEclipseArtifactType(String dependencyExtension) {
+    this.dependencyExtension = dependencyExtension;
+  }
+
+  @Override
+  public String getId() {
+    return dependencyExtension;
+  }
+
+  @Override
+  public String getExtension() {
+    return dependencyExtension;
+  }
+
+  @Override
+  public String getClassifier() {
+    return NO_CLASSIFIER;
+  }
+
+  @Override
+  public Map<String, String> getProperties() {
+    return NO_PROPERTIES;
+  }
+}

--- a/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherArtifactMapperTest.java
+++ b/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherArtifactMapperTest.java
@@ -1,0 +1,395 @@
+/*
+ * Copyright (C) 2023 - 2025, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.ascopes.protobufmavenplugin.dependencies.aether;
+
+import static io.github.ascopes.protobufmavenplugin.fixtures.RandomFixtures.someBasicString;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+import io.github.ascopes.protobufmavenplugin.dependencies.DependencyResolutionDepth;
+import java.nio.file.Path;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.quality.Strictness;
+
+@DisplayName("AetherArtifactMapper tests")
+@ExtendWith(MockitoExtension.class)
+class AetherArtifactMapperTest {
+
+  @Mock
+  org.eclipse.aether.artifact.ArtifactTypeRegistry artifactTypeRegistry;
+
+  @InjectMocks
+  AetherArtifactMapper aetherArtifactMapper;
+
+  @DisplayName(".getArtifactRegistry() returns the artifact registry")
+  @Test
+  void getArtifactRegistryReturnsTheArtifactRegistry() {
+    // Then
+    assertThat(aetherArtifactMapper.getArtifactTypeRegistry())
+        .isSameAs(artifactTypeRegistry);
+  }
+
+  @DisplayName(".mapEclipseArtifactToPath(Artifact) returns the artifact path")
+  @Test
+  @SuppressWarnings("deprecation")
+  void mapEclipseArtifactToPathReturnsTheArtifactPath(@TempDir Path dir) {
+    // Given
+    var file = dir.resolve(someBasicString() + ".xml");
+    var artifact = mock(org.eclipse.aether.artifact.Artifact.class);
+    when(artifact.getFile()).thenReturn(file.toFile());
+
+    // When
+    var actualFile = aetherArtifactMapper.mapEclipseArtifactToPath(artifact);
+
+    // Then
+    assertThat(actualFile).isEqualTo(file);
+  }
+
+  @DisplayName(".mapPmpArtifactToEclipseArtifact(MavenArtifact) returns the expected artifact for "
+      + "missing types, missing classifiers and unknown artifact types")
+  @NullAndEmptySource
+  @ValueSource(strings = "        ")
+  @ParameterizedTest(name = "for classifier = \"{0}\"")
+  void mapPmpArtifactToEclipseArtifactReturnsTheExpectedArtifact0(
+      String classifier
+  ) {
+    // Given
+    var mavenArtifact = mavenArtifact("org.example", "sketchy-product", "1.2.3", classifier, null);
+    when(artifactTypeRegistry.get(any())).thenReturn(null);
+
+    // When
+    var artifact = aetherArtifactMapper.mapPmpArtifactToEclipseArtifact(mavenArtifact);
+
+    // Then
+    assertThat(artifact.getGroupId()).as("groupId")
+        .isEqualTo(mavenArtifact.getGroupId());
+    assertThat(artifact.getArtifactId()).as("artifactId")
+        .isEqualTo(mavenArtifact.getArtifactId());
+    assertThat(artifact.getVersion()).as("version")
+        .isEqualTo(mavenArtifact.getVersion());
+    assertThat(artifact.getClassifier()).as("classifier")
+        .isEqualTo("");
+    assertThat(artifact.getExtension()).as("extension")
+        .isEqualTo("jar");
+  }
+
+  @DisplayName(".mapPmpArtifactToEclipseArtifact(MavenArtifact) returns the expected artifact for "
+      + "missing types, known classifiers and unknown artifact types")
+  @Test
+  void mapPmpArtifactToEclipseArtifactReturnsTheExpectedArtifact1() {
+    // Given
+    var mavenArtifact = mavenArtifact("org.example", "sketchy-product", "1.2.3", "a jar", null);
+    when(artifactTypeRegistry.get(any())).thenReturn(null);
+
+    // When
+    var artifact = aetherArtifactMapper.mapPmpArtifactToEclipseArtifact(mavenArtifact);
+
+    // Then
+    assertThat(artifact.getGroupId()).as("groupId")
+        .isEqualTo(mavenArtifact.getGroupId());
+    assertThat(artifact.getArtifactId()).as("artifactId")
+        .isEqualTo(mavenArtifact.getArtifactId());
+    assertThat(artifact.getVersion()).as("version")
+        .isEqualTo(mavenArtifact.getVersion());
+    assertThat(artifact.getClassifier()).as("classifier")
+        .isEqualTo("a jar");
+    assertThat(artifact.getExtension()).as("extension")
+        .isEqualTo("jar");
+  }
+
+  @DisplayName(".mapPmpArtifactToEclipseArtifact(MavenArtifact) returns the expected artifact for "
+      + "provided types, missing classifiers and unknown artifact types")
+  @NullAndEmptySource
+  @ValueSource(strings = "        ")
+  @ParameterizedTest(name = "for classifier = \"{0}\"")
+  void mapPmpArtifactToEclipseArtifactReturnsTheExpectedArtifact2(
+      String classifier
+  ) {
+    // Given
+    var mavenArtifact = mavenArtifact("org.example", "sketchy-product", "1.2.3", classifier, "png");
+    when(artifactTypeRegistry.get(any())).thenReturn(null);
+
+    // When
+    var artifact = aetherArtifactMapper.mapPmpArtifactToEclipseArtifact(mavenArtifact);
+
+    // Then
+    assertThat(artifact.getGroupId()).as("groupId")
+        .isEqualTo(mavenArtifact.getGroupId());
+    assertThat(artifact.getArtifactId()).as("artifactId")
+        .isEqualTo(mavenArtifact.getArtifactId());
+    assertThat(artifact.getVersion()).as("version")
+        .isEqualTo(mavenArtifact.getVersion());
+    assertThat(artifact.getClassifier()).as("classifier")
+        .isEqualTo("");
+    assertThat(artifact.getExtension()).as("extension")
+        .isEqualTo("png");
+  }
+
+  @DisplayName(".mapPmpArtifactToEclipseArtifact(MavenArtifact) returns the expected artifact for "
+      + "known types, known classifiers and unknown artifact types")
+  @Test
+  void mapPmpArtifactToEclipseArtifactReturnsTheExpectedArtifact3() {
+    // Given
+    var mavenArtifact = mavenArtifact("org.example", "sketchy-product", "1.2.3", "a png", "png");
+    when(artifactTypeRegistry.get(any())).thenReturn(null);
+
+    // When
+    var artifact = aetherArtifactMapper.mapPmpArtifactToEclipseArtifact(mavenArtifact);
+
+    // Then
+    assertThat(artifact.getGroupId()).as("groupId")
+        .isEqualTo(mavenArtifact.getGroupId());
+    assertThat(artifact.getArtifactId()).as("artifactId")
+        .isEqualTo(mavenArtifact.getArtifactId());
+    assertThat(artifact.getVersion()).as("version")
+        .isEqualTo(mavenArtifact.getVersion());
+    assertThat(artifact.getClassifier()).as("classifier")
+        .isEqualTo("a png");
+    assertThat(artifact.getExtension()).as("extension")
+        .isEqualTo("png");
+  }
+
+  @DisplayName(".mapPmpArtifactToEclipseArtifact(MavenArtifact) returns the expected artifact for "
+      + "provided types, missing classifiers and unknown artifact types")
+  @NullAndEmptySource
+  @ValueSource(strings = "        ")
+  @ParameterizedTest(name = "for classifier = \"{0}\"")
+  void mapPmpArtifactToEclipseArtifactReturnsTheExpectedArtifact4(
+      String classifier
+  ) {
+    // Given
+    var mavenArtifact = mavenArtifact("org.example", "sketchy-product", "1.2.3", classifier, "png");
+    when(artifactTypeRegistry.get(any())).thenReturn(null);
+
+    // When
+    var artifact = aetherArtifactMapper.mapPmpArtifactToEclipseArtifact(mavenArtifact);
+
+    // Then
+    assertThat(artifact.getGroupId()).as("groupId")
+        .isEqualTo(mavenArtifact.getGroupId());
+    assertThat(artifact.getArtifactId()).as("artifactId")
+        .isEqualTo(mavenArtifact.getArtifactId());
+    assertThat(artifact.getVersion()).as("version")
+        .isEqualTo(mavenArtifact.getVersion());
+    assertThat(artifact.getClassifier()).as("classifier")
+        .isEqualTo("");
+    assertThat(artifact.getExtension()).as("extension")
+        .isEqualTo("png");
+  }
+
+  @DisplayName(".mapPmpArtifactToEclipseArtifact(MavenArtifact) returns the expected artifact for "
+      + "missing types, missing classifiers and known artifact types")
+  @NullAndEmptySource
+  @ValueSource(strings = "        ")
+  @ParameterizedTest(name = "for classifier = \"{0}\"")
+  void mapPmpArtifactToEclipseArtifactReturnsTheExpectedArtifact5(
+      String classifier
+  ) {
+    // Given
+    var mavenArtifact = mavenArtifact("org.example", "sketchy-product", "1.2.3", classifier, null);
+    var artifactType = eclipseArtifactType("boop", "beep");
+    when(artifactTypeRegistry.get(any())).thenReturn(artifactType);
+
+    // When
+    var artifact = aetherArtifactMapper.mapPmpArtifactToEclipseArtifact(mavenArtifact);
+
+    // Then
+    assertThat(artifact.getGroupId()).as("groupId")
+        .isEqualTo(mavenArtifact.getGroupId());
+    assertThat(artifact.getArtifactId()).as("artifactId")
+        .isEqualTo(mavenArtifact.getArtifactId());
+    assertThat(artifact.getVersion()).as("version")
+        .isEqualTo(mavenArtifact.getVersion());
+    assertThat(artifact.getClassifier()).as("classifier")
+        .isEqualTo("gzipped-tarball");
+    assertThat(artifact.getExtension()).as("extension")
+        .isEqualTo(".tar.gz");
+  }
+
+  @DisplayName(".mapPmpArtifactToEclipseArtifact(MavenArtifact) returns the expected artifact for "
+      + "missing types, known classifiers and known artifact types")
+  @Test
+  void mapPmpArtifactToEclipseArtifactReturnsTheExpectedArtifact6() {
+    // Given
+    var mavenArtifact = mavenArtifact("org.example", "sketchy-product", "1.2.3", "a jar", null);
+    var artifactType = eclipseArtifactType("boop", "beep");
+    when(artifactTypeRegistry.get(any())).thenReturn(artifactType);
+
+    // When
+    var artifact = aetherArtifactMapper.mapPmpArtifactToEclipseArtifact(mavenArtifact);
+
+    // Then
+    assertThat(artifact.getGroupId()).as("groupId")
+        .isEqualTo(mavenArtifact.getGroupId());
+    assertThat(artifact.getArtifactId()).as("artifactId")
+        .isEqualTo(mavenArtifact.getArtifactId());
+    assertThat(artifact.getVersion()).as("version")
+        .isEqualTo(mavenArtifact.getVersion());
+    assertThat(artifact.getClassifier()).as("classifier")
+        .isEqualTo("a jar");
+    assertThat(artifact.getExtension()).as("extension")
+        .isEqualTo(".tar.gz");
+  }
+
+  @DisplayName(".mapPmpArtifactToEclipseArtifact(MavenArtifact) returns the expected artifact for "
+      + "provided types, missing classifiers and known artifact types")
+  @NullAndEmptySource
+  @ValueSource(strings = "        ")
+  @ParameterizedTest(name = "for classifier = \"{0}\"")
+  void mapPmpArtifactToEclipseArtifactReturnsTheExpectedArtifact7(
+      String classifier
+  ) {
+    // Given
+    var mavenArtifact = mavenArtifact("org.example", "sketchy-product", "1.2.3", classifier, "png");
+    var artifactType = eclipseArtifactType("boop", "beep");
+    when(artifactTypeRegistry.get(any())).thenReturn(artifactType);
+
+    // When
+    var artifact = aetherArtifactMapper.mapPmpArtifactToEclipseArtifact(mavenArtifact);
+
+    // Then
+    assertThat(artifact.getGroupId()).as("groupId")
+        .isEqualTo(mavenArtifact.getGroupId());
+    assertThat(artifact.getArtifactId()).as("artifactId")
+        .isEqualTo(mavenArtifact.getArtifactId());
+    assertThat(artifact.getVersion()).as("version")
+        .isEqualTo(mavenArtifact.getVersion());
+    assertThat(artifact.getClassifier()).as("classifier")
+        .isEqualTo("gzipped-tarball");
+    assertThat(artifact.getExtension()).as("extension")
+        .isEqualTo(".tar.gz");
+  }
+
+  @DisplayName(".mapPmpArtifactToEclipseArtifact(MavenArtifact) returns the expected artifact for "
+      + "known types, known classifiers and known artifact types")
+  @Test
+  void mapPmpArtifactToEclipseArtifactReturnsTheExpectedArtifact8() {
+    // Given
+    var mavenArtifact = mavenArtifact("org.example", "sketchy-product", "1.2.3", "a png", "png");
+    var artifactType = eclipseArtifactType("boop", "beep");
+    when(artifactTypeRegistry.get(any())).thenReturn(artifactType);
+
+    // When
+    var artifact = aetherArtifactMapper.mapPmpArtifactToEclipseArtifact(mavenArtifact);
+
+    // Then
+    assertThat(artifact.getGroupId()).as("groupId")
+        .isEqualTo(mavenArtifact.getGroupId());
+    assertThat(artifact.getArtifactId()).as("artifactId")
+        .isEqualTo(mavenArtifact.getArtifactId());
+    assertThat(artifact.getVersion()).as("version")
+        .isEqualTo(mavenArtifact.getVersion());
+    assertThat(artifact.getClassifier()).as("classifier")
+        .isEqualTo("a png");
+    assertThat(artifact.getExtension()).as("extension")
+        .isEqualTo(".tar.gz");
+  }
+
+  @DisplayName(".mapPmpArtifactToEclipseArtifact(MavenArtifact) returns the expected artifact for "
+      + "provided types, missing classifiers and known artifact types")
+  @NullAndEmptySource
+  @ValueSource(strings = "        ")
+  @ParameterizedTest(name = "for classifier = \"{0}\"")
+  void mapPmpArtifactToEclipseArtifactReturnsTheExpectedArtifact(
+      String classifier
+  ) {
+    // Given
+    var mavenArtifact = mavenArtifact("org.example", "sketchy-product", "1.2.3", classifier, "png");
+    var artifactType = eclipseArtifactType("boop", "beep");
+    when(artifactTypeRegistry.get(any())).thenReturn(artifactType);
+
+    // When
+    var artifact = aetherArtifactMapper.mapPmpArtifactToEclipseArtifact(mavenArtifact);
+
+    // Then
+    assertThat(artifact.getGroupId()).as("groupId")
+        .isEqualTo(mavenArtifact.getGroupId());
+    assertThat(artifact.getArtifactId()).as("artifactId")
+        .isEqualTo(mavenArtifact.getArtifactId());
+    assertThat(artifact.getVersion()).as("version")
+        .isEqualTo(mavenArtifact.getVersion());
+    assertThat(artifact.getClassifier()).as("classifier")
+        .isEqualTo("gzipped-tarball");
+    assertThat(artifact.getExtension()).as("extension")
+        .isEqualTo(".tar.gz");
+  }
+
+  // TODO: continue these
+
+  @SuppressWarnings("SameParameterValue")
+  static io.github.ascopes.protobufmavenplugin.dependencies.MavenArtifact mavenArtifact(
+      String groupId,
+      String artifactId,
+      String version,
+      @Nullable String classifier,
+      @Nullable String type
+  ) {
+    return mavenArtifact(
+        groupId,
+        artifactId,
+        version,
+        classifier,
+        type,
+        DependencyResolutionDepth.TRANSITIVE
+    );
+  }
+
+  @SuppressWarnings("SameParameterValue")
+  static io.github.ascopes.protobufmavenplugin.dependencies.MavenArtifact mavenArtifact(
+      String groupId,
+      String artifactId,
+      String version,
+      @Nullable String classifier,
+      @Nullable String type,
+      DependencyResolutionDepth dependencyResolutionDepth
+  ) {
+    var artifact = mock(
+        io.github.ascopes.protobufmavenplugin.dependencies.MavenArtifact.class,
+        withSettings().strictness(Strictness.LENIENT)
+    );
+    when(artifact.getGroupId()).thenReturn(groupId);
+    when(artifact.getArtifactId()).thenReturn(artifactId);
+    when(artifact.getVersion()).thenReturn(version);
+    when(artifact.getType()).thenReturn(type);
+    when(artifact.getClassifier()).thenReturn(classifier);
+    when(artifact.getDependencyResolutionDepth()).thenReturn(dependencyResolutionDepth);
+    return artifact;
+  }
+
+  static org.eclipse.aether.artifact.ArtifactType eclipseArtifactType(
+      String extension,
+      String classifier
+  ) {
+    var artifactType = mock(org.eclipse.aether.artifact.ArtifactType.class);
+    when(artifactType.getExtension()).thenReturn(".tar.gz");
+    when(artifactType.getClassifier()).thenReturn("gzipped-tarball");
+    return artifactType;
+  }
+}

--- a/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/FallbackEclipseArtifactTypeTest.java
+++ b/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/FallbackEclipseArtifactTypeTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2023 - 2025, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.ascopes.protobufmavenplugin.dependencies.aether;
+
+import static io.github.ascopes.protobufmavenplugin.fixtures.RandomFixtures.someBasicString;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("DefaultEclipseArtifactType tests")
+class FallbackEclipseArtifactTypeTest {
+
+  @DisplayName(".getId() returns the extension")
+  @Test
+  void getIdReturnsTheExtension() {
+    // Given
+    var dependencyExtension = someBasicString();
+    var artifactType = new FallbackEclipseArtifactType(dependencyExtension);
+
+    // Then
+    assertThat(artifactType.getId()).isEqualTo(dependencyExtension);
+  }
+
+  @DisplayName(".getExtension() returns the extension")
+  @Test
+  void getExtensionReturnsTheExtension() {
+    // Given
+    var dependencyExtension = someBasicString();
+    var artifactType = new FallbackEclipseArtifactType(dependencyExtension);
+
+    // Then
+    assertThat(artifactType.getExtension()).isEqualTo(dependencyExtension);
+  }
+
+  @DisplayName(".getClassifier() returns an empty string")
+  @Test
+  void getClassifierReturnsAnEmptyString() {
+    // Given
+    var artifactType = new FallbackEclipseArtifactType(someBasicString());
+
+    // Then
+    assertThat(artifactType.getClassifier()).isEmpty();
+  }
+
+  @DisplayName(".getProperties() returns an empty map")
+  @Test
+  void getPropertiesReturnsAnEmptyMap() {
+    // Given
+    var artifactType = new FallbackEclipseArtifactType(someBasicString());
+
+    // Then
+    assertThat(artifactType.getProperties()).isEmpty();
+  }
+}


### PR DESCRIPTION
Reorganises some code around artifact mapping and implements the first set of unit tests.