### PR TITLE
Use Maven 4 for default builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,8 +76,8 @@ jobs:
             java-version: 11
             maven: 3.8.8
           - os-name: ubuntu-latest
-            java-version: 17
-            maven: 4.0.0-rc-3
+            java-version: 11
+            maven: 3.9.9
 
     steps:
       - name: Checkout code

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -16,4 +16,4 @@
 # under the License.
 wrapperVersion=3.3.2
 distributionType=only-script
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/4.0.0-rc-3/apache-maven-4.0.0-rc-3-bin.zip


### PR DESCRIPTION
Run majority of builds with Maven 4 rather than Maven 3 to catch more issues with future compatibility.