### PR TITLE
Use a custom Plexus converter to defer URL parsing to the last minute

### DIFF
--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generation/GenerationRequest.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generation/GenerationRequest.java
@@ -19,7 +19,7 @@ import io.github.ascopes.protobufmavenplugin.dependencies.DependencyResolutionDe
 import io.github.ascopes.protobufmavenplugin.dependencies.MavenArtifact;
 import io.github.ascopes.protobufmavenplugin.plugins.MavenProtocPlugin;
 import io.github.ascopes.protobufmavenplugin.plugins.PathProtocPlugin;
-import io.github.ascopes.protobufmavenplugin.plugins.UrlProtocPlugin;
+import io.github.ascopes.protobufmavenplugin.plugins.UriProtocPlugin;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
@@ -56,7 +56,7 @@ public interface GenerationRequest {
    *
    * @return the collection of plugins.
    */
-  Collection<? extends UrlProtocPlugin> getBinaryUrlPlugins();
+  Collection<? extends UriProtocPlugin> getBinaryUrlPlugins();
 
   /**
    * The preference for how to resolve transitive dependencies by default.

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/MainGenerateMojo.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/MainGenerateMojo.java
@@ -17,6 +17,7 @@ package io.github.ascopes.protobufmavenplugin.mojo;
 
 import io.github.ascopes.protobufmavenplugin.generation.OutputDescriptorAttachmentRegistrar;
 import io.github.ascopes.protobufmavenplugin.generation.SourceRootRegistrar;
+import io.github.ascopes.protobufmavenplugin.mojo.plexus.ProtobufMavenPluginConfigurator;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
@@ -41,6 +42,7 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
  */
 @Mojo(
     name = "generate",
+    configurator = ProtobufMavenPluginConfigurator.NAME,
     defaultPhase = LifecyclePhase.GENERATE_SOURCES,
     // We require resolving TEST scope here since the user can control the overall scope
     // we use for dependencies. The TEST scope is documented to cover all other scopes.

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/TestGenerateMojo.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/TestGenerateMojo.java
@@ -17,6 +17,7 @@ package io.github.ascopes.protobufmavenplugin.mojo;
 
 import io.github.ascopes.protobufmavenplugin.generation.OutputDescriptorAttachmentRegistrar;
 import io.github.ascopes.protobufmavenplugin.generation.SourceRootRegistrar;
+import io.github.ascopes.protobufmavenplugin.mojo.plexus.ProtobufMavenPluginConfigurator;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
@@ -45,6 +46,7 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
  */
 @Mojo(
     name = "generate-test",
+    configurator = ProtobufMavenPluginConfigurator.NAME,
     defaultPhase = LifecyclePhase.GENERATE_TEST_SOURCES,
     requiresDependencyCollection = ResolutionScope.TEST,
     requiresDependencyResolution = ResolutionScope.TEST,

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/plexus/PathConverter.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/plexus/PathConverter.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2023 - 2025, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.ascopes.protobufmavenplugin.mojo.plexus;
+
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import org.codehaus.plexus.component.configurator.ComponentConfigurationException;
+import org.codehaus.plexus.component.configurator.converters.basic.AbstractBasicConverter;
+
+
+/**
+ * Converter for Path objects on the root file system.
+ *
+ * <p>We provide this to avoid using the URL and File APIs in the Mojo interface.
+ *
+ * <p>Newer versions of Plexus/Sisu provide this for us, so in the future, we can remove these
+ * components (looks to be supported from Maven 3.9.x).
+ *
+ * @author Ashley Scopes
+ * @since 3.1.3
+ */
+final class PathConverter extends AbstractBasicConverter {
+
+  @Override
+  public boolean canConvert(Class<?> type) {
+    return type.equals(Path.class);
+  }
+
+  @Override
+  protected Object fromString(String str) throws ComponentConfigurationException {
+    try {
+      return Path.of(str);
+    } catch (InvalidPathException ex) {
+      throw new ComponentConfigurationException("Failed to parse path '" + str + "': " + ex, ex);
+    }
+  }
+}

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/plexus/ProtobufMavenPluginConfigurator.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/plexus/ProtobufMavenPluginConfigurator.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2023 - 2025, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.ascopes.protobufmavenplugin.mojo.plexus;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+import org.codehaus.plexus.component.configurator.BasicComponentConfigurator;
+
+/**
+ * Custom configurator for this Maven plugin which allows us to inject additional converter types to
+ * work around internal quirks regarding how Maven, Sisu, and Plexus operate under the hood.
+ *
+ * @author Ashley Scopes
+ * @since 3.1.3
+ */
+@Named(ProtobufMavenPluginConfigurator.NAME)
+@Singleton
+public class ProtobufMavenPluginConfigurator extends BasicComponentConfigurator {
+
+  public static final String NAME = "protobuf-maven-plugin-configurator";
+
+  ProtobufMavenPluginConfigurator() {
+    converterLookup.registerConverter(new PathConverter());
+    converterLookup.registerConverter(new UriConverter());
+  }
+}

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/plexus/UriConverter.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/plexus/UriConverter.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2023 - 2025, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.ascopes.protobufmavenplugin.mojo.plexus;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import org.codehaus.plexus.component.configurator.ComponentConfigurationException;
+import org.codehaus.plexus.component.configurator.converters.basic.AbstractBasicConverter;
+
+
+/**
+ * Converter for URIs.
+ *
+ * <p>We provide this to avoid using the URL and File APIs in the Mojo interface. URLs do an
+ * immediate lookup for the URL scheme's appropriate URLStreamHandlerProvider upon construction, and
+ * we have no control over how that works. We have no ability to inject custom URL handlers at this
+ * point because the URL class is hardcoded to only consider the system classloader. Since Maven
+ * uses ClassWorlds to run multiple classloaders for each plugin and component, we will not be
+ * loaded as part of that default classloader. By deferring this operation to as late as possible
+ * (i.e. in {@link io.github.ascopes.protobufmavenplugin.dependencies.UriResourceFetcher}), we can
+ * ensure we provide the desired URL handler directly instead. This allows us to hook custom URL
+ * handlers in via {@link java.util.ServiceLoader} dynamically, like we would be able to outside a
+ * Maven plugin running in Plexus.
+ *
+ * <p>Newer versions of Plexus/Sisu provide this for us, so in the future, we can remove these
+ * components (looks to be supported from Maven 3.9.x).
+ *
+ * @author Ashley Scopes
+ * @since 3.1.3
+ */
+final class UriConverter extends AbstractBasicConverter {
+
+  @Override
+  public boolean canConvert(Class<?> type) {
+    return type.equals(URI.class);
+  }
+
+  @Override
+  protected Object fromString(String str) throws ComponentConfigurationException {
+    try {
+      return new URI(str);
+    } catch (URISyntaxException ex) {
+      throw new ComponentConfigurationException("Failed to parse URI '" + str + "': " + ex, ex);
+    }
+  }
+}

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/plexus/package-info.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/plexus/package-info.java
@@ -13,23 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.github.ascopes.protobufmavenplugin.plugins;
-
-import java.net.URL;
-import org.immutables.value.Value.Modifiable;
-
-
 /**
- * Implementation independent descriptor for a protoc plugin that can be resolved from a URL.
- *
- * <p>URL-based plugins can be marked as optional if they should be skipped when the resource
- * is unable to be resolved.
- *
- * @author Ashley Scopes
- * @since 2.0.0
+ * Overrides for how MOJOs are configured within Plexus and Sisu.
  */
-@Modifiable
-public interface UrlProtocPlugin extends OptionalProtocPlugin {
-
-  URL getUrl();
-}
+package io.github.ascopes.protobufmavenplugin.mojo.plexus;

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/BinaryPluginResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/BinaryPluginResolver.java
@@ -17,7 +17,7 @@ package io.github.ascopes.protobufmavenplugin.plugins;
 
 import io.github.ascopes.protobufmavenplugin.dependencies.MavenArtifactPathResolver;
 import io.github.ascopes.protobufmavenplugin.dependencies.PlatformClassifierFactory;
-import io.github.ascopes.protobufmavenplugin.dependencies.UrlResourceFetcher;
+import io.github.ascopes.protobufmavenplugin.dependencies.UriResourceFetcher;
 import io.github.ascopes.protobufmavenplugin.utils.Digests;
 import io.github.ascopes.protobufmavenplugin.utils.FileUtils;
 import io.github.ascopes.protobufmavenplugin.utils.ResolutionException;
@@ -49,14 +49,14 @@ final class BinaryPluginResolver {
   private final MavenArtifactPathResolver artifactPathResolver;
   private final PlatformClassifierFactory platformClassifierFactory;
   private final SystemPathBinaryResolver systemPathResolver;
-  private final UrlResourceFetcher urlResourceFetcher;
+  private final UriResourceFetcher urlResourceFetcher;
 
   @Inject
   BinaryPluginResolver(
       MavenArtifactPathResolver artifactPathResolver,
       PlatformClassifierFactory platformClassifierFactory,
       SystemPathBinaryResolver systemPathResolver,
-      UrlResourceFetcher urlResourceFetcher
+      UriResourceFetcher urlResourceFetcher
   ) {
     this.artifactPathResolver = artifactPathResolver;
     this.platformClassifierFactory = platformClassifierFactory;
@@ -77,7 +77,7 @@ final class BinaryPluginResolver {
   }
 
   Collection<? extends ResolvedProtocPlugin> resolveUrlPlugins(
-      Collection<? extends UrlProtocPlugin> plugins
+      Collection<? extends UriProtocPlugin> plugins
   ) throws ResolutionException {
     return resolveAll(plugins, this::resolveUrlPlugin);
   }
@@ -126,12 +126,12 @@ final class BinaryPluginResolver {
   }
 
   private Optional<ResolvedProtocPlugin> resolveUrlPlugin(
-      UrlProtocPlugin plugin
+      UriProtocPlugin plugin
   ) throws ResolutionException {
 
     log.debug("Resolving URL protoc plugin {}", plugin);
 
-    var maybePath = urlResourceFetcher.fetchFileFromUrl(plugin.getUrl(), ".exe");
+    var maybePath = urlResourceFetcher.fetchFileFromUri(plugin.getUrl(), ".exe");
 
     if (maybePath.isEmpty() && plugin.isOptional()) {
       return Optional.empty();

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/UriProtocPlugin.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/UriProtocPlugin.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2023 - 2025, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.ascopes.protobufmavenplugin.plugins;
+
+import java.net.URI;
+import org.immutables.value.Value.Modifiable;
+
+
+/**
+ * Implementation independent descriptor for a protoc plugin that can be resolved from a URI.
+ *
+ * <p>URI-based plugins can be marked as optional if they should be skipped when the resource
+ * is unable to be resolved.
+ *
+ * @author Ashley Scopes
+ * @since 2.0.0
+ */
+@Modifiable
+public interface UriProtocPlugin extends OptionalProtocPlugin {
+
+  // TODO(ascopes): in v4.0.0, rename to "getUri" here, and elsewhere.
+  URI getUrl();
+}

--- a/protobuf-maven-plugin/src/site/markdown/changing-protoc-versions.md
+++ b/protobuf-maven-plugin/src/site/markdown/changing-protoc-versions.md
@@ -27,7 +27,7 @@ On Linux, MacOS, and other POSIX-like operating systems, this will read the `$PA
 variable and search for a binary named `protoc` case-sensitively. The executable **MUST** be
 executable by the current user (i.e. `chmod +x /path/to/protoc`), otherwise it will be ignored.
 
-On Windows, this will respect the `%PATH%` environment variable (case insensitive). The path will
+On Windows, this will respect the `%PATH%` environment variable (case-insensitive). The path will
 be searched for files where their name matches `protoc` case-insensitively, ignoring the file
 extension. The file extension must match one of the extensions specified in the `%PATHEXT%`
 environment variable. The above example would match `protoc.exe` on Windows, as an example.

--- a/protobuf-maven-plugin/src/site/markdown/using-protoc-plugins.md
+++ b/protobuf-maven-plugin/src/site/markdown/using-protoc-plugins.md
@@ -125,9 +125,9 @@ Any protocols supported by your JRE should be able to be used here, including:
 - `http`
 - `https`
 - `ftp`
-- `jar` - this also works for ZIP files, and can be used to dereference files within the archive,
-  e.g. `jar:https://github.com/some-project/some-repo/releases/download/v1.1.1/plugin.zip!/plugin.exe`,
-  which would download `https://github.com/some-project/some-repo/releases/download/v1.1.1/plugin.zip`
+- `jar` - can be used to dereference files within a JAR or ZIP archive, 
+  e.g. `jar:https://github.com/some-project/some-repo/releases/download/v1.1.1/plugin.jar!/plugin.exe`,
+  which would download `https://github.com/some-project/some-repo/releases/download/v1.1.1/plugin.jar`
   and internally extract `plugin.exe` from that archive.
 
 You can also mark these plugins as being optional by setting `<optional>true</optional>` on the

--- a/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/mojo/AbstractGenerateMojoTestTemplate.java
+++ b/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/mojo/AbstractGenerateMojoTestTemplate.java
@@ -38,9 +38,8 @@ import io.github.ascopes.protobufmavenplugin.generation.ProtobufBuildOrchestrato
 import io.github.ascopes.protobufmavenplugin.generation.SourceRootRegistrar;
 import io.github.ascopes.protobufmavenplugin.plugins.MavenProtocPluginBean;
 import io.github.ascopes.protobufmavenplugin.plugins.PathProtocPluginBean;
-import io.github.ascopes.protobufmavenplugin.plugins.UrlProtocPluginBean;
+import io.github.ascopes.protobufmavenplugin.plugins.UriProtocPluginBean;
 import io.github.ascopes.protobufmavenplugin.utils.ResolutionException;
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -281,7 +280,7 @@ abstract class AbstractGenerateMojoTestTemplate<A extends AbstractGenerateMojo> 
   @NullAndEmptySource
   @ParameterizedTest(name = "when {0}")
   void whenBinaryUrlPluginsNullExpectEmptyListInRequest(
-      List<UrlProtocPluginBean> plugins
+      List<UriProtocPluginBean> plugins
   ) throws Throwable {
     // Given
     mojo.binaryUrlPlugins = plugins;
@@ -300,7 +299,7 @@ abstract class AbstractGenerateMojoTestTemplate<A extends AbstractGenerateMojo> 
   @Test
   void whenBinaryUrlPluginsProvidedExpectPluginsInRequest() throws Throwable {
     // Given
-    List<UrlProtocPluginBean> plugins = mock();
+    List<UriProtocPluginBean> plugins = mock();
     mojo.binaryUrlPlugins = plugins;
 
     // When
@@ -475,7 +474,7 @@ abstract class AbstractGenerateMojoTestTemplate<A extends AbstractGenerateMojo> 
   @DisplayName("when importPaths is null, expect an empty list in the request")
   @NullAndEmptySource
   @ParameterizedTest(name = "when {0}")
-  void whenImportPathsNullExpectEmptyListInRequest(List<File> importPaths) throws Throwable {
+  void whenImportPathsNullExpectEmptyListInRequest(List<Path> importPaths) throws Throwable {
     // Given
     mojo.importPaths = importPaths;
 
@@ -495,11 +494,11 @@ abstract class AbstractGenerateMojoTestTemplate<A extends AbstractGenerateMojo> 
       @TempDir Path someTempDir
   ) throws Throwable {
     // Given
-    var path1 = someTempDir.resolve("foo").resolve("bar");
-    var path2 = someTempDir.resolve("do").resolve("ray");
-    var path3 = someTempDir.resolve("aaa").resolve("bbb");
+    var path1 = Files.createDirectories(someTempDir.resolve("foo").resolve("bar"));
+    var path2 = Files.createDirectories(someTempDir.resolve("do").resolve("ray"));
+    var path3 = Files.createDirectories(someTempDir.resolve("aaa").resolve("bbb"));
 
-    mojo.importPaths = List.of(path1.toFile(), path2.toFile(), path3.toFile());
+    mojo.importPaths = List.of(path1, path2, path3);
 
     // When
     mojo.execute();
@@ -736,7 +735,7 @@ abstract class AbstractGenerateMojoTestTemplate<A extends AbstractGenerateMojo> 
       @TempDir Path expectedOutputDirectory
   ) throws Throwable {
     // Given
-    mojo.outputDirectory = expectedOutputDirectory.toFile();
+    mojo.outputDirectory = expectedOutputDirectory;
 
     // When
     mojo.execute();
@@ -891,7 +890,7 @@ abstract class AbstractGenerateMojoTestTemplate<A extends AbstractGenerateMojo> 
   @NullAndEmptySource
   @ParameterizedTest(name = "when {0}")
   void whenSourceDescriptorPathsNullExpectEmptyCollectionInRequest(
-      List<File> sourceDescriptorPaths
+      List<Path> sourceDescriptorPaths
   ) throws Throwable {
     // Given
     mojo.sourceDescriptorPaths = sourceDescriptorPaths;
@@ -916,7 +915,7 @@ abstract class AbstractGenerateMojoTestTemplate<A extends AbstractGenerateMojo> 
     var path2 = Files.createDirectories(someTempDir.resolve("do").resolve("ray"));
     var path3 = Files.createDirectories(someTempDir.resolve("aaa").resolve("bbb"));
 
-    mojo.sourceDescriptorPaths = List.of(path1.toFile(), path2.toFile(), path3.toFile());
+    mojo.sourceDescriptorPaths = List.of(path1, path2, path3);
 
     // When
     mojo.execute();
@@ -942,7 +941,7 @@ abstract class AbstractGenerateMojoTestTemplate<A extends AbstractGenerateMojo> 
     var path3 = Files.createFile(dir2.resolve("file2.binpb"));
     assertThat(path2).doesNotExist();
 
-    mojo.sourceDescriptorPaths = List.of(path1.toFile(), path2.toFile(), path3.toFile());
+    mojo.sourceDescriptorPaths = List.of(path1, path2, path3);
 
     // When
     mojo.execute();
@@ -958,7 +957,7 @@ abstract class AbstractGenerateMojoTestTemplate<A extends AbstractGenerateMojo> 
   @NullAndEmptySource
   @ParameterizedTest(name = "when {0}")
   void whenSourceDirectoriesNullExpectDefaultValueInRequest(
-      List<File> sourceDirectories
+      List<Path> sourceDirectories
   ) throws Throwable {
     // Given
     mojo.sourceDirectories = sourceDirectories;
@@ -987,7 +986,7 @@ abstract class AbstractGenerateMojoTestTemplate<A extends AbstractGenerateMojo> 
     var path2 = Files.createDirectories(someTempDir.resolve("do").resolve("ray"));
     var path3 = Files.createDirectories(someTempDir.resolve("aaa").resolve("bbb"));
 
-    mojo.sourceDirectories = List.of(path1.toFile(), path2.toFile(), path3.toFile());
+    mojo.sourceDirectories = List.of(path1, path2, path3);
 
     // When
     mojo.execute();
@@ -1010,7 +1009,7 @@ abstract class AbstractGenerateMojoTestTemplate<A extends AbstractGenerateMojo> 
     var path3 = Files.createDirectories(someTempDir.resolve("aaa").resolve("bbb"));
     assertThat(path2).doesNotExist();
 
-    mojo.sourceDirectories = List.of(path1.toFile(), path2.toFile(), path3.toFile());
+    mojo.sourceDirectories = List.of(path1, path2, path3);
 
     // When
     mojo.execute();

--- a/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/mojo/plexus/PathConverterTest.java
+++ b/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/mojo/plexus/PathConverterTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2023 - 2025, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.ascopes.protobufmavenplugin.mojo.plexus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mockStatic;
+
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import org.codehaus.plexus.component.configurator.ComponentConfigurationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+@DisplayName("PathConverter test")
+class PathConverterTest {
+
+  PathConverter converter;
+
+  @BeforeEach
+  void setUp() {
+    converter = new PathConverter();
+  }
+
+  @DisplayName("only the expected types are convertible")
+  @CsvSource({
+      "     java.nio.file.Path,  true",
+      "           java.net.URI, false",
+      "       java.lang.Object, false",
+      "      java.lang.Integer, false",
+      "        java.lang.Class, false",
+      "       java.lang.String, false",
+      "java.lang.StringBuilder, false",
+      "           java.io.File, false",
+      "           java.net.URL, false",
+  })
+  @ParameterizedTest(name = "for {0}, expect {1}")
+  void onlyTheExpectedTypesAreConvertible(Class<?> type, boolean expectedResult) {
+    // Then
+    assertThat(converter.canConvert(type))
+        .isEqualTo(expectedResult);
+  }
+
+  @DisplayName("Paths can be parsed successfully")
+  @Test
+  void pathsCanBeParsedSuccessfully() throws ComponentConfigurationException {
+    // Given
+    var path = Path.of("foo", "bar", "baz.txt");
+
+    // Then
+    assertThat(converter.fromString(path.toString()))
+        .isEqualTo(path);
+  }
+
+  @DisplayName("Invalid Paths raise an exception during parsing")
+  @Test
+  void invalidPathsRaiseAnExceptionDuringParsing() {
+    // Mocked because we cannot create reproducible results across Windows and Unix
+    try (var pathStatic = mockStatic(Path.class)) {
+      // Given
+      var expectedCause = new InvalidPathException("that is bad", "bad stuff found", 123);
+      pathStatic.when(() -> Path.of(anyString()))
+          .thenThrow(expectedCause);
+
+      // Then
+      assertThatExceptionOfType(ComponentConfigurationException.class)
+          .isThrownBy(() -> converter.fromString("invalid-path"))
+          .withMessage("Failed to parse path 'invalid-path': "
+              + "java.nio.file.InvalidPathException: bad stuff found at index 123: that is bad")
+          .havingCause()
+          .isSameAs(expectedCause);
+
+    }
+  }
+}

--- a/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/mojo/plexus/UriConverterTest.java
+++ b/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/mojo/plexus/UriConverterTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2023 - 2025, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.ascopes.protobufmavenplugin.mojo.plexus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import org.codehaus.plexus.component.configurator.ComponentConfigurationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+@DisplayName("UriConverter test")
+class UriConverterTest {
+
+  UriConverter converter;
+
+  @BeforeEach
+  void setUp() {
+    converter = new UriConverter();
+  }
+
+  @DisplayName("only the expected types are convertible")
+  @CsvSource({
+      "           java.net.URI,  true",
+      "     java.nio.file.Path, false",
+      "       java.lang.Object, false",
+      "      java.lang.Integer, false",
+      "        java.lang.Class, false",
+      "       java.lang.String, false",
+      "java.lang.StringBuilder, false",
+      "           java.io.File, false",
+      "           java.net.URL, false",
+  })
+  @ParameterizedTest(name = "for {0}, expect {1}")
+  void onlyTheExpectedTypesAreConvertible(Class<?> type, boolean expectedResult) {
+    // Then
+    assertThat(converter.canConvert(type))
+        .isEqualTo(expectedResult);
+  }
+
+  @DisplayName("URIs can be parsed successfully")
+  @Test
+  void urisCanBeParsedSuccessfully() throws ComponentConfigurationException {
+    // Given
+    var uri = URI.create("https://google.com");
+
+    // Then
+    assertThat(converter.fromString(uri.toString()))
+        .isEqualTo(uri);
+  }
+
+  @DisplayName("Invalid URIs raise an exception during parsing")
+  @Test
+  void invalidUrisRaiseAnExceptionDuringParsing() {
+    // Then
+    assertThatExceptionOfType(ComponentConfigurationException.class)
+        .isThrownBy(() -> converter.fromString("foo\\bar"))
+        // Annoyingly this varies with the JDK and OS in use. Windows reports a different issue
+        // to Linux!
+        .withMessageMatching("Failed to parse URI 'foo\\\\bar': "
+            + "java.net.URISyntaxException: .*")
+        .havingCause()
+        .isInstanceOf(URISyntaxException.class);
+  }
+}


### PR DESCRIPTION
This will allow us to later register custom protocol handlers for URLs correctly. We cannot do this at the moment because Plexus defaults to trying to parse URLs using the URL default constructor, and that only checks the system classloader for handlers that are registered via the URLStreamHandlerProvider SPI. Our issue is that whilst this would be fine in a normal application, Maven plugins utilise ClassWorlds to separate classloading for each plugin. This means we never run on the default classloader and anything we register with our ServiceLoader will be ignored.

By defining this scaffolding, we can defer parsing URLs until we enter the UrlResourceFetcher (now named UriResourceFetcher), and we can inject our own logic and lookups procedurally.

This scaffold also allows us to pass Path and URI objects around when working with Maven 3.8, which does not override the default converters to include one for the NIO and URI APIs. This is available from Maven 3.9 onwards, so we can eventually deprecate and remove these workarounds.