### PR TITLE
GH-603: Resolve project dependencies via Maven

### DIFF
--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherArtifactMapper.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherArtifactMapper.java
@@ -120,19 +120,19 @@ final class AetherArtifactMapper {
     );
   }
 
-  org.eclipse.aether.graph.Dependency mapMavenDependencyToEclipseDependency(
-      org.apache.maven.model.Dependency mavenDependency
+  org.eclipse.aether.artifact.Artifact mapMavenArtifactToEclipseArtifact(
+      org.apache.maven.artifact.Artifact mavenArtifact
   ) {
     // maven-core recommended tool to perform these kind of conversions
-    return org.apache.maven.RepositoryUtils
-        .toDependency(mavenDependency, artifactTypeRegistry);
+    return org.apache.maven.RepositoryUtils.toArtifact(mavenArtifact);
   }
 
   org.eclipse.aether.artifact.Artifact mapMavenDependencyToEclipseArtifact(
       org.apache.maven.model.Dependency mavenDependency
   ) {
     // maven-core recommended tool to perform these kind of conversions
-    return mapMavenDependencyToEclipseDependency(mavenDependency).getArtifact();
+    return org.apache.maven.RepositoryUtils.toDependency(mavenDependency, artifactTypeRegistry)
+        .getArtifact();
   }
 
   private Set<org.eclipse.aether.graph.Exclusion> mapPmpExclusionsToEclipseExclusions(

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherDependencyManagement.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherDependencyManagement.java
@@ -19,6 +19,7 @@ import static java.util.Objects.requireNonNullElse;
 import static java.util.function.Function.identity;
 
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
@@ -82,7 +83,9 @@ final class AetherDependencyManagement {
         Collectors.toMap(
             AetherDependencyManagement::getDependencyManagementKey,
             identity(),
-            AetherDependencyManagement::newestArtifact
+            AetherDependencyManagement::newestArtifact,
+            // Retain order. It matters!
+            LinkedHashMap::new
         ),
         Collections::unmodifiableMap
     );

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherDependencyManagement.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherDependencyManagement.java
@@ -15,7 +15,6 @@
  */
 package io.github.ascopes.protobufmavenplugin.dependencies.aether;
 
-import static java.util.Objects.requireNonNullElse;
 import static java.util.function.Function.identity;
 
 import java.util.Collections;

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/MainGenerateMojo.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/MainGenerateMojo.java
@@ -41,7 +41,7 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
     name = "generate",
     defaultPhase = LifecyclePhase.GENERATE_SOURCES,
     requiresDependencyCollection = ResolutionScope.COMPILE_PLUS_RUNTIME,
-    requiresDependencyResolution = ResolutionScope.NONE,
+    requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME,
     requiresOnline = true,
     threadSafe = true
 )

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/TestGenerateMojo.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/TestGenerateMojo.java
@@ -44,8 +44,8 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 @Mojo(
     name = "generate-test",
     defaultPhase = LifecyclePhase.GENERATE_TEST_SOURCES,
-    requiresDependencyCollection = ResolutionScope.COMPILE_PLUS_RUNTIME,
-    requiresDependencyResolution = ResolutionScope.NONE,
+    requiresDependencyCollection = ResolutionScope.TEST,
+    requiresDependencyResolution = ResolutionScope.TEST,
     requiresOnline = true,
     threadSafe = true
 )

--- a/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherArtifactMapperTest.java
+++ b/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherArtifactMapperTest.java
@@ -18,6 +18,7 @@ package io.github.ascopes.protobufmavenplugin.dependencies.aether;
 import static io.github.ascopes.protobufmavenplugin.fixtures.DependencyFixtures.eclipseArtifact;
 import static io.github.ascopes.protobufmavenplugin.fixtures.DependencyFixtures.eclipseArtifactType;
 import static io.github.ascopes.protobufmavenplugin.fixtures.DependencyFixtures.eclipseDependency;
+import static io.github.ascopes.protobufmavenplugin.fixtures.DependencyFixtures.mavenArtifact;
 import static io.github.ascopes.protobufmavenplugin.fixtures.DependencyFixtures.mavenDependency;
 import static io.github.ascopes.protobufmavenplugin.fixtures.DependencyFixtures.pmpExclusion;
 import static io.github.ascopes.protobufmavenplugin.fixtures.DependencyFixtures.pmpMavenArtifact;
@@ -619,44 +620,6 @@ class AetherArtifactMapperTest {
     );
   }
 
-  @DisplayName(".mapMavenDependencyToEclipseDependency(Dependency) returns the expected result")
-  @Test
-  void mapMavenDependencyToEclipseDependencyReturnsTheExpectedResult() {
-    try (var repositoryUtils = mockStatic(RepositoryUtils.class)) {
-      // Given
-      var expectedDependency = eclipseDependency(
-          "org.example",
-          "foo-bar",
-          "1.2.3.4",
-          "blah",
-          "ping",
-          "compile",
-          null
-      );
-      repositoryUtils.when(() -> RepositoryUtils.toDependency(any(), same(artifactTypeRegistry)))
-          .thenReturn(expectedDependency);
-      var inputDependency = mavenDependency(
-          "org.example",
-          "foo-bar",
-          "1.2.3.4",
-          "ping",
-          "blah"
-      );
-
-      // When
-      var actualDependency = aetherArtifactMapper
-          .mapMavenDependencyToEclipseDependency(inputDependency);
-
-      // Then
-      repositoryUtils.verify(() -> RepositoryUtils
-          .toDependency(inputDependency, artifactTypeRegistry));
-      repositoryUtils.verifyNoMoreInteractions();
-
-      assertThat(actualDependency)
-          .isSameAs(expectedDependency);
-    }
-  }
-
   @DisplayName(".mapMavenDependencyToEclipseArtifact(Dependency) returns the expected result")
   @Test
   void mapMavenDependencyToEclipseArtifactReturnsTheExpectedResult() {
@@ -686,12 +649,51 @@ class AetherArtifactMapperTest {
           .mapMavenDependencyToEclipseArtifact(inputDependency);
 
       // Then
-      repositoryUtils.verify(() -> RepositoryUtils
-          .toDependency(inputDependency, artifactTypeRegistry));
-      repositoryUtils.verifyNoMoreInteractions();
+      repositoryUtils
+          .verify(() -> RepositoryUtils.toDependency(inputDependency, artifactTypeRegistry));
+      repositoryUtils
+          .verifyNoMoreInteractions();
 
       assertThat(actualArtifact)
           .isSameAs(expectedDependency.getArtifact());
+    }
+  }
+
+  @DisplayName(".mapMavenArtifactToEclipseArtifact(Artifact) returns the expected result")
+  @Test
+  void mapMavenArtifactToEclipseArtifactReturnsTheExpectedResult() {
+    try (var repositoryUtils = mockStatic(RepositoryUtils.class)) {
+      // Given
+      var expectedArtifact = eclipseArtifact(
+          "org.example",
+          "foo-bar",
+          "1.2.3.4",
+          "blah",
+          "png"
+      );
+      repositoryUtils
+          .when(() -> RepositoryUtils.toArtifact(any(org.apache.maven.artifact.Artifact.class)))
+          .thenReturn(expectedArtifact);
+      var inputArtifact = mavenArtifact(
+          "org.example",
+          "foo-bar",
+          "1.2.3.4",
+          "blah",
+          "png"
+      );
+
+      // When
+      var actualArtifact = aetherArtifactMapper
+          .mapMavenArtifactToEclipseArtifact(inputArtifact);
+
+      // Then
+      repositoryUtils
+          .verify(() -> RepositoryUtils.toArtifact(inputArtifact));
+      repositoryUtils
+          .verifyNoMoreInteractions();
+
+      assertThat(actualArtifact)
+          .isSameAs(expectedArtifact);
     }
   }
 }

--- a/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/fixtures/DependencyFixtures.java
+++ b/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/fixtures/DependencyFixtures.java
@@ -99,6 +99,25 @@ public final class DependencyFixtures {
     return exclusion;
   }
 
+  public static org.apache.maven.artifact.Artifact mavenArtifact(
+      String groupId,
+      String artifactId,
+      String version,
+      @Nullable String classifier,
+      @Nullable String type
+  ) {
+    var artifact = mock(
+        org.apache.maven.artifact.Artifact.class,
+        defaultSettings("some maven artifact")
+    );
+    when(artifact.getGroupId()).thenReturn(groupId);
+    when(artifact.getArtifactId()).thenReturn(artifactId);
+    when(artifact.getVersion()).thenReturn(version);
+    when(artifact.getType()).thenReturn(type);
+    when(artifact.getClassifier()).thenReturn(classifier);
+    return artifact;
+  }
+
   public static org.apache.maven.model.Dependency mavenDependency() {
     return mavenDependency(
         someBasicString(),


### PR DESCRIPTION
This adjusts how we discover dependencies to enable Maven to resolve the project ones to paths for us
prior to actually calling the plugin. This avoids
having to use Aether directly for large numbers of dependencies on each run.

May provide performance improvements to GH-596 and GH-600.

Fixes GH-603.

