### PR TITLE
GH-582: Allow suppressing internal Artifact resolution errors for dependencies

### DIFF
--- a/protobuf-maven-plugin/pom.xml
+++ b/protobuf-maven-plugin/pom.xml
@@ -407,6 +407,9 @@
               <version>${maven-invoker-plugin.version}</version>
               <configuration>
                 <invokerPropertiesFile>invoker-path-protoc.properties</invokerPropertiesFile>
+                <!-- The remote debugger deadlocks if we don't set this! -->
+                <properties/>
+                <parallelThreads>1</parallelThreads>
               </configuration>
             </plugin>
           </plugins>

--- a/protobuf-maven-plugin/src/it/invoker-debug.properties
+++ b/protobuf-maven-plugin/src/it/invoker-debug.properties
@@ -15,7 +15,7 @@
 #
 
 # Verbose (runs Maven with --debug)
-invoker.debug = false
+invoker.debug = true
 invoker.mavenOpts = -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=localhost:5005
 invoker.quiet = false
 invoker.timeoutInSeconds = 0

--- a/protobuf-maven-plugin/src/it/invoker.properties
+++ b/protobuf-maven-plugin/src/it/invoker.properties
@@ -15,6 +15,6 @@
 #
 
 # Verbose (runs Maven with --debug)
-invoker.debug = false
+invoker.debug = true
 invoker.quiet = false
 invoker.timeoutInSeconds = 300

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherMavenArtifactPathResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherMavenArtifactPathResolver.java
@@ -95,7 +95,7 @@ final class AetherMavenArtifactPathResolver implements MavenArtifactPathResolver
   public Path resolveArtifact(MavenArtifact mavenArtifact) throws ResolutionException {
     log.debug("Resolving artifact: {}", mavenArtifact);
     var unresolvedArtifact = aetherMapper.mapPmpArtifactToEclipseArtifact(mavenArtifact);
-    var resolvedArtifact = aetherResolver.resolveArtifact(unresolvedArtifact);
+    var resolvedArtifact = aetherResolver.resolveRequiredArtifact(unresolvedArtifact);
     return aetherMapper.mapEclipseArtifactToPath(resolvedArtifact);
   }
 
@@ -122,7 +122,7 @@ final class AetherMavenArtifactPathResolver implements MavenArtifactPathResolver
           .forEach(unresolvedDependencies::add);
     }
 
-    var resolvedArtifacts = aetherResolver.resolveDependenciesToArtifacts(
+    var resolvedArtifacts = aetherResolver.resolveDependencies(
         unresolvedDependencies,
         dependencyScopes,
         failOnInvalidDependencies

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherResolver.java
@@ -18,6 +18,7 @@ package io.github.ascopes.protobufmavenplugin.dependencies.aether;
 import static java.util.Objects.requireNonNull;
 
 import io.github.ascopes.protobufmavenplugin.utils.ResolutionException;
+import io.github.ascopes.protobufmavenplugin.utils.StringUtils;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -30,6 +31,7 @@ import org.eclipse.aether.graph.Dependency;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.resolution.ArtifactRequest;
 import org.eclipse.aether.resolution.ArtifactResolutionException;
+import org.eclipse.aether.resolution.ArtifactResult;
 import org.eclipse.aether.resolution.DependencyRequest;
 import org.eclipse.aether.resolution.DependencyResolutionException;
 import org.eclipse.aether.resolution.DependencyResult;
@@ -39,6 +41,10 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Integration layer with the Eclipse Aether resolver.
+ *
+ * <p>Warning: the code in this class is very fragile and changing it can easily result in the
+ * introduction of regressions for users. If you need to alter it, be very sure that you know
+ * what you are doing!
  *
  * @author Ashley Scopes
  * @since 2.4.4
@@ -76,128 +82,133 @@ final class AetherResolver {
     return Collections.unmodifiableList(remoteRepositories);
   }
 
-  Artifact resolveArtifact(Artifact unresolvedArtifact) throws ResolutionException {
-    log.info("Resolving artifact {} from repositories", unresolvedArtifact);
-    var request = new ArtifactRequest(unresolvedArtifact, remoteRepositories, null);
+  Artifact resolveRequiredArtifact(Artifact artifact) throws ResolutionException {
+    log.info("Attempting to resolve artifact {}", artifact);
+
+    var request = new ArtifactRequest();
+    request.setArtifact(artifact);
+    request.setRepositories(remoteRepositories);
+
+    ArtifactResult result;
 
     try {
-      var response = repositorySystem.resolveArtifact(repositorySystemSession, request);
-      if (response.isResolved()) {
-        // Almost certain this shouldn't happen, but knowing my luck, some weird edge case will
-        // exist with this.
-        logWarnings("resolving artifact " + unresolvedArtifact, response.getExceptions());
-        return requireNonNull(response.getArtifact(), "No artifact was returned! Panic!");
-      }
-
-      throw resolutionException(
-          "failed to resolve artifact " + unresolvedArtifact, response.getExceptions()
-      );
-
+      result = repositorySystem.resolveArtifact(repositorySystemSession, request);
     } catch (ArtifactResolutionException ex) {
-      throw new ResolutionException("Failed to resolve artifact " + unresolvedArtifact, ex);
+      log.debug("Discarding internal exception", ex);
+      result = ex.getResult();
     }
-  }
 
-  // Include project dependencies via flag in callee, don't do it here, it is a mess.
-  Collection<Artifact> resolveDependenciesToArtifacts(
-      List<Dependency> unresolvedDependencies,
-      Set<String> dependencyScopes,
-      boolean failOnInvalidDependencies
-  ) throws ResolutionException {
-    var scopeFilter = new ScopeDependencyFilter(dependencyScopes);
-    var collectRequest = new CollectRequest(unresolvedDependencies, null, remoteRepositories);
-    var request = new DependencyRequest(collectRequest, scopeFilter);
-
-    log.debug(
-        "Attempting to resolve the following dependencies in this pass: {}",
-        unresolvedDependencies
-    );
-
-    var response = resolveDependencies(request, failOnInvalidDependencies);
-    return extractArtifactsFromResolvedDependencies(response, failOnInvalidDependencies);
-  }
-
-  private DependencyResult resolveDependencies(
-      DependencyRequest request,
-      boolean failOnInvalidDependencies
-  ) throws ResolutionException {
-    DependencyResult response;
-
-    // Part 1: resolve the dependencies directly.
-    try {
-      response = repositorySystem.resolveDependencies(repositorySystemSession, request);
-
-    } catch (DependencyResolutionException ex) {
-      // GH-299: if this exception is raised, we may still have some results we can use. If this is
-      // the case then resolution only partially failed, so continue for now unless strict
-      // resolution is enabled. We do not fail-fast here anymore (since 2.4.0) as any resolution
-      // errors should be dealt with by the maven-compiler-plugin later on if needed.
-      //
-      // If we didn't get any result, then something more fatal has occurred, so raise.
-      response = ex.getResult();
-
-      if (response == null || failOnInvalidDependencies) {
-        throw resolutionException("Failed to resolve dependencies from repositories", List.of(ex));
-      }
-
-      log.warn(
-          "Failed to resolve one or more dependencies, this operation will be a best-effort "
-              + "attempt, and dependencies may be missing during protobuf compilation. "
-              + "Error was: {}",
-          // Exceptions are hidden if we don't pass --error to Maven, so we report the
-          // message as well.
-          ex.getMessage(),
-          ex
+    // Looks like we can get resolution exceptions even if things resolve correctly, as it appears
+    // to raise for the local repository first.
+    // If this happens, don't bother raising or reporting it as it is normal behaviour. If anything
+    // else goes wrong, then we can panic about it.
+    if (result.isMissing()) {
+      throw mapExceptions(
+          "Failed to resolve artifact " + artifact,
+          result.getExceptions()
       );
     }
 
-    return response;
+    reportWarnings(result.getExceptions());
+
+    // This shouldn't happen, but I do not trust that Aether isn't hiding some wild edge cases
+    // for me here.
+    return requireNonNull(
+        result.getArtifact(),
+        () -> "No resolution exceptions raised, but no artifact was returned "
+            + "by Aether while resolving " + artifact
+    );
   }
 
-  private List<Artifact> extractArtifactsFromResolvedDependencies(
-      DependencyResult response,
-      boolean failOnInvalidDependencies
+  Collection<Artifact> resolveDependencies(
+      List<Dependency> dependencies,
+      Set<String> allowedDependencyScopes,
+      boolean failOnResolutionErrors
   ) throws ResolutionException {
-    var artifacts = new ArrayList<Artifact>();
-    var exceptions = new ArrayList<Exception>();
-    var failedAtLeastOnce = false;
+    var collectRequest = new CollectRequest();
+    collectRequest.setDependencies(dependencies);
+    collectRequest.setManagedDependencies(null);  // TODO: dependency management in GH-555
+    collectRequest.setRepositories(remoteRepositories);
 
-    for (var artifactResponse : response.getArtifactResults()) {
-      exceptions.addAll(artifactResponse.getExceptions());
-      var artifact = artifactResponse.getArtifact();
-      if (artifact == null) {
-        failedAtLeastOnce = true;
-      } else {
+    var dependencyRequest = new DependencyRequest();
+    dependencyRequest.setCollectRequest(collectRequest);
+    dependencyRequest.setFilter(new ScopeDependencyFilter(allowedDependencyScopes));
+
+    log.info(
+        "Resolving {}",
+        StringUtils.pluralize(dependencies.size(), "dependency", "dependencies")
+    );
+    log.debug("Attempting to resolve the following dependencies: {}", dependencies);
+
+    DependencyResult dependencyResult;
+
+    try {
+      dependencyResult = repositorySystem
+          .resolveDependencies(repositorySystemSession, dependencyRequest);
+    } catch (DependencyResolutionException ex) {
+      log.debug("Discarding internal exception", ex);
+      dependencyResult = ex.getResult();
+    }
+
+    var artifacts = new ArrayList<Artifact>();
+    var exceptions = new ArrayList<>(dependencyResult.getCollectExceptions());
+    var isMissing = false;
+
+    // Why oh why can't we return a simple result type for this...
+    for (var artifactResult : dependencyResult.getArtifactResults()) {
+      var artifact = artifactResult.getArtifact();
+      if (artifact != null) {
+        log.debug("Resolution of {} returned artifact {}", dependencies, artifact);
         artifacts.add(artifact);
       }
-    }
 
-    if (failedAtLeastOnce) {
-      if (failOnInvalidDependencies) {
-        throw resolutionException("Failed to resolve artifacts for dependencies", exceptions);
-      } else {
-        log.warn(
-            "Encountered {} problem(s) resolving artifacts. Enable debug logs for more details",
-            exceptions.size()
-        );
-        exceptions.forEach(ex -> log.debug("Ignoring artifact resolution exception", ex));
+      if (artifactResult.isMissing()) {
+        isMissing = true;
       }
+
+      exceptions.addAll(artifactResult.getExceptions());
     }
-    return artifacts;
+
+    // Looks like we can get resolution exceptions even if things resolve correctly, as it appears
+    // to raise for the local repository first.
+    // If this happens, don't bother raising as it is normal behaviour. If anything else goes wrong,
+    // then we can panic about it.
+    if (isMissing && failOnResolutionErrors) {
+      throw mapExceptions("Failed to resolve dependencies", exceptions);
+    }
+
+    reportWarnings(exceptions);
+
+    return Collections.unmodifiableList(artifacts);
   }
 
-  private ResolutionException resolutionException(String errorMessage, Iterable<Exception> causes) {
-    var ex = new ResolutionException(errorMessage);
-    var iterator = causes.iterator();
-    if (iterator.hasNext()) {
-      ex.initCause(iterator.next());
-      iterator.forEachRemaining(ex::addSuppressed);
-    }
-    return ex;
+  private ResolutionException mapExceptions(String message, Collection<Exception> causes) {
+    var causeIterator = causes.iterator();
+
+    // Assumption: this is always possible. If it isn't, we screwed up somewhere.
+    var cause = causeIterator.next();
+    var exception = new ResolutionException(
+        message
+            + " - resolution failed with "
+            + StringUtils.pluralize(causes.size(), "error: ", "errors - first was: ")
+            + cause.getMessage(),
+        cause
+    );
+    causeIterator.forEachRemaining(exception::addSuppressed);
+    return exception;
   }
 
-  private void logWarnings(String descriptionOfAction, Iterable<Exception> exceptions) {
-    exceptions.iterator().forEachRemaining(ex -> log.debug(
-        "Encountered a non-fatal resolution error while {}", descriptionOfAction, ex));
+  private void reportWarnings(Iterable<? extends Exception> exceptions) {
+    exceptions.forEach(exception -> {
+      // We purposely log the warning class and message twice, since exception tracebacks are
+      // hidden unless Maven was invoked with --errors.
+      //noinspection LoggingPlaceholderCountMatchesArgumentCount
+      log.warn(
+          "Dependency resolution warning was reported - {}: {}",
+          exception.getClass().getName(),
+          exception.getMessage(),
+          exception
+      );
+    });
   }
 }

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generation/ProtobufBuildOrchestrator.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generation/ProtobufBuildOrchestrator.java
@@ -27,6 +27,7 @@ import io.github.ascopes.protobufmavenplugin.sources.SourceListing;
 import io.github.ascopes.protobufmavenplugin.sources.incremental.IncrementalCacheManager;
 import io.github.ascopes.protobufmavenplugin.utils.FileUtils;
 import io.github.ascopes.protobufmavenplugin.utils.ResolutionException;
+import io.github.ascopes.protobufmavenplugin.utils.StringUtils;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -247,9 +248,9 @@ public final class ProtobufBuildOrchestrator {
 
     log.info(
         "Generating source code from {} (discovered {} within {})",
-        pluralize(sourcesToCompile.size(), "source file"),
-        pluralize(totalSourceFileCount, "source file"),
-        pluralize(projectInputs.getCompilableSources().size(), "source path")
+        StringUtils.pluralize(sourcesToCompile.size(), "source file"),
+        StringUtils.pluralize(totalSourceFileCount, "source file"),
+        StringUtils.pluralize(projectInputs.getCompilableSources().size(), "source path")
     );
 
     return sourcesToCompile;
@@ -288,11 +289,5 @@ public final class ProtobufBuildOrchestrator {
         );
       }
     }
-  }
-
-  private static String pluralize(int count, String name) {
-    return count == 1
-        ? "1 " + name
-        : count + " " + name + "s";
   }
 }

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/utils/StringUtils.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/utils/StringUtils.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2023 - 2025, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.ascopes.protobufmavenplugin.utils;
+
+/**
+ * Various common string helpers.
+ *
+ * @author Ashley Scopes
+ */
+public final class StringUtils {
+  private StringUtils() {
+    // Static-only class.
+  }
+
+  public static String pluralize(int quantity, String singular) {
+    return pluralize(quantity, singular, singular + "s");
+  }
+
+  public static String pluralize(int quantity, String singular, String plural) {
+    return quantity == 1
+        ? quantity + " " + singular
+        : quantity + " " + plural;
+  }
+}

--- a/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/utils/StringUtilsTest.java
+++ b/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/utils/StringUtilsTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2023 - 2025, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.ascopes.protobufmavenplugin.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+@DisplayName("StringUtils tests")
+class StringUtilsTest {
+  @DisplayName(".pluralise(int, String) returns the expected results")
+  @CsvSource({
+      "0, cat, 0 cats",
+      "1, cat, 1 cat",
+      "2, cat, 2 cats",
+      "2718281, cat, 2718281 cats",
+  })
+  @ParameterizedTest(name = "for quantity {0} and singular {1}, expect {2}")
+  void pluraliseIntStringReturnsExpectedValue(int quantity, String singular, String expected) {
+    // Then
+    assertThat(StringUtils.pluralize(quantity, singular))
+        .isEqualTo(expected);
+  }
+
+  @DisplayName(".pluralise(int, String, String) returns the expected results")
+  @CsvSource({
+      "0, cat, cats, 0 cats",
+      "0, sheep, sheep, 0 sheep",
+      "0, dependency, dependencies, 0 dependencies",
+      "1, cat, cats, 1 cat",
+      "1, sheep, sheep, 1 sheep",
+      "1, dependency, dependencies, 1 dependency",
+      "2, cat, cats, 2 cats",
+      "2, sheep, sheep, 2 sheep",
+      "2, dependency, dependencies, 2 dependencies",
+      "2718281, cat, cats, 2718281 cats",
+      "2718281, sheep, sheep, 2718281 sheep",
+      "2718281, dependency, dependencies, 2718281 dependencies",
+  })
+  @ParameterizedTest(name = "for quantity {0}, singular {1}, and plural {2}, expect {3}")
+  void pluraliseIntStringReturnsExpectedValue(
+      int quantity,
+      String singular,
+      String plural,
+      String expected
+  ) {
+    // Then
+    assertThat(StringUtils.pluralize(quantity, singular, plural))
+        .isEqualTo(expected);
+  }
+}


### PR DESCRIPTION
Extend the functionality to not fail on dependency resolution errors to the artifact resolution mechanism within the dependency resolver backend.

Overhauled the underlying logic to avoid other edge cases due to the way Aether works being overly confusing.