### PR TITLE
GH-575: Allow excluding dependencies provided within plugin configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,45 @@ The following will generate Java classes and corresponding Kotlin wrappers:
 </plugin>
 ```
 
+### Dependencies
+
+Native Maven dependency management is supported out of the box, allowing you to use Maven as an
+artifact registry for bundles of Proto files seamlessly.
+
+```xml
+<project>
+  ...
+  
+  <dependencies>
+    <dependency>
+      <groupId>org.example.protos</groupId>
+      <artifactId>user-protos</artifactId>
+      <version>...</version>
+      <classifier>zip</classifier>
+    </dependency>
+  </dependencies>
+  
+  <plugins>
+    <plugin>
+      <groupId>io.github.ascopes</groupId>
+      <artifactId>protobuf-maven-plugin</artifactId>
+
+      <configuration>
+        <protocVersion>...</protocVersion>
+      </configuration>
+
+      <executions>
+        <execution>
+          <goals>
+            <goal>generate</goal>
+          </goals>
+        </execution>
+      </executions>
+    </plugin>
+  </plugins>
+</project>
+```
+
 ### Plugins
 
 The following snippet will compile any protobuf sources in `src/main/protobuf` to Java source code,

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>io.github.ascopes</groupId>
   <artifactId>protobuf-maven-plugin-parent</artifactId>
-  <version>2.11.1-SNAPSHOT</version>
+  <version>2.12.0-SNAPSHOT</version>
 
   <name>Protobuf Maven Plugin Parent</name>
   <description>Parent POM for the Protobuf Maven Plugin.</description>

--- a/protobuf-maven-plugin/pom.xml
+++ b/protobuf-maven-plugin/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes</groupId>
     <artifactId>protobuf-maven-plugin-parent</artifactId>
-    <version>2.11.1-SNAPSHOT</version>
+    <version>2.12.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>protobuf-maven-plugin</artifactId>

--- a/protobuf-maven-plugin/src/it/gh-575-configuration-import-dependencies-exclusions/avatars/pom.xml
+++ b/protobuf-maven-plugin/src/it/gh-575-configuration-import-dependencies-exclusions/avatars/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2023 - 2025, Ashley Scopes.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>gh-575-configuration-import-dependencies-exclusions</groupId>
+    <artifactId>parent</artifactId>
+    <version>@project.version@</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>avatars</artifactId>
+  <packaging>pom</packaging>
+
+  <dependencies>
+    <dependency>
+      <!-- This shouldn't be included but the test assumes we configured this module badly and
+           are now including a load of stuff we shouldn't be. We will then test the ability to
+           exclude this from a downstream project that transitively depends on this one. -->
+      <groupId>${project.parent.groupId}</groupId>
+      <artifactId>metadata</artifactId>
+      <version>${project.parent.version}</version>
+      <scope>compile</scope>
+      <classifier>protos</classifier>
+      <type>zip</type>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/protobuf-maven-plugin/src/it/gh-575-configuration-import-dependencies-exclusions/avatars/src/main/protobuf/avatars/avatar.proto
+++ b/protobuf-maven-plugin/src/it/gh-575-configuration-import-dependencies-exclusions/avatars/src/main/protobuf/avatars/avatar.proto
@@ -1,0 +1,33 @@
+//
+// Copyright (C) 2023 - 2025, Ashley Scopes.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+package avatars;
+
+option java_multiple_files = true;
+option java_package = "org.example.avatars";
+
+enum AvatarFormat {
+  PNG = 0;
+  WEBP = 1;
+  SVG = 2;
+}
+
+message Avatar {
+  string binary_data = 1;
+  AvatarFormat format = 2;
+}

--- a/protobuf-maven-plugin/src/it/gh-575-configuration-import-dependencies-exclusions/channels/pom.xml
+++ b/protobuf-maven-plugin/src/it/gh-575-configuration-import-dependencies-exclusions/channels/pom.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2023 - 2025, Ashley Scopes.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>gh-575-configuration-import-dependencies-exclusions</groupId>
+    <artifactId>parent</artifactId>
+    <version>@project.version@</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>channels</artifactId>
+  <packaging>pom</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+
+        <configuration>
+          <!-- This test will verify that we can exclude the dependency from <importDependencies/> -->
+          <importDependencies>
+            <importDependency>
+              <groupId>${project.parent.groupId}</groupId>
+              <artifactId>users</artifactId>
+              <version>${project.parent.version}</version>
+              <classifier>protos</classifier>
+              <type>zip</type>
+              <exclusions>
+                <exclusion>
+                  <groupId>${project.parent.groupId}</groupId>
+                  <artifactId>metadata</artifactId>
+                </exclusion>
+              </exclusions>
+            </importDependency>
+          </importDependencies>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/protobuf-maven-plugin/src/it/gh-575-configuration-import-dependencies-exclusions/channels/src/main/protobuf/channels/channel.proto
+++ b/protobuf-maven-plugin/src/it/gh-575-configuration-import-dependencies-exclusions/channels/src/main/protobuf/channels/channel.proto
@@ -1,0 +1,40 @@
+//
+// Copyright (C) 2023 - 2025, Ashley Scopes.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+package channels;
+
+option java_multiple_files = true;
+option java_package = "org.example.channels";
+
+import "avatars/avatar.proto";
+import "users/user.proto";
+
+enum ChannelType {
+  VOICE = 0;
+  TEXT = 1;
+  VIDEO = 2;
+}
+
+message Channel {
+  string id = 1;
+  string name = 2;
+  bool nsfw = 3;
+  ChannelType channel_type = 4;
+  users.User owner = 5;
+  optional avatars.Avatar icon = 6;
+}

--- a/protobuf-maven-plugin/src/it/gh-575-configuration-import-dependencies-exclusions/invoker.properties
+++ b/protobuf-maven-plugin/src/it/gh-575-configuration-import-dependencies-exclusions/invoker.properties
@@ -1,0 +1,25 @@
+#
+# Copyright (C) 2023 - 2025, Ashley Scopes.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# We have to run the steps individually as `channels` does not use the dependencies from the
+# dependency tree, so Maven cannot infer the right build order otherwise. An unfortunate downside of
+# letting the plugin manage the dependencies rather than Maven.
+invoker.goals.0 = clean
+invoker.goals.1 = install --projects . --non-recursive
+invoker.goals.2 = install --projects metadata
+invoker.goals.3 = install --projects avatars
+invoker.goals.4 = install --projects users
+invoker.goals.5 = install --projects channels

--- a/protobuf-maven-plugin/src/it/gh-575-configuration-import-dependencies-exclusions/metadata/pom.xml
+++ b/protobuf-maven-plugin/src/it/gh-575-configuration-import-dependencies-exclusions/metadata/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2023 - 2025, Ashley Scopes.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>gh-575-configuration-import-dependencies-exclusions</groupId>
+    <artifactId>parent</artifactId>
+    <version>@project.version@</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>metadata</artifactId>
+  <packaging>pom</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/protobuf-maven-plugin/src/it/gh-575-configuration-import-dependencies-exclusions/metadata/src/main/protobuf/metadata/metadata.proto
+++ b/protobuf-maven-plugin/src/it/gh-575-configuration-import-dependencies-exclusions/metadata/src/main/protobuf/metadata/metadata.proto
@@ -1,0 +1,34 @@
+//
+// Copyright (C) 2023 - 2025, Ashley Scopes.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+package metadata;
+
+option java_multiple_files = true;
+option java_package = "org.example.metadata";
+
+message Metadata {
+  map<string, MetadataValue> pairs = 1;
+  string version = 2;
+}
+
+message MetadataValue {
+  oneof value {
+    string string = 1;
+    Metadata nested = 2;
+  }
+}

--- a/protobuf-maven-plugin/src/it/gh-575-configuration-import-dependencies-exclusions/pom.xml
+++ b/protobuf-maven-plugin/src/it/gh-575-configuration-import-dependencies-exclusions/pom.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2023 - 2025, Ashley Scopes.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>@project.groupId@.it</groupId>
+    <artifactId>integration-test-parent</artifactId>
+    <version>@project.version@</version>
+    <relativePath>../setup/pom.xml</relativePath>
+  </parent>
+
+  <groupId>gh-575-configuration-import-dependencies-exclusions</groupId>
+  <artifactId>parent</artifactId>
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>metadata</module>
+    <module>avatars</module>
+    <module>channels</module>
+    <module>users</module>
+  </modules>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-assembly-plugin</artifactId>
+
+          <configuration>
+            <attach>true</attach>
+            <inlineDescriptors>
+              <inlineDescriptor>
+                <id>protos</id>
+                <!-- Needed to avoid creating a nested directory named after the artifact itself. -->
+                <baseDirectory>.</baseDirectory>
+                <formats>
+                  <format>zip</format>
+                </formats>
+                <fileSets>
+                  <fileSet>
+                    <outputDirectory>./</outputDirectory>
+                    <directory>src/main/protobuf</directory>
+                  </fileSet>
+                </fileSets>
+              </inlineDescriptor>
+            </inlineDescriptors>
+          </configuration>
+
+          <executions>
+            <execution>
+              <id>assemble-zip</id>
+              <phase>package</phase>
+              <goals>
+                <goal>single</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+
+        <plugin>
+          <groupId>@project.groupId@</groupId>
+          <artifactId>@project.artifactId@</artifactId>
+
+          <executions>
+            <execution>
+              <goals>
+                <goal>generate</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>

--- a/protobuf-maven-plugin/src/it/gh-575-configuration-import-dependencies-exclusions/test.groovy
+++ b/protobuf-maven-plugin/src/it/gh-575-configuration-import-dependencies-exclusions/test.groovy
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2023 - 2025, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import groovy.lang.Closure
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.function.Consumer
+import java.util.stream.Collectors
+import java.util.stream.Stream
+
+import static org.assertj.core.api.Assertions.assertThat
+
+// Type hint to work around method ambiguity in groovy.
+@SuppressWarnings("all")
+<T> Consumer<T> consumer(Closure consumer) { consumer }
+
+Path baseDirectory = basedir.toPath().toAbsolutePath()
+Path dependencyDirectory = baseDirectory
+    .resolve("channels")
+    .resolve("target")
+    .resolve("protobuf-maven-plugin")
+    .resolve("generate")
+    .resolve("default")
+    .resolve("archives")
+
+assertThat(dependencyDirectory).isDirectory()
+
+try (Stream<Path> listing = Files.list(dependencyDirectory)) {
+  List<String> directories = listing
+      .map { it.fileName.toString() }
+      .collect(Collectors.toList())
+  assertThat(directories).satisfiesOnlyOnce consumer { assertThat(it).startsWith("avatars-") }
+  assertThat(directories).satisfiesOnlyOnce consumer { assertThat(it).startsWith("users-") }
+  assertThat(directories).noneSatisfy consumer { assertThat(it).startsWith("metadata-") }
+}
+
+return true

--- a/protobuf-maven-plugin/src/it/gh-575-configuration-import-dependencies-exclusions/users/pom.xml
+++ b/protobuf-maven-plugin/src/it/gh-575-configuration-import-dependencies-exclusions/users/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2023 - 2025, Ashley Scopes.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>gh-575-configuration-import-dependencies-exclusions</groupId>
+    <artifactId>parent</artifactId>
+    <version>@project.version@</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>users</artifactId>
+  <packaging>pom</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.parent.groupId}</groupId>
+      <artifactId>avatars</artifactId>
+      <version>${project.parent.version}</version>
+      <scope>compile</scope>
+      <classifier>protos</classifier>
+      <type>zip</type>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/protobuf-maven-plugin/src/it/gh-575-configuration-import-dependencies-exclusions/users/src/main/protobuf/users/user.proto
+++ b/protobuf-maven-plugin/src/it/gh-575-configuration-import-dependencies-exclusions/users/src/main/protobuf/users/user.proto
@@ -1,0 +1,34 @@
+//
+// Copyright (C) 2023 - 2025, Ashley Scopes.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+package users;
+
+option java_multiple_files = true;
+option java_package = "org.example.users";
+
+import "avatars/avatar.proto";
+
+message User {
+  string id = 1;
+  string username = 2;
+  string email_address = 3;
+  reserved 4;
+  optional string nickname = 5;
+  optional avatars.Avatar avatar = 6;
+  uint64 created_at = 7;
+}

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/MavenArtifact.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/MavenArtifact.java
@@ -39,5 +39,5 @@ public interface MavenArtifact {
 
   @Nullable DependencyResolutionDepth getDependencyResolutionDepth();
 
-  Set<MavenExclusionBean> getExcludes();
+  Set<MavenExclusionBean> getExclusions();
 }

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/MavenExclusion.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/MavenExclusion.java
@@ -15,29 +15,30 @@
  */
 package io.github.ascopes.protobufmavenplugin.dependencies;
 
-import java.util.Set;
-import org.jspecify.annotations.Nullable;
-
+import org.immutables.value.Value.Modifiable;
 
 /**
- * Base interface for a parameter that consumes Maven artifact details.
+ * Marker to exclude a specific transitive dependency.
+ *
+ * <p>Holds an optional classifier and optional extension, in addition to the group ID and
+ * artifact ID.
  *
  * @author Ashley Scopes
- * @since 1.2.0
+ * @since 2.12.0
  */
-public interface MavenArtifact {
-
+@Modifiable
+public interface MavenExclusion {
   String getGroupId();
 
   String getArtifactId();
 
-  String getVersion();
+  default String getClassifier() {
+    // Eclipse uses an asterisk wildcard to imply all classifiers.
+    return "*";
+  }
 
-  @Nullable String getType();
-
-  @Nullable String getClassifier();
-
-  @Nullable DependencyResolutionDepth getDependencyResolutionDepth();
-
-  Set<MavenExclusionBean> getExcludes();
+  default String getType() {
+    // Eclipse uses an asterisk wildcard to imply all types.
+    return "*";
+  }
 }

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherArtifactMapper.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherArtifactMapper.java
@@ -108,7 +108,7 @@ final class AetherArtifactMapper {
 
     var exclusions = effectiveDependencyResolutionDepth == DependencyResolutionDepth.DIRECT
         ? Set.of(WildcardAwareDependencyTraverser.WILDCARD_EXCLUSION)
-        : mapPmpExclusionsToEclipseExclusions(mavenArtifact.getExcludes());
+        : mapPmpExclusionsToEclipseExclusions(mavenArtifact.getExclusions());
 
     var artifact = mapPmpArtifactToEclipseArtifact(mavenArtifact);
 

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherArtifactMapper.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherArtifactMapper.java
@@ -19,12 +19,14 @@ import static java.util.Objects.requireNonNullElse;
 import static java.util.function.Predicate.not;
 
 import io.github.ascopes.protobufmavenplugin.dependencies.DependencyResolutionDepth;
+import io.github.ascopes.protobufmavenplugin.dependencies.MavenExclusion;
 import io.github.ascopes.protobufmavenplugin.utils.FileUtils;
 import java.nio.file.Path;
-import java.util.List;
+import java.util.Collection;
 import java.util.Objects;
 import java.util.Optional;
-import org.eclipse.aether.graph.Exclusion;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -105,8 +107,8 @@ final class AetherArtifactMapper {
     );
 
     var exclusions = effectiveDependencyResolutionDepth == DependencyResolutionDepth.DIRECT
-        ? List.of(WildcardAwareDependencyTraverser.WILDCARD_EXCLUSION)
-        : List.<Exclusion>of();
+        ? Set.of(WildcardAwareDependencyTraverser.WILDCARD_EXCLUSION)
+        : mapPmpExclusionsToEclipseExclusions(mavenArtifact.getExcludes());
 
     var artifact = mapPmpArtifactToEclipseArtifact(mavenArtifact);
 
@@ -124,5 +126,18 @@ final class AetherArtifactMapper {
     // maven-core recommended tool to perform these kind of conversions
     return org.apache.maven.RepositoryUtils
         .toDependency(mavenDependency, artifactTypeRegistry);
+  }
+
+  private Set<org.eclipse.aether.graph.Exclusion> mapPmpExclusionsToEclipseExclusions(
+      Collection<? extends MavenExclusion> exclusions
+  ) {
+    return exclusions.stream()
+        .map(exclusion -> new org.eclipse.aether.graph.Exclusion(
+            exclusion.getGroupId(),
+            exclusion.getArtifactId(),
+            exclusion.getClassifier(),
+            exclusion.getType()
+        ))
+        .collect(Collectors.toUnmodifiableSet());
   }
 }

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/AbstractGenerateMojo.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/AbstractGenerateMojo.java
@@ -418,7 +418,7 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    *   <li>{@code artifactId} - the artifact ID to exclude</li>
    *   <li>{@code classifier} - optional - the classifier to exclude. If omitted, any classifiers
    *      are matched.</li>
-   *    <li>{@code type} - optional - the type of the artifact to exclude. If omitted, any types
+   *   <li>{@code type} - optional - the type of the artifact to exclude. If omitted, any types
    *      are matched.</li>
    * </ul>
    *
@@ -828,7 +828,7 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    *   <li>{@code artifactId} - the artifact ID to exclude</li>
    *   <li>{@code classifier} - optional - the classifier to exclude. If omitted, any classifiers
    *      are matched.</li>
-   *    <li>{@code type} - optional - the type of the artifact to exclude. If omitted, any types
+   *   <li>{@code type} - optional - the type of the artifact to exclude. If omitted, any types
    *      are matched.</li>
    * </ul>
    *

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/AbstractGenerateMojo.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/AbstractGenerateMojo.java
@@ -408,6 +408,18 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    *   <li>{@code classifier} - the artifact classifier - optional</li>
    *   <li>{@code dependencyResolutionDepth} - the dependency resolution depth to override
    *      the project settings with - optional</li>
+   *   <li>{@code excludes} - a set of exclusions to apply to transitive dependencies</li>
+   * </ul>
+   *
+   * <p>Exclusions are a set of objects, each with the following fields:
+   *
+   * <ul>
+   *   <li>{@code groupId} - the group ID to exclude</li>
+   *   <li>{@code artifactId} - the artifact ID to exclude</li>
+   *   <li>{@code classifier} - optional - the classifier to exclude. If omitted, any classifiers
+   *      are matched.</li>
+   *    <li>{@code type} - optional - the type of the artifact to exclude. If omitted, any types
+   *      are matched.</li>
    * </ul>
    *
    * @since 1.2.0
@@ -806,6 +818,18 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    *   <li>{@code classifier} - the artifact classifier - optional</li>
    *   <li>{@code dependencyResolutionDepth} - the dependency resolution depth to override
    *      the project settings with - optional</li>
+   *   <li>{@code excludes} - a set of exclusions to apply to transitive dependencies</li>
+   * </ul>
+   *
+   * <p>Exclusions are a set of objects, each with the following fields:
+   *
+   * <ul>
+   *   <li>{@code groupId} - the group ID to exclude</li>
+   *   <li>{@code artifactId} - the artifact ID to exclude</li>
+   *   <li>{@code classifier} - optional - the classifier to exclude. If omitted, any classifiers
+   *      are matched.</li>
+   *    <li>{@code type} - optional - the type of the artifact to exclude. If omitted, any types
+   *      are matched.</li>
    * </ul>
    *
    * @since 1.2.0
@@ -855,6 +879,14 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
   abstract Set<String> defaultDependencyScopes();
 
   /**
+   * Provides the registrar for output descriptor files to attach them to the Maven project
+   * as additional artifacts.
+   *
+   * @return the registrar to use.
+   */
+  abstract OutputDescriptorAttachmentRegistrar outputDescriptorAttachmentRegistrar();
+
+  /**
    * Provides the source root registrar for this Mojo.
    *
    * <p>This specifies where to attach generated sources to in order for it
@@ -863,8 +895,6 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    * @return the registrar to use.
    */
   abstract SourceRootRegistrar sourceRootRegistrar();
-
-  abstract OutputDescriptorAttachmentRegistrar outputDescriptorAttachmentRegistrar();
 
   /*
    * Core implementation.

--- a/protobuf-maven-plugin/src/site/markdown/dependencies.md
+++ b/protobuf-maven-plugin/src/site/markdown/dependencies.md
@@ -193,12 +193,12 @@ unique use cases for it.
         <classifier>zip</classifier>
         <scope>compile</scope>
       
-        <excludes>
-          <exclude>
+        <exclusions>
+          <exclusion>
             <groupId>org.example</groupId>
             <artifactId>ticketsystem-beta-user-protos</artifactId>
-          </exclude>
-        </excludes>
+          </exclusion>
+        </exclusions>
       </includeDependency>
     </includeDependencies>
   </configuration>

--- a/protobuf-maven-plugin/src/site/markdown/dependencies.md
+++ b/protobuf-maven-plugin/src/site/markdown/dependencies.md
@@ -1,0 +1,238 @@
+# Dependencies
+
+Like any other Java project in Maven, your Protobuf project may need to depend on other dependencies
+located in a Maven repository or some other location. This has first-class support within this
+plugin without you needing to do anything special.
+
+## A simple example
+
+Any Maven dependencies in your project that are a valid ZIP or JAR archive or file tree will be 
+scanned during execution to discover any `*.proto` files internally. All proto files will be 
+extracted and made visible to `protoc` relative to their file hierarchy.
+
+For example, suppose you are writing a ticketing system, and you are working on the user profiles
+functionality. You may have the following project structure:
+
+```
+┣━ pom.xml  (org.example/ticketsystem-users-parent)
+┗━ ticketsystem-user-protos/
+    ┣━ pom.xml  (org.example/ticketsystem-user-protos)
+    ┗━ src/
+        ┗━ main/
+            ┗━ protobuf/
+                ┗━ org/
+                    ┗━ example/
+                        ┗━ ticketsystem/
+                            ┗━ users/
+                                ┣━ avatar.proto
+                                ┣━ profile.proto
+                                ┣━ team.proto
+                                ┗━ user.proto      
+```
+
+You may have a set of message definitions that depends on proto files from other projects. In our
+case, let's say our `team.proto` depends on a `ticket_board.proto` in a totally different Maven
+project:
+
+```protobuf
+// org/example/ticketsystem/users/team.proto
+
+syntax = "proto3";
+
+package org.example.ticketsystem.users;
+
+option java_multiple_files = true;
+option java_package = "org.example.ticketsystem.users";
+
+import "org/example/ticketsystem/board/ticket_board.proto";
+import "org/example/ticketsystem/users/avatar.proto";
+import "org/example/ticketsystem/users/user.proto";
+
+message Team {
+  org.example.ticketsystem.users.Avatar icon = 1;
+  string name = 2;
+  org.example.ticketsystem.users.User owner = 3;
+  org.example.ticketsystem.board.TicketBoard ticket_board = 4;
+}
+```
+
+Luckily for us, the `ticket_board.proto` is published in our Maven repository in a ZIP file with
+the following hierarchy:
+
+```
+┣━ pom.xml  (org.example/ticketsystem-users-parent)
+┗━ ticket_board_protos.zip
+    ┣━ META_INF/
+    ┃   ┗━ .../
+    ┗━ org/
+        ┗━ example/
+            ┗━ ticketsystem/
+                ┗━ board/
+                    ┗━ ticket_board.proto       
+```
+
+We can add a dependency on this in our `pom.xml`, and the protobuf-maven-plugin will automatically
+detect it and discover the proto files inside it, enabling our project to build successfully:
+
+```xml
+<project>
+  ...
+  
+  <dependencies>
+    <dependency>
+      <groupId>org.example</groupId>
+      <artifactId>ticketsystem-ticket-board</artifactId>
+      <version>...</version>
+      <classifier>zip</classifier>
+      <scope>compile</scope>      
+    </dependency>
+  </dependencies>
+</project>
+```
+
+## Maven Dependencies
+
+By default, the plugin will discover all `*.proto` files in all dependencies of the current Maven
+project. This occurs transitively, and all are added to the `protoc` import path.
+
+The idea here is that the behaviour for imports should almost exactly mimic how Java dependencies
+work and how they are resolved on the classpath.
+
+It is important to note that by default, only dependencies with the `compile`, `provided`, `system`
+and `test` (only for test executions) scopes will be inspected.
+
+If you wish to exclude certain transitive dependencies, you can use the existing Maven
+exclusion mechanism.
+
+```xml
+<dependency>
+  <groupId>org.example</groupId>
+  <artifactId>ticketsystem-ticket-board</artifactId>
+  <version>...</version>
+  <classifier>zip</classifier>
+  <scope>compile</scope>
+  
+  <excludes>
+    <exclude>
+      <groupId>org.example</groupId>
+      <artifactId>ticketsystem-beta-user-protos</artifactId>
+    </exclude>
+  </excludes>
+</dependency>
+```
+
+This will also respect Maven dependency management.
+
+## Advanced configuration
+
+In addition to scanning Maven dependencies, the plugin also has several advanced settings to enable
+you to control the dependencies that are resolved from within the plugin itself.
+
+
+### Disabling resolution of Maven project dependencies
+
+If you wish to disable discovery of `*.proto` sources from Maven project dependencies, you can
+disable this in the plugin configuration:
+
+```xml
+<plugin>
+  <groupId>io.github.ascopes</groupId>
+  <artifactId>protobuf-maven-plugin</artifactId>
+  
+  <configuration>
+    <ignoreProjectDependencies>true</ignoreProjectDependencies>
+  </configuration>
+</plugin>
+```
+
+If you do this, only dependencies explicitly configured in the plugin configuration will be
+considered.
+
+### Adding additional import paths from the local file system
+
+If you wish to make `*.proto` files from the local file system visible to `protoc`, you can add
+their directory roots to the plugin configuration:
+
+```xml
+<plugin>
+  <groupId>io.github.ascopes</groupId>
+  <artifactId>protobuf-maven-plugin</artifactId>
+  
+  <configuration>
+    <importPaths>
+      <importPath>/path/to/protos/root</importPath>
+      ...
+    </importPaths>
+  </configuration>
+</plugin>
+```
+
+In this example, `/path/to/protos/root` will be recursively searched for `*.proto` sources
+and added to the import path.
+
+You can add as many of these as you like to your project.
+
+### Adding Maven artifact dependencies within the plugin configuration
+
+If you wish to keep your protobuf dependencies out of your main project configuration, you can
+configure them within the plugin configuration itself. Ideally you should use the Maven project
+dependency configuration for this, but regardless, this feature is provided in case you have any
+unique use cases for it.
+
+```xml
+<plugin>
+  <groupId>io.github.ascopes</groupId>
+  <artifactId>protobuf-maven-plugin</artifactId>
+
+  <configuration>
+    <includeDependencies>
+      <includeDependency>
+        <groupId>org.example</groupId>
+        <artifactId>ticketsystem-ticket-board</artifactId>
+        <version>...</version>
+        <classifier>zip</classifier>
+        <scope>compile</scope>
+      
+        <excludes>
+          <exclude>
+            <groupId>org.example</groupId>
+            <artifactId>ticketsystem-beta-user-protos</artifactId>
+          </exclude>
+        </excludes>
+      </includeDependency>
+    </includeDependencies>
+  </configuration>
+</plugin>
+```
+
+### Compiling dependencies
+
+If you wish to also _compile_ your dependencies, you can specify them in the `sourceDependencies`
+and `sourceDirectories` configuration parameters, depending on whether they are Maven artifacts
+or paths on the local file system:
+
+```xml
+<plugin>
+  <groupId>io.github.ascopes</groupId>
+  <artifactId>protobuf-maven-plugin</artifactId>
+  
+  <configuration>
+    <sourceDependencies>
+      <sourceDependency>
+        <groupId>org.example.foobar</groupId>
+        <artifactId>core-protos</artifactId>
+        <version>1.2.3</version>
+        <type>zip</type>
+      </sourceDependency>
+    </sourceDependencies>
+    
+    <sourceDirectories>
+      <!-- Keep the default path -->
+      <sourceDirectory>${project.basedir}/src/protobuf</sourceDirectory>
+
+      <!-- Add something else from the local system -->
+      <sourceDirectory>/path/to/something/else/to/include</sourceDirectory>
+    </sourceDirectories>
+  </configuration>
+</plugin>
+```

--- a/protobuf-maven-plugin/src/site/site.xml
+++ b/protobuf-maven-plugin/src/site/site.xml
@@ -54,6 +54,7 @@
       <item name="Requirements" href="requirements.html"/>
       <item name="Basic Usage" href="basic-usage.html"/>
       <item name="Additional Language Support" href="additional-language-support.html"/>
+      <item name="Dependencies" href="dependencies.html"/>
       <item name="Descriptor Files" href="descriptor-files.html"/>
       <item name="Changing Protoc Versions" href="changing-protoc-versions.html"/>
       <item name="Using Protoc Plugins" href="using-protoc-plugins.html"/>

--- a/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherArtifactMapperTest.java
+++ b/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherArtifactMapperTest.java
@@ -458,7 +458,7 @@ class AetherArtifactMapperTest {
             .singleElement()
             .isSameAs(WildcardAwareDependencyTraverser.WILDCARD_EXCLUSION);
       } else {
-        var expectedExclusions = inputMavenArtifact.getExcludes()
+        var expectedExclusions = inputMavenArtifact.getExclusions()
             .stream()
             .map(exclusion -> new org.eclipse.aether.graph.Exclusion(
                 exclusion.getGroupId(),
@@ -646,7 +646,7 @@ class AetherArtifactMapperTest {
     when(artifact.getType()).thenReturn(type);
     when(artifact.getClassifier()).thenReturn(classifier);
     when(artifact.getDependencyResolutionDepth()).thenReturn(dependencyResolutionDepth);
-    when(artifact.getExcludes()).thenReturn(Set.of(exclusions));
+    when(artifact.getExclusions()).thenReturn(Set.of(exclusions));
     return artifact;
   }
 

--- a/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherArtifactMapperTest.java
+++ b/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherArtifactMapperTest.java
@@ -24,12 +24,14 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 
 import io.github.ascopes.protobufmavenplugin.dependencies.DependencyResolutionDepth;
+import io.github.ascopes.protobufmavenplugin.dependencies.MavenExclusionBean;
 import java.nio.file.Path;
+import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.maven.RepositoryUtils;
 import org.jspecify.annotations.Nullable;
@@ -456,9 +458,19 @@ class AetherArtifactMapperTest {
             .singleElement()
             .isSameAs(WildcardAwareDependencyTraverser.WILDCARD_EXCLUSION);
       } else {
+        var expectedExclusions = inputMavenArtifact.getExcludes()
+            .stream()
+            .map(exclusion -> new org.eclipse.aether.graph.Exclusion(
+                exclusion.getGroupId(),
+                exclusion.getArtifactId(),
+                exclusion.getClassifier(),
+                exclusion.getType()
+            ))
+            .collect(Collectors.toList());
+
         softly.assertThat(actualOutputDependency.getExclusions())
             .as("exclusions")
-            .isEmpty();
+            .containsExactlyInAnyOrderElementsOf(expectedExclusions);
       }
     });
   }
@@ -504,6 +516,68 @@ class AetherArtifactMapperTest {
         argumentSet(
             "DIRECT explicit depth, TRANSITIVE default depth",
             mavenArtifact("xxx", "bar", "420", null, null, DependencyResolutionDepth.TRANSITIVE),
+            DependencyResolutionDepth.TRANSITIVE,
+            false
+        ),
+        argumentSet(
+            "TRANSITIVE explicit depth, exclusions present",
+            mavenArtifact(
+                "xxx",
+                "bar",
+                "420",
+                null,
+                null,
+                DependencyResolutionDepth.TRANSITIVE,
+                mavenExclusion(
+                    "org.springframework.boot",
+                    "spring-boot-starter-webflux",
+                    "*",
+                    "*"
+                ),
+                mavenExclusion(
+                    "org.springframework.boot",
+                    "spring-boot-starter-logging",
+                    "*",
+                    "jar"
+                ),
+                mavenExclusion(
+                    "org.springframework.boot",
+                    "spring-boot-starter-parent",
+                    "test",
+                    "pom"
+                )
+            ),
+            DependencyResolutionDepth.DIRECT,
+            false
+        ),
+        argumentSet(
+            "TRANSITIVE default depth, exclusions present",
+            mavenArtifact(
+                "xxx",
+                "bar",
+                "420",
+                null,
+                null,
+                null,
+                mavenExclusion(
+                    "org.springframework.boot",
+                    "spring-boot-starter-webflux",
+                    "*",
+                    "*"
+                ),
+                mavenExclusion(
+                    "org.springframework.boot",
+                    "spring-boot-starter-logging",
+                    "*",
+                    "jar"
+                ),
+                mavenExclusion(
+                    "org.springframework.boot",
+                    "spring-boot-starter-parent",
+                    "test",
+                    "pom"
+                )
+            ),
             DependencyResolutionDepth.TRANSITIVE,
             false
         )
@@ -559,7 +633,8 @@ class AetherArtifactMapperTest {
       String version,
       @Nullable String classifier,
       @Nullable String type,
-      @Nullable DependencyResolutionDepth dependencyResolutionDepth
+      @Nullable DependencyResolutionDepth dependencyResolutionDepth,
+      MavenExclusionBean... exclusions
   ) {
     var artifact = mock(
         io.github.ascopes.protobufmavenplugin.dependencies.MavenArtifact.class,
@@ -571,7 +646,27 @@ class AetherArtifactMapperTest {
     when(artifact.getType()).thenReturn(type);
     when(artifact.getClassifier()).thenReturn(classifier);
     when(artifact.getDependencyResolutionDepth()).thenReturn(dependencyResolutionDepth);
+    when(artifact.getExcludes()).thenReturn(Set.of(exclusions));
     return artifact;
+  }
+
+  static io.github.ascopes.protobufmavenplugin.dependencies.MavenExclusionBean mavenExclusion(
+      String groupId,
+      String artifactId,
+      @Nullable String classifier,
+      @Nullable String extension
+  ) {
+    // Kind of gross that we have to return MavenExclusionBean here but Maven forces our hand
+    // due to not being able to cope with interface types.
+    var exclusion = mock(
+        io.github.ascopes.protobufmavenplugin.dependencies.MavenExclusionBean.class,
+        withSettings().strictness(Strictness.LENIENT)
+    );
+    when(exclusion.getGroupId()).thenReturn(groupId);
+    when(exclusion.getArtifactId()).thenReturn(artifactId);
+    when(exclusion.getClassifier()).thenReturn(classifier);
+    when(exclusion.getType()).thenReturn(extension);
+    return exclusion;
   }
 
   static org.eclipse.aether.artifact.ArtifactType eclipseArtifactType(


### PR DESCRIPTION
Add the ability to provide `<excludes>` blocks within `<sourceDependencies>` and `<importDependencies>` provided within the plugin `<configuration>` block, as requested by @jaredstehler.

Closes GH-575.

Relates to GH-555.