### PR TITLE
Update site skin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,7 @@
 
     <!-- Plugin dependencies -->
     <checkstyle.version>10.21.4</checkstyle.version>
+    <maven-fluido-skin.version>2.1.0</maven-fluido-skin.version>
     <maven-surefire-junit5-tree-reporter.version>1.4.0</maven-surefire-junit5-tree-reporter.version>
 
     <!--
@@ -191,6 +192,21 @@
         <groupId>org.apache.maven.resolver</groupId>
         <artifactId>maven-resolver-api</artifactId>
         <version>${maven-resolver-api.version}</version>
+      </dependency>
+
+      <dependency>
+        <!--
+            This is a bit of a hack: we do not technically depend
+            on this in any project but we reference it in our
+            site.xml that is consumed by Maven Site Plugin. Usually
+            we'd declare the version in there directly, but by doing
+            it here with a property, we cal allow dependabot to
+            start to manage this automatically for us. The property
+            is then filtered into the site.xml automatically.
+        -->  
+        <groupId>org.apache.maven.skins</groupId>
+        <artifactId>maven-fluido-skin</artifactId>
+        <version>${maven-fluido-skin.version}</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
     <maven-project-info-reports-plugin.version>3.9.0</maven-project-info-reports-plugin.version>
     <maven-release-plugin.version>3.1.1</maven-release-plugin.version>
     <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
-    <maven-site-plugin.version>4.0.0-M16</maven-site-plugin.version>
+    <maven-site-plugin.version>3.21.0</maven-site-plugin.version>
     <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
     <maven-surefire-plugin.version>3.5.2</maven-surefire-plugin.version>
     <sisu-maven-plugin.version>0.3.5</sisu-maven-plugin.version>

--- a/protobuf-maven-plugin/src/site/site.xml
+++ b/protobuf-maven-plugin/src/site/site.xml
@@ -78,6 +78,6 @@
   <skin>
     <groupId>org.apache.maven.skins</groupId>
     <artifactId>maven-fluido-skin</artifactId>
-    <version>2.0.0-M10</version>
+    <version>${maven-fluido-skin.version}</version>
   </skin>
 </site>


### PR DESCRIPTION
- Roll back maven-site-plugin to v3

    Seems the newest Fluido skin is incompatible with the 4.0.0-M16
    release of maven-site-plugin, and the newest 3.x version is a few
    months newer. Let's wait until v4 is stable before upgrading it.

- Upgrade fluido skin to stable release

    Move the fluido skin to a stable release, and track it
    in the pom.xml so dependabot can start to manage it
    automatically in the future.