### PR TITLE
GH-579: Resolve dependencies from MavenProject repository list

### DIFF
--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherMavenArtifactPathResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherMavenArtifactPathResolver.java
@@ -27,7 +27,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.inject.Named;
-import org.apache.maven.RepositoryUtils;
 import org.apache.maven.execution.MavenSession;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.graph.Dependency;
@@ -54,8 +53,13 @@ final class AetherMavenArtifactPathResolver implements MavenArtifactPathResolver
       MavenSession mavenSession,
       RepositorySystem repositorySystem
   ) {
-    var artifactRepositories = mavenSession.getProjectBuildingRequest().getRemoteRepositories();
-    var remoteRepositories = RepositoryUtils.toRepos(artifactRepositories);
+    // Prior to v2.12.0, we used the ProjectBuildingRequest on the MavenSession
+    // and used RepositoryUtils.toRepos to create the repository list. GH-579
+    // was raised to report that the <repositories> block in the POM was being
+    // ignored. This appears to be due to the project building request only
+    // looking at what is in ~/.m2/settings.xml. The current project remote
+    // repositories seems to be what we need to use instead here.
+    var remoteRepositories = mavenSession.getCurrentProject().getRemoteProjectRepositories();
 
     this.mavenSession = mavenSession;
 

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/ProtobufMavenPluginRepositorySession.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/ProtobufMavenPluginRepositorySession.java
@@ -16,9 +16,7 @@
 package io.github.ascopes.protobufmavenplugin.dependencies.aether;
 
 import org.eclipse.aether.AbstractForwardingRepositorySystemSession;
-import org.eclipse.aether.RepositoryCache;
 import org.eclipse.aether.RepositorySystemSession;
-import org.jspecify.annotations.Nullable;
 
 /**
  * Custom repository session for the Protobuf Maven Plugin which injects some special components to
@@ -41,14 +39,6 @@ final class ProtobufMavenPluginRepositorySession
   @Override
   protected RepositorySystemSession getSession() {
     return delegate;
-  }
-
-  @Nullable
-  @Override
-  public RepositoryCache getCache() {
-    // GH-579: Temporarily disabled all caching to help debug issues with repository
-    // resolution. This may be enabled in the future again.
-    return null;
   }
 
   @Override

--- a/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherMavenArtifactPathResolverTest.java
+++ b/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherMavenArtifactPathResolverTest.java
@@ -21,13 +21,12 @@ import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 
 import java.util.List;
-import org.apache.maven.RepositoryUtils;
-import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.execution.MavenSession;
-import org.apache.maven.project.ProjectBuildingRequest;
+import org.apache.maven.project.MavenProject;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.ArtifactTypeRegistry;
+import org.eclipse.aether.repository.RemoteRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -39,29 +38,26 @@ import org.mockito.quality.Strictness;
  * @author Ashley Scopes
  */
 @DisplayName("AetherMavenArtifactPathResolver tests")
-@SuppressWarnings("deprecation")
 class AetherMavenArtifactPathResolverTest {
 
   MavenSession mavenSession;
-  ProjectBuildingRequest projectBuildingRequest;
-  List<ArtifactRepository> remoteRepositories;
+  MavenProject currentProject;
+  List<RemoteRepository> remoteRepositories;
   RepositorySystemSession repositorySystemSession;
   ArtifactTypeRegistry artifactTypeRegistry;
-
   RepositorySystem repositorySystem;
-
   AetherMavenArtifactPathResolver underTest;
 
   @BeforeEach
   void setUp() {
     mavenSession = mock(lenient());
-    projectBuildingRequest = mock(lenient());
+    currentProject = mock(lenient());
     remoteRepositories = List.of(mock(deep()), mock(deep()), mock(deep()));
     repositorySystemSession = mock(lenient());
     artifactTypeRegistry = mock(lenient());
 
-    when(mavenSession.getProjectBuildingRequest()).thenReturn(projectBuildingRequest);
-    when(projectBuildingRequest.getRemoteRepositories()).thenReturn(remoteRepositories);
+    when(mavenSession.getCurrentProject()).thenReturn(currentProject);
+    when(currentProject.getRemoteProjectRepositories()).thenReturn(remoteRepositories);
     when(mavenSession.getRepositorySession()).thenReturn(repositorySystemSession);
     when(repositorySystemSession.getArtifactTypeRegistry()).thenReturn(artifactTypeRegistry);
 
@@ -96,7 +92,7 @@ class AetherMavenArtifactPathResolverTest {
     assertThat(underTest.getAetherResolver().getRepositorySystemSession().getSession())
         .isSameAs(repositorySystemSession);
     assertThat(underTest.getAetherResolver().getRemoteRepositories())
-        .isEqualTo(RepositoryUtils.toRepos(remoteRepositories));
+        .isEqualTo(remoteRepositories);
   }
 
   static MockSettings lenient() {


### PR DESCRIPTION
This replaces the use of a ProjectBuildingRequest to determine the project remote repositories with inspection of the current MavenProject instead.

It has been observed that ProjectBuildingRequest ignores any repositories defined in the project POM, and only considers the contenrs of the settings.xml in the user's ~/.m2.

Conversely, it was observed that the list within the current MavenProject provides the correct expected list when the user has overridden repositories in their POM.

This means that dependencies should now resolve correctly in private repositories if the user overrides them per project.

Fixes GH-579