### PR TITLE
Hook up a ZIP protocol handler for URLs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>io.github.ascopes</groupId>
   <artifactId>protobuf-maven-plugin-parent</artifactId>
-  <version>3.1.4-SNAPSHOT</version>
+  <version>3.2.0-SNAPSHOT</version>
 
   <name>Protobuf Maven Plugin Parent</name>
   <description>Parent POM for the Protobuf Maven Plugin.</description>

--- a/protobuf-maven-plugin/pom.xml
+++ b/protobuf-maven-plugin/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes</groupId>
     <artifactId>protobuf-maven-plugin-parent</artifactId>
-    <version>3.1.4-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>protobuf-maven-plugin</artifactId>

--- a/protobuf-maven-plugin/src/it/scalapb-plugin/pom.xml
+++ b/protobuf-maven-plugin/src/it/scalapb-plugin/pom.xml
@@ -74,7 +74,7 @@
 
           <binaryUrlPlugins>
             <binaryUrlPlugin>
-              <url>jar:https://github.com/scalapb/ScalaPB/releases/download/v${scalapb.version}/protoc-gen-scala-${scalapb.version}-linux-x86_64.zip!/protoc-gen-scala</url>
+              <url>zip:https://github.com/scalapb/ScalaPB/releases/download/v${scalapb.version}/protoc-gen-scala-${scalapb.version}-linux-x86_64.zip!/protoc-gen-scala</url>
               <options>flat_package,grpc,scala3_sources</options>
             </binaryUrlPlugin>
           </binaryUrlPlugins>

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/fs/ZipUrlStreamHandlerProvider.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/fs/ZipUrlStreamHandlerProvider.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2023 - 2025, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.ascopes.protobufmavenplugin.fs;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
+import java.net.spi.URLStreamHandlerProvider;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * URL stream handler SPI implementation that enables the use of the
+ * "zip" protocol within URLs. This allows users to dereference files within
+ * ZIP archives.
+ *
+ * <p>Underneath, this simply delegates to the JDK's JAR provider, as
+ * both formats work in the same way internally.
+ *
+ * @author Ashley Scopes
+ * @since 3.1.4
+ */
+public final class ZipUrlStreamHandlerProvider extends URLStreamHandlerProvider {
+
+  @Override
+  public @Nullable URLStreamHandler createURLStreamHandler(String protocol) {
+    if (!"zip".equals(protocol)) {
+      return null;
+    }
+
+    return new URLStreamHandler() {
+      @Override
+      public URLConnection openConnection(URL url) throws IOException {
+        // Replace zip with jar, as the JDK JAR handler can deal with this
+        // for us rather than needing a brand new implementation.
+        return URI.create("jar" + url.toExternalForm().substring(3))
+            .toURL()
+            .openConnection();
+      }
+    };
+  }
+}

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/fs/ZipUrlStreamHandlerProvider.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/fs/ZipUrlStreamHandlerProvider.java
@@ -32,7 +32,7 @@ import org.jspecify.annotations.Nullable;
  * both formats work in the same way internally.
  *
  * @author Ashley Scopes
- * @since 3.1.4
+ * @since 3.2.p
  */
 public final class ZipUrlStreamHandlerProvider extends URLStreamHandlerProvider {
 

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/AbstractGenerateMojo.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/AbstractGenerateMojo.java
@@ -195,8 +195,8 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    *   <li>FTP resources, specified using {@code ftp://example.server/path/to/file}</li>
    * </ul>
    *
-   * <p>Additionally, the {@code jar} protocol can be used with any of the above to
-   * enable extracting a file from a JAR or ZIP and using it directly.
+   * <p>Additionally, the {@code zip} or {@code jar} protocol can be used with any of the above to
+   * enable extracting a file from a ZIP or JAR and using it directly.
    *
    * <p>For example:
    * <pre>{@code
@@ -214,7 +214,7 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    *
    *   <!-- HTTP resource that is a ZIP holding the binary we want. -->
    *   <binaryUrlPlugin>
-   *     <url>jar:https://myorganisation.org/protoc/plugins/myplugin3.zip!/protoc-gen-something.exe</url>
+   *     <url>zip:https://myorganisation.org/protoc/plugins/myplugin3.zip!/protoc-gen-something.exe</url>
    *   </binaryUrlPlugin>
    * </binaryUrlPlugins>
    * }</pre>

--- a/protobuf-maven-plugin/src/main/resources/META-INF/services/java.net.spi.URLStreamHandlerProvider
+++ b/protobuf-maven-plugin/src/main/resources/META-INF/services/java.net.spi.URLStreamHandlerProvider
@@ -1,0 +1,2 @@
+io.github.ascopes.protobufmavenplugin.fs.ZipUrlStreamHandlerProvider
+

--- a/protobuf-maven-plugin/src/site/markdown/using-protoc-plugins.md
+++ b/protobuf-maven-plugin/src/site/markdown/using-protoc-plugins.md
@@ -125,7 +125,11 @@ Any protocols supported by your JRE should be able to be used here, including:
 - `http`
 - `https`
 - `ftp`
-- `jar` - can be used to dereference files within a JAR or ZIP archive, 
+- `zip` - can be used to dereference files within a ZIP archive,
+  e.g. `zip:https://github.com/some-project/some-repo/releases/download/v1.1.1/plugin.zip!/plugin.exe`,
+  which would download `https://github.com/some-project/some-repo/releases/download/v1.1.1/plugin.zip`
+  and internally extract `plugin.exe` from that archive.
+- `jar` - can be used to dereference files within a JAR archive, 
   e.g. `jar:https://github.com/some-project/some-repo/releases/download/v1.1.1/plugin.jar!/plugin.exe`,
   which would download `https://github.com/some-project/some-repo/releases/download/v1.1.1/plugin.jar`
   and internally extract `plugin.exe` from that archive.

--- a/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/fs/ZipUrlStreamHandlerProviderTest.java
+++ b/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/fs/ZipUrlStreamHandlerProviderTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2023 - 2025, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.ascopes.protobufmavenplugin.fs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.ServiceLoader;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+@DisplayName("ZipUrlStreamHandlerProvider tests")
+class ZipUrlStreamHandlerProviderTest {
+
+  @DisplayName("the provider returns null for unsupported protocols")
+  @Test
+  void providerReturnsNullForUnsupportedProtocols() {
+    // Given
+    var provider = new ZipUrlStreamHandlerProvider();
+
+    // Then
+    assertThat(provider.createURLStreamHandler("tar"))
+        .isNull();
+  }
+
+  @DisplayName("the provider returns a handler for supported protocols")
+  @Test
+  void providerReturnsHandlerForSupportedProtocols() {
+    // Given
+    var provider = new ZipUrlStreamHandlerProvider();
+
+    // Then
+    assertThat(provider.createURLStreamHandler("zip"))
+        .isNotNull();
+  }
+
+  @DisplayName("the 'zip' protocol can be used to read files from ZIP archives")
+  @Test
+  void zipProtocolCanBeUsedToReadFilesFromZips(@TempDir Path tempDir) throws IOException {
+    // Given
+    var zip = createZip(tempDir.resolve("test.zip"), Map.of(
+        "foo/bar/baz.txt", "Hello, World!",
+        "META-INF/versions/8/foo/bar/baz.txt", "This should be ignored"
+    ));
+
+    var uri = URI.create("zip:" + zip.toUri() + "!/foo/bar/baz.txt");
+
+    // When
+    var conn = uri.toURL().openConnection();
+    conn.connect();
+    var os = new ByteArrayOutputStream();
+    try (var is = conn.getInputStream()) {
+      is.transferTo(os);
+    }
+
+    // Then
+    assertThat(os.toString())
+        .isEqualTo("Hello, World!");
+  }
+
+  static Path createZip(Path target, Map<String, String> files) throws IOException {
+    try (var zos = new ZipOutputStream(Files.newOutputStream(target))) {
+      for (var file : files.entrySet()) {
+        zos.putNextEntry(new ZipEntry(file.getKey()));
+        var data = file.getValue().getBytes();
+        zos.write(data, 0, data.length);
+        zos.closeEntry();
+      }
+    }
+    return target;
+  }
+}


### PR DESCRIPTION
This correctly allows users to reference plugins from ZIP archives using zip:file:path/to/archive.zip!/file.exe rather than having to use JAR, which is unintuitive.

Internally this just alters the URL to treat it as a JAR, since both ZIPs and JARs operate in the same way,
but this should be less jarring for users.