### PR TITLE
v3.0.0 - improve how ordering of plugins works

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>io.github.ascopes</groupId>
   <artifactId>protobuf-maven-plugin-parent</artifactId>
-  <version>2.13.2-SNAPSHOT</version>
+  <version>3.0.0-SNAPSHOT</version>
 
   <name>Protobuf Maven Plugin Parent</name>
   <description>Parent POM for the Protobuf Maven Plugin.</description>

--- a/protobuf-maven-plugin/pom.xml
+++ b/protobuf-maven-plugin/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes</groupId>
     <artifactId>protobuf-maven-plugin-parent</artifactId>
-    <version>2.13.2-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>protobuf-maven-plugin</artifactId>

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/AbstractGenerateMojo.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/AbstractGenerateMojo.java
@@ -135,7 +135,9 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    *   <li>{@code options} - a string of options to pass to the plugin
    *       - optional.</li>
    *   <li>{@code order} - an integer order to run the plugins in. Defaults
-   *       to 100,000. Higher numbers run later than lower numbers.</li>
+   *       to 0. Higher numbers run later than lower numbers. The built-in
+   *       code generators in {@code protoc} and descriptor generation has
+   *       an order of 0.</li>
    *   <li>{@code skip} - set to {@code true} to skip invoking this plugin -
    *       useful if you want to control whether the plugin runs via a
    *       property - optional.</li>
@@ -169,7 +171,9 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    *   <li>{@code options} - a string of options to pass to the plugin
    *       - optional.</li>
    *   <li>{@code order} - an integer order to run the plugins in. Defaults
-   *       to 100,000. Higher numbers run later than lower numbers.</li>
+   *       to 0. Higher numbers run later than lower numbers. The built-in
+   *       code generators in {@code protoc} and descriptor generation has
+   *       an order of 0.</li>
    *   <li>{@code skip} - set to {@code true} to skip invoking this plugin -
    *       useful if you want to control whether the plugin runs via a
    *       property - optional.</li>
@@ -230,7 +234,9 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    *   <li>{@code options} - a string of options to pass to the plugin
    *       - optional.</li>
    *   <li>{@code order} - an integer order to run the plugins in. Defaults
-   *       to 100,000. Higher numbers run later than lower numbers.</li>
+   *       to 0. Higher numbers run later than lower numbers. The built-in
+   *       code generators in {@code protoc} and descriptor generation has
+   *       an order of 0.</li>
    *   <li>{@code skip} - set to {@code true} to skip invoking this plugin -
    *       useful if you want to control whether the plugin runs via a
    *       property - optional.</li>
@@ -529,7 +535,9 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    *       uses the standard {@code protoc} interface for specifying options
    *       - optional.</li>
    *   <li>{@code order} - an integer order to run the plugins in. Defaults
-   *       to 100,000. Higher numbers run later than lower numbers.</li>
+   *       to 0. Higher numbers run later than lower numbers. The built-in
+   *       code generators in {@code protoc} and descriptor generation has
+   *       an order of 0.</li>
    *   <li>{@code skip} - set to {@code true} to skip invoking this plugin -
    *       useful if you want to control whether the plugin runs via a
    *       property - optional.</li>

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/ProtocPlugin.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/ProtocPlugin.java
@@ -31,9 +31,7 @@ public interface ProtocPlugin {
   @Nullable String getOptions();
 
   default int getOrder() {
-    // A semi-sensible default value that can allow users to easily
-    // place values before or after the default order.
-    return 100_000;
+    return 0;
   }
 
   default boolean isSkip() {

--- a/protobuf-maven-plugin/src/site/markdown/using-protoc-plugins.md
+++ b/protobuf-maven-plugin/src/site/markdown/using-protoc-plugins.md
@@ -268,6 +268,28 @@ then you can provide the following:
 
 It would also be valid to use a binary plugin for Salesforce here if you prefer.
 
+## Plugin ordering
+
+Plugins are inheriantly orderable and can be ordered relative to eachother, as well as
+relative to the built-in generators in `protoc` and the generation of descriptors.
+
+By default, plugins are applied with the same precedence as descriptors and languages,
+which have an order of `0`, but this can be overridden to a negative integer to run the
+plugin first, or to a positive integer to run the plugin last.
+
+The order can be specified with the `order` attribute on any plugin block. For example:
+
+```xml
+<jvmMavenPlugin>
+  ...
+  <!-- Always run before generating Java sources. -->
+  <order>-999</order>
+</jvmMavenPlugin>
+```
+
+The order that generation is performed in for equally-ordered plugins is undefined, but
+guaranteed to be stable between builds on the same system in the same location.
+
 ## Running plugins without default Java code generation
 
 You can turn the default Java code generation step off by setting `<javaEnabled>false</javaEnabled>` on the


### PR DESCRIPTION
Improve codegen ordering

This breaking change alters how we determine the order to run plugin
code generation in to be able to be relative to the builtin code
generators in protoc and the descriptor file generation in protoc.

Plugins now have an order of 0 rather than 100,000 by default. The
implication of setting a negative order is that it will run prior
to builtin and descriptor generation, and a positive order will run
afterwards.

The order of language generation is also now stable between builds.