### PR TITLE
Defer coverage reports to the end of the CI pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -166,3 +166,23 @@ jobs:
           retention-days: 7
           include-hidden-files: true
           if-no-files-found: error
+
+  notify-coverage:
+    name: Notify of coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs:
+      - build
+      - validate-codecov
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Publish code coverage
+        uses: codecov/codecov-action@v5
+        continue-on-error: true
+        if: always()
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
+          run_command: send-notifications

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,10 +3,16 @@ coverage:
   precision: 2
 
 codecov:
+  notify:
+    # Notify via a separate pipeline step in CI once all builds have completed. This way, we don't
+    # report coverage after each parallel build completes, which results in spammy and incorrect
+    # email notifications and prematurely marking the build as having failed.
+    # https://github.com/codecov/codecov-action/issues/1436#issuecomment-2614065472
+    manual_trigger: true
   require_ci_to_pass: true
   strict_yaml_branch: main
 
 comment:
-  layout: "diff, flags, files"
+  layout: "reach, diff, flags, files"
   behavior: default
   require_changes: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -15,4 +15,3 @@ codecov:
 comment:
   layout: "reach, diff, flags, files"
   behavior: default
-  require_changes: true


### PR DESCRIPTION
Applies the new functionality in https://github.com/codecov/codecov-action/issues/1436 to be able to defer reporting coverage until the entire pipeline has uploaded coverage reports. This reduces noise in pull request logs.