### PR TITLE
GH-523: Relax prerequisite constraint to Maven 3.8 from 3.8.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ jobs:
             maven: default
           - os-name: ubuntu-latest
             java-version: 11
-            maven: prerequisite
+            maven: 3.8.8
           - os-name: ubuntu-latest
             java-version: 17
             maven: 4.0.0-rc-2
@@ -94,7 +94,6 @@ jobs:
         shell: bash
         run: |-
           case '${{ matrix.maven }}' in
-            prerequisite) version=$(./mvnw -B -T1 -q -pl protobuf-maven-plugin help:evaluate -DforceStdout -Dexpression='project.prerequisites.maven');;
             default) :;;
             *) version='${{ matrix.maven }}';;
           esac

--- a/protobuf-maven-plugin/pom.xml
+++ b/protobuf-maven-plugin/pom.xml
@@ -31,7 +31,7 @@
   <packaging>maven-plugin</packaging>
 
   <prerequisites>
-    <maven>3.8.2</maven>
+    <maven>3.8</maven>
   </prerequisites>
 
   <dependencies>


### PR DESCRIPTION
Following the suggestion from GH-523 to relax the Maven version constraints from `3.8.2` to `3.8`