### PR TITLE
GH-621: Remove dead code for working directory discovery

### DIFF
--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/utils/HostSystem.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/utils/HostSystem.java
@@ -55,7 +55,6 @@ public final class HostSystem {
   private final String operatingSystem;
   private final String cpuArchitecture;
   private final String pathSeparator;
-  private final Path workingDirectory;
   private final Path javaHome;
   private final String javaVendor;
   private final List<Path> path;
@@ -72,7 +71,6 @@ public final class HostSystem {
     operatingSystem = properties.getProperty("os.name", "");
     cpuArchitecture = properties.getProperty("os.arch", "");
     pathSeparator = properties.getProperty("path.separator", "");
-    workingDirectory = FileUtils.normalize(Path.of(""));
     javaHome = FileUtils.normalize(Path.of(properties.getProperty("java.home", "")));
     javaVendor = properties.getProperty("java.vendor", "");
     path = parsePath(requireNonNullElse(envProvider.apply("PATH"), ""), pathSeparator);
@@ -101,10 +99,6 @@ public final class HostSystem {
 
   public boolean isProbablyWindows() {
     return operatingSystem.toLowerCase(Locale.ROOT).startsWith("windows");
-  }
-
-  public Path getWorkingDirectory() {
-    return workingDirectory;
   }
 
   public Path getJavaExecutablePath() {

--- a/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/utils/HostSystemTest.java
+++ b/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/utils/HostSystemTest.java
@@ -215,22 +215,6 @@ class HostSystemTest {
     assertThat(actualResult).isEqualTo(expectedResult);
   }
 
-  @DisplayName(".getWorkingDirectory() returns the working directory")
-  @Test
-  void getWorkingDirectoryReturnsTheWorkingDirectory() {
-    // Given
-    var hostSystemBean = new HostSystem();
-
-    // When
-    var actualWorkingDirectory = hostSystemBean.getWorkingDirectory();
-
-    // Then
-    assertThat(actualWorkingDirectory)
-        .isNormalized()
-        .isAbsolute()
-        .isEqualTo(Path.of("").toAbsolutePath().normalize());
-  }
-
   @DisplayName(".getJavaExecutablePath() returns the Java executable")
   @CsvSource({
       " Windows, java.exe",


### PR DESCRIPTION
Closes GH-621.

Originally this was going to be a bugfix to handle the working directory correctly when calling `mvn -f` but this appears to be totally dead code anyway, so I am just removing it.