### PR TITLE
GH-603: Fix scope detection for 'generate' goal

### DIFF
--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherMavenArtifactPathResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherMavenArtifactPathResolver.java
@@ -109,11 +109,7 @@ final class AetherMavenArtifactPathResolver implements MavenArtifactPathResolver
         .forEach(unresolvedDependencies::add);
 
     var resolvedArtifacts = aetherResolver
-        .resolveDependencies(
-            unresolvedDependencies,
-            dependencyScopes,
-            failOnInvalidDependencies
-        )
+        .resolveDependencies(unresolvedDependencies, dependencyScopes, failOnInvalidDependencies)
         .stream();
 
     if (includeProjectArtifacts) {

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/MainGenerateMojo.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/MainGenerateMojo.java
@@ -40,8 +40,10 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 @Mojo(
     name = "generate",
     defaultPhase = LifecyclePhase.GENERATE_SOURCES,
-    requiresDependencyCollection = ResolutionScope.COMPILE_PLUS_RUNTIME,
-    requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME,
+    // We require resolving TEST scope here since the user can control the overall scope
+    // we use for dependencies. The TEST scope is documented to cover all other scopes.
+    requiresDependencyCollection = ResolutionScope.TEST,
+    requiresDependencyResolution = ResolutionScope.TEST,
     requiresOnline = true,
     threadSafe = true
 )


### PR DESCRIPTION
Addresses a regression introduced in GH-604 as part of the workaround for GH-603 that prevented TEST-scoped dependencies in the project being included for resolution if the user ran the 'generate' goal with custom scopes in the configuration rather than the 'generate-test' goal.