### PR TITLE
Disable caching of resolution errors

### DIFF
--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/NoCacheResolutionErrorPolicy.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/NoCacheResolutionErrorPolicy.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2023 - 2025, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.ascopes.protobufmavenplugin.dependencies.aether;
+
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.metadata.Metadata;
+import org.eclipse.aether.resolution.ResolutionErrorPolicy;
+import org.eclipse.aether.resolution.ResolutionErrorPolicyRequest;
+
+/**
+ * Policy that disables resolution error caching.
+ *
+ * <p>In Maven 3.9.9 or newer, we should use {@code SimpleResolutionErrorPolicy} elsewhere instead
+ * of this. For now, this is implemented to enable Maven 3.8 compatibility.
+ *
+ * @author Ashley Scopes
+ * @since 2.13.0
+ */
+final class NoCacheResolutionErrorPolicy implements ResolutionErrorPolicy {
+
+  @Override
+  public int getArtifactPolicy(
+      RepositorySystemSession session,
+      ResolutionErrorPolicyRequest<Artifact> request
+  ) {
+    return CACHE_DISABLED;
+  }
+
+  @Override
+  public int getMetadataPolicy(
+      RepositorySystemSession session,
+      ResolutionErrorPolicyRequest<Metadata> request
+  ) {
+    return CACHE_DISABLED;
+  }
+}

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/ProtobufMavenPluginRepositorySession.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/ProtobufMavenPluginRepositorySession.java
@@ -17,9 +17,7 @@ package io.github.ascopes.protobufmavenplugin.dependencies.aether;
 
 import org.eclipse.aether.AbstractForwardingRepositorySystemSession;
 import org.eclipse.aether.RepositorySystemSession;
-import org.eclipse.aether.resolution.ArtifactDescriptorPolicy;
 import org.eclipse.aether.resolution.ResolutionErrorPolicy;
-import org.eclipse.aether.util.repository.SimpleResolutionErrorPolicy;
 
 /**
  * Custom repository session for the Protobuf Maven Plugin which injects some special components to
@@ -54,6 +52,6 @@ final class ProtobufMavenPluginRepositorySession
     // As of 2.13.0, we do not want to cache invalid dependencies between builds. This gets a bit
     // confusing for users if it collides with logic that Maven itself is performing, so lets just
     // totally avoid it.
-    return new SimpleResolutionErrorPolicy(ResolutionErrorPolicy.CACHE_DISABLED);
+    return new NoCacheResolutionErrorPolicy();
   }
 }

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/ProtobufMavenPluginRepositorySession.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/ProtobufMavenPluginRepositorySession.java
@@ -17,6 +17,9 @@ package io.github.ascopes.protobufmavenplugin.dependencies.aether;
 
 import org.eclipse.aether.AbstractForwardingRepositorySystemSession;
 import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.resolution.ArtifactDescriptorPolicy;
+import org.eclipse.aether.resolution.ResolutionErrorPolicy;
+import org.eclipse.aether.util.repository.SimpleResolutionErrorPolicy;
 
 /**
  * Custom repository session for the Protobuf Maven Plugin which injects some special components to
@@ -44,5 +47,13 @@ final class ProtobufMavenPluginRepositorySession
   @Override
   public WildcardAwareDependencyTraverser getDependencyTraverser() {
     return new WildcardAwareDependencyTraverser(delegate.getDependencyTraverser());
+  }
+
+  @Override
+  public ResolutionErrorPolicy getResolutionErrorPolicy() {
+    // As of 2.13.0, we do not want to cache invalid dependencies between builds. This gets a bit
+    // confusing for users if it collides with logic that Maven itself is performing, so lets just
+    // totally avoid it.
+    return new SimpleResolutionErrorPolicy(ResolutionErrorPolicy.CACHE_DISABLED);
   }
 }

--- a/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/NoCacheResolutionErrorPolicyTest.java
+++ b/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/NoCacheResolutionErrorPolicyTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2023 - 2025, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.ascopes.protobufmavenplugin.dependencies.aether;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import org.eclipse.aether.resolution.ResolutionErrorPolicy;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("NoCacheResolutionErrorPolicy tests")
+class NoCacheResolutionErrorPolicyTest {
+
+  @DisplayName(".getArtifactPolicy(...) returns CACHE_DISABLED")
+  @Test
+  void getArtifactPolicyReturnsNoCachingFlag() {
+    // Given
+    var policy = new NoCacheResolutionErrorPolicy();
+
+    // Then
+    assertThat(policy.getArtifactPolicy(mock(), mock()))
+        .isEqualTo(ResolutionErrorPolicy.CACHE_DISABLED);
+  }
+
+  @DisplayName(".getMetadataPolicy(...) returns CACHE_DISABLED")
+  @Test
+  void getMetadataPolicyReturnsNoCachingFlag() {
+    // Given
+    var policy = new NoCacheResolutionErrorPolicy();
+
+    // Then
+    assertThat(policy.getMetadataPolicy(mock(), mock()))
+        .isEqualTo(ResolutionErrorPolicy.CACHE_DISABLED);
+  }
+}

--- a/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/ProtobufMavenPluginRepositorySessionTest.java
+++ b/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/ProtobufMavenPluginRepositorySessionTest.java
@@ -76,4 +76,20 @@ class ProtobufMavenPluginRepositorySessionTest {
     assertThat(underTest.getDependencyTraverser())
         .isNotSameAs(underTest.getDependencyTraverser());
   }
+
+  @DisplayName(".getResolutionErrorPolicy() returns the expected value")
+  @Test
+  void getResolutionErrorPolicyReturnsTheExpectedValue() {
+    // Then
+    assertThat(underTest.getResolutionErrorPolicy())
+        .isNotNull()
+        .satisfies(
+            policy -> assertThat(policy.getArtifactPolicy(mock(), mock()))
+                .as("artifact policy")
+                .isZero(),
+            policy -> assertThat(policy.getMetadataPolicy(mock(), mock()))
+                .as("metadata policy")
+                .isZero()
+        );
+  }
 }

--- a/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/ProtobufMavenPluginRepositorySessionTest.java
+++ b/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/ProtobufMavenPluginRepositorySessionTest.java
@@ -82,14 +82,6 @@ class ProtobufMavenPluginRepositorySessionTest {
   void getResolutionErrorPolicyReturnsTheExpectedValue() {
     // Then
     assertThat(underTest.getResolutionErrorPolicy())
-        .isNotNull()
-        .satisfies(
-            policy -> assertThat(policy.getArtifactPolicy(mock(), mock()))
-                .as("artifact policy")
-                .isZero(),
-            policy -> assertThat(policy.getMetadataPolicy(mock(), mock()))
-                .as("metadata policy")
-                .isZero()
-        );
+        .isInstanceOf(NoCacheResolutionErrorPolicy.class);
   }
 }


### PR DESCRIPTION
While Maven itself defaults to doing this, we do not want to be caching resolution failures by default for things like the resolution of protoc. This avoids some confusing behaviour for users when developing locally.