### PR TITLE
Omit javax.annotation-api in examples and documentation

### DIFF
--- a/protobuf-maven-plugin/src/it/gh-277-plugin-ordering/pom.xml
+++ b/protobuf-maven-plugin/src/it/gh-277-plugin-ordering/pom.xml
@@ -61,13 +61,6 @@
       <artifactId>reactor-core</artifactId>
       <scope>compile</scope>
     </dependency>
-
-    <!-- See https://github.com/grpc/grpc-java/issues/9179 -->
-    <dependency>
-      <groupId>javax.annotation</groupId>
-      <artifactId>javax.annotation-api</artifactId>
-      <scope>compile</scope>
-    </dependency>
   </dependencies>
 
   <build>
@@ -94,6 +87,8 @@
               <groupId>io.grpc</groupId>
               <artifactId>protoc-gen-grpc-java</artifactId>
               <version>${grpc.version}</version>
+              <!-- See https://github.com/grpc/grpc-java/issues/9179 -->
+              <options>@generated=omit</options>
               <order>100</order>
             </binaryMavenPlugin>
           </binaryMavenPlugins>

--- a/protobuf-maven-plugin/src/it/grpc-plugin/pom.xml
+++ b/protobuf-maven-plugin/src/it/grpc-plugin/pom.xml
@@ -56,13 +56,6 @@
       <scope>compile</scope>
     </dependency>
 
-    <!-- See https://github.com/grpc/grpc-java/issues/9179 -->
-    <dependency>
-      <groupId>javax.annotation</groupId>
-      <artifactId>javax.annotation-api</artifactId>
-      <scope>compile</scope>
-    </dependency>
-
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
@@ -92,6 +85,8 @@
               <groupId>io.grpc</groupId>
               <artifactId>protoc-gen-grpc-java</artifactId>
               <version>${grpc.version}</version>
+              <!-- See https://github.com/grpc/grpc-java/issues/9179 -->
+              <options>@generated=omit</options>
             </binaryMavenPlugin>
           </binaryMavenPlugins>
         </configuration>

--- a/protobuf-maven-plugin/src/it/http-url-grpc-plugin/pom.xml
+++ b/protobuf-maven-plugin/src/it/http-url-grpc-plugin/pom.xml
@@ -62,13 +62,6 @@
       <scope>compile</scope>
     </dependency>
 
-    <!-- See https://github.com/grpc/grpc-java/issues/9179 -->
-    <dependency>
-      <groupId>javax.annotation</groupId>
-      <artifactId>javax.annotation-api</artifactId>
-      <scope>compile</scope>
-    </dependency>
-
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
@@ -96,6 +89,8 @@
           <binaryUrlPlugins>
             <binaryUrlPlugin>
               <url>https://repo1.maven.org/maven2/io/grpc/protoc-gen-grpc-java/${grpc.version}/protoc-gen-grpc-java-${grpc.version}-linux-x86_64.exe</url>
+              <!-- See https://github.com/grpc/grpc-java/issues/9179 -->
+              <options>@generated=omit</options>
             </binaryUrlPlugin>
           </binaryUrlPlugins>
         </configuration>

--- a/protobuf-maven-plugin/src/it/reactor-grpc-binary-plugin/pom.xml
+++ b/protobuf-maven-plugin/src/it/reactor-grpc-binary-plugin/pom.xml
@@ -62,12 +62,6 @@
       <artifactId>reactor-core</artifactId>
     </dependency>
 
-    <!-- See https://github.com/grpc/grpc-java/issues/9179 -->
-    <dependency>
-      <groupId>javax.annotation</groupId>
-      <artifactId>javax.annotation-api</artifactId>
-    </dependency>
-
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
@@ -97,7 +91,10 @@
               <groupId>io.grpc</groupId>
               <artifactId>protoc-gen-grpc-java</artifactId>
               <version>${grpc.version}</version>
+              <!-- See https://github.com/grpc/grpc-java/issues/9179 -->
+              <options>@generated=omit</options>
             </binaryMavenPlugin>
+
             <binaryMavenPlugin>
               <groupId>com.salesforce.servicelibs</groupId>
               <artifactId>reactor-grpc</artifactId>

--- a/protobuf-maven-plugin/src/it/setup/pom.xml
+++ b/protobuf-maven-plugin/src/it/setup/pom.xml
@@ -34,7 +34,6 @@
 
   <properties>
     <grpc.version>1.72.0</grpc.version>
-    <javax-annotation-api.version>1.3.2</javax-annotation-api.version>
     <kotlin.version>2.1.20</kotlin.version>
     <proto-google-common-protos.version>2.55.3</proto-google-common-protos.version>
     <scala.version>3.6.4</scala.version>
@@ -83,13 +82,6 @@
         <groupId>io.projectreactor</groupId>
         <artifactId>reactor-core</artifactId>
         <version>${reactor-core.version}</version>
-      </dependency>
-
-      <!-- See https://github.com/grpc/grpc-java/issues/9179 -->
-      <dependency>
-        <groupId>javax.annotation</groupId>
-        <artifactId>javax.annotation-api</artifactId>
-        <version>${javax-annotation-api.version}</version>
       </dependency>
 
       <dependency>

--- a/protobuf-maven-plugin/src/site/markdown/using-protoc-plugins.md
+++ b/protobuf-maven-plugin/src/site/markdown/using-protoc-plugins.md
@@ -41,6 +41,8 @@ that plugin directly via the group ID, artifact ID, and version (like any other 
         <groupId>io.grpc</groupId>
         <artifactId>protoc-gen-grpc-java</artifactId>
         <version>${grpc.version}</version>
+        <!-- Avoid dependency on javax.annotation-api -->
+        <options>@generated=omit</options>
       </binaryMavenPlugin>
     </binaryMavenPlugins>
   </configuration>
@@ -65,6 +67,8 @@ executable name instead:
     <binaryPathPlugins>
       <binaryPathPlugin>
         <name>protoc-gen-grpc-java</name>
+        <!-- Avoid dependency on javax.annotation-api -->
+        <options>@generated=omit</options>
       </binaryPathPlugin>
     </binaryPathPlugins>
   </configuration>
@@ -104,6 +108,8 @@ specific file system path:
     <binaryUrlPlugins>
       <binaryUrlPlugin>
         <url>file:///opt/protoc/protoc-gen-grpc-java</url>
+        <!-- Avoid dependency on javax.annotation-api -->
+        <options>@generated=omit</options>
       </binaryUrlPlugin>
       <binaryUrlPlugin>
         <url>ftp://company-server.internal/some-other-plugin.exe</url>
@@ -254,6 +260,8 @@ then you can provide the following:
         <groupId>io.grpc</groupId>
         <artifactId>protoc-gen-grpc-java</artifactId>
         <version>${grpc.version}</version>
+        <!-- Avoid dependency on javax.annotation-api -->
+        <options>@generated=omit</options>
       </binaryMavenPlugin>
     </binaryMavenPlugins>
     <jvmMavenPlugins>


### PR DESCRIPTION
Changes the configuration for various integration tests, as well as any documentation examples, to remove the grpc transitive dependency on javax.annotation-api.