### PR TITLE
Ensure directory exists for outputDescriptorFile path

### DIFF
--- a/protobuf-maven-plugin/src/it/output-descriptor-mkdirs/invoker.properties
+++ b/protobuf-maven-plugin/src/it/output-descriptor-mkdirs/invoker.properties
@@ -1,0 +1,17 @@
+#
+# Copyright (C) 2023 - 2025, Ashley Scopes.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+invoker.goals = clean package

--- a/protobuf-maven-plugin/src/it/output-descriptor-mkdirs/pom.xml
+++ b/protobuf-maven-plugin/src/it/output-descriptor-mkdirs/pom.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2023 - 2025, Ashley Scopes.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>@project.groupId@.it</groupId>
+    <artifactId>integration-test-parent</artifactId>
+    <version>@project.version@</version>
+    <relativePath>../setup/pom.xml</relativePath>
+  </parent>
+
+  <groupId>output-descriptor-mkdirs</groupId>
+  <artifactId>output-descriptor-mkdirs</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <scope>compile</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+
+        <configuration>
+          <outputDescriptorFile>${project.build.directory}/generated-sources/protobuf/descriptor-sets/protobin.desc</outputDescriptorFile>
+        </configuration>
+
+        <executions>
+          <execution>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/protobuf-maven-plugin/src/it/output-descriptor-mkdirs/src/main/protobuf/helloworld.proto
+++ b/protobuf-maven-plugin/src/it/output-descriptor-mkdirs/src/main/protobuf/helloworld.proto
@@ -1,0 +1,27 @@
+//
+// Copyright (C) 2023 - 2025, Ashley Scopes.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "org.example.helloworld";
+
+package org.example.helloworld;
+
+message GreetingRequest {
+  string name = 1;
+}
+

--- a/protobuf-maven-plugin/src/it/output-descriptor-mkdirs/test.groovy
+++ b/protobuf-maven-plugin/src/it/output-descriptor-mkdirs/test.groovy
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2023 - 2025, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import java.nio.file.Path
+
+import static org.assertj.core.api.Assertions.assertThat
+
+Path baseProjectDir = basedir.toPath().toAbsolutePath()
+Path expectedGeneratedFile = baseProjectDir.resolve("target/generated-sources/protobuf/descriptor-sets/protobin.desc")
+
+
+// Verify the protoc produced the expected output file
+assertThat(expectedGeneratedFile)
+    .exists()
+    .isRegularFile()
+
+return true

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generation/ProtobufBuildOrchestrator.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generation/ProtobufBuildOrchestrator.java
@@ -32,6 +32,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -192,6 +193,18 @@ public final class ProtobufBuildOrchestrator {
         });
 
     Files.createDirectories(directory);
+
+    Optional.ofNullable(request.getOutputDescriptorFile())
+        .map(p -> p.toAbsolutePath().getParent())
+        .ifPresent(p -> {
+          try {
+            Files.createDirectories(p);
+          } catch (IOException e) {
+            throw new IllegalStateException(
+                "Failed to create output directory for descriptor file '"
+                    + p + "'", e);
+          }
+        });
   }
 
   private void registerSourceRoots(GenerationRequest request) {


### PR DESCRIPTION
This will allow me to specify a nested output path for proto descriptors, e.g.

```xml
<outputDescriptorFile>${project.build.directory}/generated-sources/protobuf/descriptor-sets/protobin.desc</outputDescriptorFile>
```
