### PR TITLE
GH-596: Restrict executor currency to avoid resource exhaustion

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ present [in the integration tests](https://github.com/ascopes/protobuf-maven-plu
 | Java 11 Support                     | :white_check_mark:                          |
 | Java 17 Support                     | :white_check_mark:                          |
 | Java 21 Support                     | :white_check_mark:                          |
-| Project Loom Virtual Thread support | :white_check_mark: (Java 21 and newer only) |
 
 ### Languages and frameworks
 


### PR DESCRIPTION
Large projects will currently attempt to extract a large number of JARs in memory without an explicit concurrency limit. This may result in resource exhaustion for CPU and/or memory, affecting the stability of the plugin.

This reworks the ConcurrentExecutor to use a set of sensible values that scales based on the available compute.