### PR TITLE
Generate table of contents in markdown documentation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -313,6 +313,7 @@
                 <includes>
                   <include>**/src/**/*.groovy</include>
                   <include>**/src/**/*.java</include>
+                  <include>**/src/**/*.js</include>
                   <include>**/src/**/*.kt</include>
                   <include>**/src/**/*.properties</include>
                   <include>**/src/**/*.proto</include>

--- a/protobuf-maven-plugin/src/site/markdown/additional-language-support.md
+++ b/protobuf-maven-plugin/src/site/markdown/additional-language-support.md
@@ -1,5 +1,7 @@
 # Other language support
 
+<div id="pmp-toc"></div>
+
 While Maven does not provide official plugins for most other programming
 languages, the protobuf-maven-plugin allows you to generate source code for
 a number of other programming languages.

--- a/protobuf-maven-plugin/src/site/markdown/basic-usage.md
+++ b/protobuf-maven-plugin/src/site/markdown/basic-usage.md
@@ -1,5 +1,7 @@
 # Basic Usage
 
+<div id="pmp-toc"></div>
+
 This plugin is designed with simplicity in mind. As a result, you do not need
 to do much to get this working.
 

--- a/protobuf-maven-plugin/src/site/markdown/changing-protoc-versions.md
+++ b/protobuf-maven-plugin/src/site/markdown/changing-protoc-versions.md
@@ -1,5 +1,7 @@
 # Changing `protoc` versions
 
+<div id="pmp-toc"></div>
+
 Sometimes, it may not be possible to use the version of `protoc` that is available on Maven.
 If you are in this situation, a few alternatives exist.
 

--- a/protobuf-maven-plugin/src/site/markdown/dependencies.md
+++ b/protobuf-maven-plugin/src/site/markdown/dependencies.md
@@ -1,5 +1,7 @@
 # Dependencies
 
+<div id="pmp-toc"></div>
+
 Like any other Java project in Maven, your Protobuf project may need to depend on other dependencies
 located in a Maven repository or some other location. This has first-class support within this
 plugin without you needing to do anything special.

--- a/protobuf-maven-plugin/src/site/markdown/descriptor-files.md
+++ b/protobuf-maven-plugin/src/site/markdown/descriptor-files.md
@@ -1,14 +1,16 @@
 # Descriptor files
 
-Descriptors are used to encapsulate the information found in one or more `.proto` files into a single binary
-blob that can be passed as an input into `protoc`.
+<div id="pmp-toc"></div>
+
+Descriptors are used to encapsulate the information found in one or more `.proto` files into a 
+single binary blob that can be passed as an input into `protoc`.
 
 ## Generating proto descriptor files
 
 If you need to generate a `FileDescriptorSet` (a protocol buffer, defined in 
 [descriptor.proto](https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/descriptor.proto)),
-you can provide an `outputDescriptorFile` configuration option. This will output a binary blob containing all of
-the inputs you provided.
+you can provide an `outputDescriptorFile` configuration option. This will output a binary blob 
+containing all the inputs you provided.
 
 ```xml
 <plugin>
@@ -34,8 +36,8 @@ For more information see [descriptor production](https://protobuf.com/docs/descr
 ## Attachment and deploying to a repository
 
 Generated descriptor files can optionally be attached to the Maven build as artifacts. The default 
-artifact type is `protobin`. For the `generate-test` goal, the default artifact type is `test-protobin`, 
-and default classifier is `test`.
+artifact type is `protobin`. For the `generate-test` goal, the default artifact type is 
+`test-protobin`, and the default classifier is `test`.
 
 The following options configure descriptor attachment:
 

--- a/protobuf-maven-plugin/src/site/markdown/faster-builds.md
+++ b/protobuf-maven-plugin/src/site/markdown/faster-builds.md
@@ -1,5 +1,7 @@
 # Faster builds
 
+<div id="pmp-toc"></div>
+
 When you have large numbers of proto files, builds can become slow and hinder development. To work
 around this, there are a few things you can do.
 

--- a/protobuf-maven-plugin/src/site/markdown/index.md
+++ b/protobuf-maven-plugin/src/site/markdown/index.md
@@ -1,5 +1,7 @@
 # Introduction
 
+<div id="pmp-toc"></div>
+
 The Protobuf Maven Plugin is a modern Maven plugin that attempts to reduce the hassle needed to
 integrate Protobuf compilation into your build process.
 
@@ -15,12 +17,12 @@ for you automatically.
 
 In addition to generating Java sources, this plugin can also generate Kotlin sources.
 
-# Bugs and feature requests
+## Bugs and feature requests
 
 Please raise any bugs or feature requests on 
 [the GitHub project for this plugin](https://github.com/ascopes/protobuf-maven-plugin/issues).
 
-# Detailed examples
+## Detailed examples
 
 If you need detailed working examples to use as reference, then the 
 [integration tests](https://github.com/ascopes/protobuf-maven-plugin/tree/main/protobuf-maven-plugin/src/it)

--- a/protobuf-maven-plugin/src/site/markdown/known-issues.md
+++ b/protobuf-maven-plugin/src/site/markdown/known-issues.md
@@ -1,5 +1,7 @@
 # Known Issues
 
+<div id="pmp-toc"></div>
+
 While every attempt is made to ensure this plugin is as functional and complete as possible,
 some known issues exist.
 

--- a/protobuf-maven-plugin/src/site/markdown/requirements.md
+++ b/protobuf-maven-plugin/src/site/markdown/requirements.md
@@ -1,5 +1,7 @@
 # Requirements
 
+<div id="pmp-toc"></div>
+
 ## Minimum requirements
 
 This plugin requires that you meet the following requirements at a minimum:

--- a/protobuf-maven-plugin/src/site/markdown/using-protoc-plugins.md
+++ b/protobuf-maven-plugin/src/site/markdown/using-protoc-plugins.md
@@ -1,5 +1,7 @@
 # Using `protoc` Plugins
 
+<div id="pmp-toc"></div>
+
 If you wish to generate gRPC stubs, or outputs for other languages like Scala that are not already
 covered by the protoc executable, you can add custom plugins to your build.
 

--- a/protobuf-maven-plugin/src/site/resources/js/configure.js
+++ b/protobuf-maven-plugin/src/site/resources/js/configure.js
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2023 - 2025, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+"use strict";
+
+window.addEventListener("load", () => {
+  initAnchorJs();
+  initTableOfContents();
+  initHighlightJs();
+  initDarkMode();
+});
+
+function initAnchorJs() {
+  anchors.add();
+}
+
+function initTableOfContents() {
+  generateTableOfContents();
+}
+
+function initHighlightJs() {
+  hljs.configure({languages: ["clojure", "groovy", "java", "kotlin", "protobuf", "scala", "xml"]});
+  hljs.highlightAll();
+}

--- a/protobuf-maven-plugin/src/site/resources/js/fluido-toc-generator.js
+++ b/protobuf-maven-plugin/src/site/resources/js/fluido-toc-generator.js
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2023 - 2025, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+"use strict";
+
+function generateTableOfContents() {
+  const targetElement = document.getElementById("pmp-toc");
+
+  if (targetElement === null || typeof(targetElement) === "undefined") {
+    return;
+  }
+
+  const section = getParentSection(targetElement);
+  const headingTree = buildHeadingTree(section);
+  targetElement.innerHTML = "<p>TODO: finish implementing this<p>";
+}
+
+function getParentSection(element) {
+  do {
+    element = element.parentElement;
+  } while (element !== null && element.tagName !== "SECTION");
+
+  if (element === null) {
+    throw new Error("No parent section was found, panic!");
+  }
+
+  return element;
+}
+
+function buildHeadingTree(section) {
+  // Purposely don't get the h1 heading for the page itself.
+  const headings = section.querySelectorAll("h2, h3, h4, h5, h6");
+  const headers = [];
+  return "not implemented yet";
+}
+
+window.addEventListener("load", () => generateTableOfContents());

--- a/protobuf-maven-plugin/src/site/site.xml
+++ b/protobuf-maven-plugin/src/site/site.xml
@@ -45,6 +45,8 @@
           document.addEventListener("DOMContentLoaded", initSyntaxHighlighting);
         }
       </script>
+      <!-- Table of contents generation -->
+      <script src="/js/fluido-toc-generator.js"></script>
       ]]>
     </head>
 

--- a/protobuf-maven-plugin/src/site/site.xml
+++ b/protobuf-maven-plugin/src/site/site.xml
@@ -27,26 +27,19 @@
   <body>
     <head>
       <![CDATA[
-      <!-- Highlight.js -->
-      <link rel="icon" type="image/png" href="images/favicon.png"/>
-      <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css">
-      <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
-      <script>
-        "use strict";
+        <!-- Highlight.js -->
+        <link rel="icon" type="image/png" href="images/favicon.png"/>
+        <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles/github.min.css">
+        <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/highlight.min.js"></script>
 
-        function initSyntaxHighlighting() {
-          hljs.configure({languages: ["clojure", "groovy", "java", "kotlin", "protobuf", "scala", "xml"]});
-          hljs.highlightAll();
-        }
+        <!-- Anchor injection -->
+        <script src="https://cdn.jsdelivr.net/npm/anchor-js/anchor.min.js"></script>
 
-        if (document.readyState === "complete" || document.readyState === "interactive") {
-          setTimeout(initSyntaxHighlighting, 1);
-        } else {
-          document.addEventListener("DOMContentLoaded", initSyntaxHighlighting);
-        }
-      </script>
-      <!-- Table of contents generation -->
-      <script src="/js/fluido-toc-generator.js"></script>
+        <!-- Table of contents generation -->
+        <script src="/js/fluido-toc-generator.js"></script>
+
+        <!-- Configure integrations on page load -->
+        <script src="/js/configure.js"></script>
       ]]>
     </head>
 
@@ -73,6 +66,9 @@
 
   <custom>
     <fluidoSkin>
+      <anchorJs>
+        <cssSelector>h1, h2, h3, h4, h5, h6</cssSelector>
+      </anchorJs>
       <profile>production</profile>
     </fluidoSkin>
   </custom>


### PR DESCRIPTION
This implements a JS hook that runs once the page has loaded and generates a table of contents by sniffing out
`<h1>...<h6>` tags to construct a virtual header tree.

This allows us to make a table of contents without extending fluido or hardcoding it in Markdown for the time being, which
should improve user experience with documentation.