### PR TITLE
Improve Termux detection semantics

### DIFF
--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/protoc/ProtocResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/protoc/ProtocResolver.java
@@ -88,7 +88,7 @@ public final class ProtocResolver {
 
     if (path.isPresent()) {
       var resolvedPath = path.get();
-  
+
       try {
         FileUtils.makeExecutable(resolvedPath);
 
@@ -117,9 +117,9 @@ public final class ProtocResolver {
   }
 
   private Optional<Path> resolveFromMavenRepositories(String version) throws ResolutionException {
-    if (hostSystem.isProbablyAndroid()) {
+    if (hostSystem.isProbablyTermux()) {
       log.warn(
-          "It looks like you are using Android! If you are using an environment such as Termux, "
+          "It looks like you are using Termux! If you are using an environment such as Termux, "
               + "then you may find that the Maven-distributed versions of protoc fail to run. "
               + "This is due to Android's kernel restricting the types of system calls that can "
               + "be made. You may wish to run 'pkg in protobuf' to install a modified version of "


### PR DESCRIPTION
Termux detection now uses the java.vendor property rather than a call to uname via a subprocess. This will still catch most cases so that a warning can
be emitted without needing to have complicated
subprocess handling for this single edge case. This also removes the warning for Android outside this
specific case as we do not test integration for this scenario to know whether it is an issue or not.