### PR TITLE
GH-586: Scope CDI components to the current executon

### DIFF
--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/PlatformClassifierFactory.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/PlatformClassifierFactory.java
@@ -21,12 +21,14 @@ import java.util.Map;
 import javax.inject.Inject;
 import javax.inject.Named;
 import org.apache.maven.execution.scope.MojoExecutionScoped;
+import org.eclipse.sisu.Description;
 
 /**
  * Factory that can produce classifiers for dependencies based on the current platform.
  *
  * @author Ashley Scopes
  */
+@Description("Generates classifiers for protoc binaries based on the current platform")
 @MojoExecutionScoped
 @Named
 public final class PlatformClassifierFactory {

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/PlatformClassifierFactory.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/PlatformClassifierFactory.java
@@ -20,12 +20,14 @@ import io.github.ascopes.protobufmavenplugin.utils.ResolutionException;
 import java.util.Map;
 import javax.inject.Inject;
 import javax.inject.Named;
+import org.apache.maven.execution.scope.MojoExecutionScoped;
 
 /**
  * Factory that can produce classifiers for dependencies based on the current platform.
  *
  * @author Ashley Scopes
  */
+@MojoExecutionScoped
 @Named
 public final class PlatformClassifierFactory {
 

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/UrlResourceFetcher.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/UrlResourceFetcher.java
@@ -30,6 +30,7 @@ import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Named;
 import org.apache.maven.Maven;
+import org.apache.maven.execution.scope.MojoExecutionScoped;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,6 +40,7 @@ import org.slf4j.LoggerFactory;
  * @author Ashley Scopes
  * @since 0.4.0
  */
+@MojoExecutionScoped
 @Named
 public final class UrlResourceFetcher {
 

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/UrlResourceFetcher.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/UrlResourceFetcher.java
@@ -31,6 +31,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import org.apache.maven.Maven;
 import org.apache.maven.execution.scope.MojoExecutionScoped;
+import org.eclipse.sisu.Description;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,6 +41,7 @@ import org.slf4j.LoggerFactory;
  * @author Ashley Scopes
  * @since 0.4.0
  */
+@Description("Fetches and downloads resources from URLs")
 @MojoExecutionScoped
 @Named
 public final class UrlResourceFetcher {

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherMavenArtifactPathResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherMavenArtifactPathResolver.java
@@ -28,6 +28,7 @@ import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.inject.Named;
 import org.apache.maven.execution.MavenSession;
+import org.apache.maven.execution.scope.MojoExecutionScoped;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.graph.Dependency;
 import org.slf4j.Logger;
@@ -40,6 +41,7 @@ import org.slf4j.LoggerFactory;
  * @author Ashley Scopes
  * @since 2.4.4, many iterations of this existed in the past with different names.
  */
+@MojoExecutionScoped
 @Named
 final class AetherMavenArtifactPathResolver implements MavenArtifactPathResolver {
   private static final Logger log = LoggerFactory.getLogger(AetherMavenArtifactPathResolver.class);

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherMavenArtifactPathResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherMavenArtifactPathResolver.java
@@ -31,6 +31,7 @@ import org.apache.maven.execution.MavenSession;
 import org.apache.maven.execution.scope.MojoExecutionScoped;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.graph.Dependency;
+import org.eclipse.sisu.Description;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,6 +42,7 @@ import org.slf4j.LoggerFactory;
  * @author Ashley Scopes
  * @since 2.4.4, many iterations of this existed in the past with different names.
  */
+@Description("Integrates with Eclipse Aether to resolve and download dependencies locally")
 @MojoExecutionScoped
 @Named
 final class AetherMavenArtifactPathResolver implements MavenArtifactPathResolver {

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generation/ProtobufBuildOrchestrator.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generation/ProtobufBuildOrchestrator.java
@@ -39,6 +39,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.execution.scope.MojoExecutionScoped;
+import org.eclipse.sisu.Description;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,6 +51,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Ashley Scopes
  */
+@Description("Orchestrator for the entire generation process, gluing all components together")
 @MojoExecutionScoped
 @Named
 public final class ProtobufBuildOrchestrator {

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generation/ProtobufBuildOrchestrator.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generation/ProtobufBuildOrchestrator.java
@@ -38,6 +38,7 @@ import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.inject.Named;
 import org.apache.maven.execution.MavenSession;
+import org.apache.maven.execution.scope.MojoExecutionScoped;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,6 +50,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Ashley Scopes
  */
+@MojoExecutionScoped
 @Named
 public final class ProtobufBuildOrchestrator {
 

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/BinaryPluginResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/BinaryPluginResolver.java
@@ -30,6 +30,7 @@ import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Named;
 import org.apache.maven.execution.scope.MojoExecutionScoped;
+import org.eclipse.sisu.Description;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,6 +39,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Ashley Scopes
  */
+@Description("Resolves native binary protoc plugins from various remote and local locations")
 @MojoExecutionScoped
 @Named
 final class BinaryPluginResolver {

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/BinaryPluginResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/BinaryPluginResolver.java
@@ -29,6 +29,7 @@ import java.util.Collection;
 import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Named;
+import org.apache.maven.execution.scope.MojoExecutionScoped;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,6 +38,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Ashley Scopes
  */
+@MojoExecutionScoped
 @Named
 final class BinaryPluginResolver {
 

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/JvmPluginResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/JvmPluginResolver.java
@@ -46,6 +46,7 @@ import java.util.jar.Manifest;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.inject.Named;
+import org.apache.maven.execution.scope.MojoExecutionScoped;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -65,6 +66,7 @@ import org.slf4j.LoggerFactory;
  * @author Ashley Scopes
  * @since 2.6.0
  */
+@MojoExecutionScoped
 @Named
 final class JvmPluginResolver {
 

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/JvmPluginResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/JvmPluginResolver.java
@@ -47,6 +47,7 @@ import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.inject.Named;
 import org.apache.maven.execution.scope.MojoExecutionScoped;
+import org.eclipse.sisu.Description;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -66,6 +67,7 @@ import org.slf4j.LoggerFactory;
  * @author Ashley Scopes
  * @since 2.6.0
  */
+@Description("Resolves and packages JVM protoc plugins from various remote and local locations")
 @MojoExecutionScoped
 @Named
 final class JvmPluginResolver {

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/ProjectPluginResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/ProjectPluginResolver.java
@@ -24,6 +24,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.inject.Inject;
 import javax.inject.Named;
+import org.apache.maven.execution.scope.MojoExecutionScoped;
 
 /**
  * Resolver for plugins within a project.
@@ -31,13 +32,14 @@ import javax.inject.Named;
  * @author Ashley Scopes
  * @since 2.7.0
  */
+@MojoExecutionScoped
 @Named
 public final class ProjectPluginResolver {
   private final BinaryPluginResolver binaryPluginResolver;
   private final JvmPluginResolver jvmPluginResolver;
 
   @Inject
-  public ProjectPluginResolver(
+  ProjectPluginResolver(
       BinaryPluginResolver binaryPluginResolver,
       JvmPluginResolver jvmPluginResolver
   ) {

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/ProjectPluginResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/ProjectPluginResolver.java
@@ -25,6 +25,7 @@ import java.util.stream.Stream;
 import javax.inject.Inject;
 import javax.inject.Named;
 import org.apache.maven.execution.scope.MojoExecutionScoped;
+import org.eclipse.sisu.Description;
 
 /**
  * Resolver for plugins within a project.
@@ -32,6 +33,7 @@ import org.apache.maven.execution.scope.MojoExecutionScoped;
  * @author Ashley Scopes
  * @since 2.7.0
  */
+@Description("Resolves and packages protoc plugins from various remote and local locations")
 @MojoExecutionScoped
 @Named
 public final class ProjectPluginResolver {

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/protoc/CommandLineExecutor.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/protoc/CommandLineExecutor.java
@@ -19,13 +19,13 @@ import io.github.ascopes.protobufmavenplugin.utils.ArgumentFileBuilder;
 import io.github.ascopes.protobufmavenplugin.utils.TeeWriter;
 import io.github.ascopes.protobufmavenplugin.utils.TemporarySpace;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.InterruptedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import javax.inject.Inject;
 import javax.inject.Named;
+import org.apache.maven.execution.scope.MojoExecutionScoped;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Ashley Scopes
  */
+@MojoExecutionScoped
 @Named
 public final class CommandLineExecutor {
 

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/protoc/CommandLineExecutor.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/protoc/CommandLineExecutor.java
@@ -26,6 +26,7 @@ import java.nio.file.Path;
 import javax.inject.Inject;
 import javax.inject.Named;
 import org.apache.maven.execution.scope.MojoExecutionScoped;
+import org.eclipse.sisu.Description;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,6 +35,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Ashley Scopes
  */
+@Description("Executes protoc in a subprocess, intercepting any outputs")
 @MojoExecutionScoped
 @Named
 public final class CommandLineExecutor {

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/protoc/ProtocResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/protoc/ProtocResolver.java
@@ -29,6 +29,7 @@ import java.nio.file.Path;
 import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Named;
+import org.apache.maven.execution.scope.MojoExecutionScoped;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,6 +38,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Ashley Scopes
  */
+@MojoExecutionScoped
 @Named
 public final class ProtocResolver {
 

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/protoc/ProtocResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/protoc/ProtocResolver.java
@@ -30,6 +30,7 @@ import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Named;
 import org.apache.maven.execution.scope.MojoExecutionScoped;
+import org.eclipse.sisu.Description;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,6 +39,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Ashley Scopes
  */
+@Description("Finds or downloads the required version of protoc from various locations")
 @MojoExecutionScoped
 @Named
 public final class ProtocResolver {

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/sources/ProjectInputResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/sources/ProjectInputResolver.java
@@ -25,6 +25,7 @@ import java.util.stream.Stream;
 import javax.inject.Inject;
 import javax.inject.Named;
 import org.apache.maven.execution.scope.MojoExecutionScoped;
+import org.eclipse.sisu.Description;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,18 +36,19 @@ import org.slf4j.LoggerFactory;
  * @author Ashley Scopes
  * @since 2.7.0
  */
+@Description("Resolves all protobuf sources to compile and/or make importable in the project")
 @MojoExecutionScoped
 @Named
 public final class ProjectInputResolver {
   private static final Logger log = LoggerFactory.getLogger(ProjectInputResolver.class);
 
   private final MavenArtifactPathResolver artifactPathResolver;
-  private final SourcePathResolver sourceResolver;
+  private final ProtoSourceResolver sourceResolver;
 
   @Inject
-  public ProjectInputResolver(
+  ProjectInputResolver(
       MavenArtifactPathResolver artifactPathResolver,
-      SourcePathResolver sourceResolver
+      ProtoSourceResolver sourceResolver
   ) {
     this.artifactPathResolver = artifactPathResolver;
     this.sourceResolver = sourceResolver;

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/sources/ProjectInputResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/sources/ProjectInputResolver.java
@@ -24,6 +24,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.inject.Inject;
 import javax.inject.Named;
+import org.apache.maven.execution.scope.MojoExecutionScoped;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,6 +35,7 @@ import org.slf4j.LoggerFactory;
  * @author Ashley Scopes
  * @since 2.7.0
  */
+@MojoExecutionScoped
 @Named
 public final class ProjectInputResolver {
   private static final Logger log = LoggerFactory.getLogger(ProjectInputResolver.class);

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/sources/ProtoSourceResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/sources/ProtoSourceResolver.java
@@ -32,6 +32,7 @@ import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.inject.Named;
 import org.apache.maven.execution.scope.MojoExecutionScoped;
+import org.eclipse.sisu.Description;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,20 +45,21 @@ import org.slf4j.LoggerFactory;
  *
  * @author Ashley Scopes
  */
+@Description("Discovers proto sources in various packaging formats on the file system")
 @MojoExecutionScoped
 @Named
-public final class SourcePathResolver {
+final class ProtoSourceResolver {
 
   private static final Set<String> POM_FILE_EXTENSIONS = Set.of(".pom", ".xml");
   private static final Set<String> ZIP_FILE_EXTENSIONS = Set.of(".jar", ".zip");
 
-  private static final Logger log = LoggerFactory.getLogger(SourcePathResolver.class);
+  private static final Logger log = LoggerFactory.getLogger(ProtoSourceResolver.class);
 
   private final ConcurrentExecutor concurrentExecutor;
   private final TemporarySpace temporarySpace;
 
   @Inject
-  public SourcePathResolver(
+  ProtoSourceResolver(
       ConcurrentExecutor concurrentExecutor,
       TemporarySpace temporarySpace
   ) {
@@ -65,7 +67,7 @@ public final class SourcePathResolver {
     this.temporarySpace = temporarySpace;
   }
 
-  public Collection<SourceListing> resolveSources(
+  Collection<SourceListing> resolveSources(
       Collection<Path> rootPaths,
       SourceGlobFilter filter
   ) {

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/sources/SourcePathResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/sources/SourcePathResolver.java
@@ -31,6 +31,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.inject.Named;
+import org.apache.maven.execution.scope.MojoExecutionScoped;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,6 +44,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Ashley Scopes
  */
+@MojoExecutionScoped
 @Named
 public final class SourcePathResolver {
 

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/utils/ConcurrentExecutor.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/utils/ConcurrentExecutor.java
@@ -30,6 +30,7 @@ import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 import javax.inject.Named;
 import org.apache.maven.execution.scope.MojoExecutionScoped;
+import org.eclipse.sisu.Description;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,6 +40,7 @@ import org.slf4j.LoggerFactory;
  * @author Ashley Scopes
  * @since 2.2.0
  */
+@Description("Manages an execution-wide thread pool for concurrent task execution")
 @MojoExecutionScoped
 @Named
 public final class ConcurrentExecutor {

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/utils/ConcurrentExecutor.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/utils/ConcurrentExecutor.java
@@ -29,7 +29,7 @@ import java.util.stream.Collectors;
 import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 import javax.inject.Named;
-import javax.inject.Singleton;
+import org.apache.maven.execution.scope.MojoExecutionScoped;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,8 +39,8 @@ import org.slf4j.LoggerFactory;
  * @author Ashley Scopes
  * @since 2.2.0
  */
+@MojoExecutionScoped
 @Named
-@Singleton  // Only one instance globally to avoid resource exhaustion
 public final class ConcurrentExecutor {
 
   private static final Logger log = LoggerFactory.getLogger(ConcurrentExecutor.class);

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/utils/HostSystem.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/utils/HostSystem.java
@@ -36,6 +36,7 @@ import java.util.stream.Stream;
 import javax.inject.Inject;
 import javax.inject.Named;
 import org.apache.maven.SessionScoped;
+import org.eclipse.sisu.Description;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,6 +45,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Ashley Scopes
  */
+@Description("Discovers information about the platform that the plugin is being invoked on")
 @Named
 @SessionScoped
 public final class HostSystem {

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/utils/HostSystem.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/utils/HostSystem.java
@@ -35,7 +35,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.inject.Inject;
 import javax.inject.Named;
-import javax.inject.Singleton;
+import org.apache.maven.SessionScoped;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,7 +45,7 @@ import org.slf4j.LoggerFactory;
  * @author Ashley Scopes
  */
 @Named
-@Singleton  // Global singleton, shared between plugin instances potentially.
+@SessionScoped
 public final class HostSystem {
 
   private static final Logger log = LoggerFactory.getLogger(HostSystem.class);

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/utils/SystemPathBinaryResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/utils/SystemPathBinaryResolver.java
@@ -23,6 +23,7 @@ import java.util.function.Predicate;
 import javax.inject.Inject;
 import javax.inject.Named;
 import org.apache.maven.SessionScoped;
+import org.eclipse.sisu.Description;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,6 +33,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Ashley Scopes
  */
+@Description("Discovers executables on the system-path using OS-aware resolution techniques")
 @Named
 @SessionScoped
 public final class SystemPathBinaryResolver {

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/utils/SystemPathBinaryResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/utils/SystemPathBinaryResolver.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import java.util.function.Predicate;
 import javax.inject.Inject;
 import javax.inject.Named;
+import org.apache.maven.SessionScoped;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,6 +33,7 @@ import org.slf4j.LoggerFactory;
  * @author Ashley Scopes
  */
 @Named
+@SessionScoped
 public final class SystemPathBinaryResolver {
 
   private static final Logger log = LoggerFactory.getLogger(SystemPathBinaryResolver.class);

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/utils/TemporarySpace.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/utils/TemporarySpace.java
@@ -25,6 +25,7 @@ import javax.inject.Named;
 import org.apache.maven.execution.scope.MojoExecutionScoped;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.project.MavenProject;
+import org.eclipse.sisu.Description;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,6 +34,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Ashley Scopes
  */
+@Description("Manages build-scoped reusable temporary directories for processing")
 @MojoExecutionScoped
 @Named
 public final class TemporarySpace {
@@ -58,10 +60,10 @@ public final class TemporarySpace {
         "unknown-goal"
     );
     var executionId = Objects.requireNonNullElse(
-        mojoExecution.getExecutionId(), 
+        mojoExecution.getExecutionId(),
         "unknown-execution-id"
     );
-    
+
     var dir = Path.of(mavenProject.getBuild().getDirectory())
         .resolve(FRAG)
         // GH-421: Include the execution ID and goal to keep file paths unique

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/utils/TemporarySpace.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/utils/TemporarySpace.java
@@ -22,6 +22,7 @@ import java.nio.file.Path;
 import java.util.Objects;
 import javax.inject.Inject;
 import javax.inject.Named;
+import org.apache.maven.execution.scope.MojoExecutionScoped;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.project.MavenProject;
 import org.slf4j.Logger;
@@ -32,6 +33,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Ashley Scopes
  */
+@MojoExecutionScoped
 @Named
 public final class TemporarySpace {
 
@@ -47,6 +49,7 @@ public final class TemporarySpace {
     this.mojoExecution = mojoExecution;
   }
 
+  @SuppressWarnings("ExtractMethodRecommender")
   public Path createTemporarySpace(String... bits) {
     // GH-488: Execution ID and goal can potentially be null, e.g. in Quarkus dev mode, so
     // default to a semi-sensible value to prevent a NullPointerException.


### PR DESCRIPTION
- Fix the default prototyping behaviour of CDI dependencies that results in a number of copies of the same components being initialised on each plugin execution. Replace this with MOJO execution-scoped components instead.
    - This should reduce overhead of invoking the plugin during builds.
- Replace global `@Singleton` CDI components with session-scoped components instead.
- Describe all Sisu components.
- Fix naming of SourcePathResolver to be clearer (see GH-567).

Fixes GH-586.
Closes GH-567 as no longer needed.