### PR TITLE
Improve URL resolution semantics and behaviours

### DIFF
--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/fs/UriResourceFetcher.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/fs/UriResourceFetcher.java
@@ -133,6 +133,13 @@ public final class UriResourceFetcher {
 
     try {
       var conn = url.openConnection();
+      // Important! Without this JarURLConnection may leave the underlying connection
+      // open after we close conn.getInputStream(). On Windows this can prevent the deletion
+      // of these files as part of operations like mvn clean, and also in our unit tests.
+      // On Windows, we can evem crash JUnit because of this!
+      // See https://github.com/junit-team/junit5/issues/4567
+      conn.setUseCaches(false);
+
       conn.setConnectTimeout(TIMEOUT);
       conn.setReadTimeout(TIMEOUT);
       conn.setAllowUserInteraction(false);
@@ -151,6 +158,7 @@ public final class UriResourceFetcher {
       return Optional.of(targetFile);
 
     } catch (FileNotFoundException ex) {
+
       // May be raised during the call to .getInputStream(), or the call to .connect(),
       // depending on the implementation.
       log.warn("No resource at '{}' appears to exist!", uri);

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/fs/UriResourceFetcher.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/fs/UriResourceFetcher.java
@@ -15,8 +15,6 @@
  */
 package io.github.ascopes.protobufmavenplugin.fs;
 
-import static java.util.Objects.requireNonNullElse;
-
 import io.github.ascopes.protobufmavenplugin.utils.Digests;
 import io.github.ascopes.protobufmavenplugin.utils.ResolutionException;
 import java.io.BufferedInputStream;
@@ -30,13 +28,13 @@ import java.net.URL;
 import java.net.spi.URLStreamHandlerProvider;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.ServiceLoader;
-import java.util.ServiceLoader.Provider;
 import javax.inject.Inject;
 import javax.inject.Named;
-import org.apache.maven.Maven;
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.execution.scope.MojoExecutionScoped;
 import org.eclipse.sisu.Description;
 import org.slf4j.Logger;
@@ -53,25 +51,27 @@ import org.slf4j.LoggerFactory;
 @Named
 public final class UriResourceFetcher {
 
-  private static final int TIMEOUT = 30_000;
-  private static final String USER_AGENT_HEADER = "User-Agent";
-  private static final String USER_AGENT_VALUE = String.format(
-      "io.github.ascopes.protobuf-maven-plugin/%s org.apache.maven/%s (Java %s)",
-      requireNonNullElse(
-          // May not be set if we are running within an IDE.
-          UriResourceFetcher.class.getPackage().getImplementationVersion(),
-          "SNAPSHOT"
-      ),
-      Maven.class.getPackage().getImplementationVersion(),
-      Runtime.version().toString()
+  // Protocols that we allow in offline mode.
+  private static final List<String> OFFLINE_PROTOCOLS = List.of(
+      "file:",
+      "jar:file:",
+      "zip:file:",
+      "jrt:"
   );
+
+  private static final int TIMEOUT = 30_000;
 
   private static final Logger log = LoggerFactory.getLogger(UriResourceFetcher.class);
 
+  private final MavenSession mavenSession;
   private final TemporarySpace temporarySpace;
 
   @Inject
-  public UriResourceFetcher(TemporarySpace temporarySpace) {
+  public UriResourceFetcher(
+      MavenSession mavenSession,
+      TemporarySpace temporarySpace
+  ) {
+    this.mavenSession = mavenSession;
     this.temporarySpace = temporarySpace;
   }
 
@@ -89,18 +89,37 @@ public final class UriResourceFetcher {
    * @throws ResolutionException if resolution fails for any other reason.
    */
   public Optional<Path> fetchFileFromUri(URI uri, String extension) throws ResolutionException {
+    if (mavenSession.isOffline()) {
+      var isInvalidOfflineProtocol = OFFLINE_PROTOCOLS.stream()
+          .noneMatch(uri.toString()::startsWith);
+
+      if (isInvalidOfflineProtocol) {
+        throw new ResolutionException(
+            "Cannot resolve URI: " + uri
+                + ". Only a limited number of URL protocols are supported in offline mode."
+        );
+      }
+    }
+
     // This will die if the URI points to a file on the non default file system...
     // probably don't care enough to fix this bug as users should not ever want to do this I guess.
-    return uri.getScheme().equalsIgnoreCase("file")
+    return "file".equals(uri.getScheme())
         ? handleFileSystemUri(uri)
         : handleOtherUri(uri, extension);
   }
 
   private Optional<Path> handleFileSystemUri(URI uri) throws ResolutionException {
     try {
-      return Optional.of(uri)
+      var result = Optional.of(uri)
           .map(Path::of)
           .filter(Files::exists);
+
+      result.ifPresentOrElse(
+          path -> log.debug("Resolved '{}' to '{}'", uri, path),
+          () -> log.warn("No resource at '{}' appears to exist!", uri)
+      );
+
+      return result;
     } catch (Exception ex) {
       throw new ResolutionException("Failed to discover file at '" + uri + "': " + ex, ex);
     }
@@ -117,7 +136,6 @@ public final class UriResourceFetcher {
       conn.setConnectTimeout(TIMEOUT);
       conn.setReadTimeout(TIMEOUT);
       conn.setAllowUserInteraction(false);
-      conn.setRequestProperty(USER_AGENT_HEADER, USER_AGENT_VALUE);
 
       log.debug("Connecting to '{}' to copy resources to '{}'", uri, targetFile);
       conn.connect();
@@ -128,16 +146,19 @@ public final class UriResourceFetcher {
       ) {
         responseStream.transferTo(fileStream);
         log.info("Downloaded '{}' to '{}' ({} bytes)", uri, targetFile, fileStream.size);
-        return Optional.of(targetFile);
-
-      } catch (FileNotFoundException ex) {
-        log.warn("No resource at '{}' appears to exist!", uri);
-        return Optional.empty();
       }
+
+      return Optional.of(targetFile);
+
+    } catch (FileNotFoundException ex) {
+      // May be raised during the call to .getInputStream(), or the call to .connect(),
+      // depending on the implementation.
+      log.warn("No resource at '{}' appears to exist!", uri);
+
+      return Optional.empty();
 
     } catch (IOException ex) {
       log.debug("Failed to download '{}' to '{}'", uri, targetFile, ex);
-
       throw new ResolutionException("Failed to download '" + uri + "' to '" + targetFile + "'", ex);
     }
   }
@@ -159,7 +180,7 @@ public final class UriResourceFetcher {
     var customHandler = ServiceLoader
         .load(URLStreamHandlerProvider.class, getClass().getClassLoader())
         .stream()
-        .map(Provider::get)
+        .map(ServiceLoader.Provider::get)
         .map(provider -> provider.createURLStreamHandler(uri.getScheme()))
         .filter(Objects::nonNull)
         .findFirst()
@@ -170,7 +191,7 @@ public final class UriResourceFetcher {
     try {
       return new URL(null, uri.toString(), customHandler);
     } catch (MalformedURLException ex) {
-      throw new ResolutionException("Syntax for URI '" + uri + "' is invalid", ex);
+      throw new ResolutionException("URI '" + uri + "' is invalid: " + ex, ex);
     }
   }
 

--- a/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/fs/UriResourceFetcherTest.java
+++ b/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/fs/UriResourceFetcherTest.java
@@ -16,7 +16,8 @@
 package io.github.ascopes.protobufmavenplugin.fs;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
@@ -32,11 +33,18 @@ import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import io.github.ascopes.protobufmavenplugin.utils.Digests;
 import io.github.ascopes.protobufmavenplugin.utils.ResolutionException;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 import org.apache.maven.Maven;
+import org.apache.maven.execution.MavenSession;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -44,6 +52,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -57,6 +66,9 @@ class UriResourceFetcherTest {
   WireMock wireMockClient;
   String wireMockBaseUri;
 
+  @Mock(strictness = Mock.Strictness.LENIENT)
+  MavenSession mavenSession;
+
   @Mock
   TemporarySpace temporarySpace;
 
@@ -67,12 +79,39 @@ class UriResourceFetcherTest {
   void setUp(WireMockRuntimeInfo wireMockInfo) {
     wireMockClient = wireMockInfo.getWireMock();
     wireMockBaseUri = wireMockInfo.getHttpBaseUrl();
+
+    when(mavenSession.isOffline())
+        .thenReturn(false);
+  }
+
+  @DisplayName("invalid URI protocols are not resolved")
+  @Test
+  void invalidUriProtocolsAreNotResolved() throws Exception {
+    // Given
+    var uri = URI.create("foobar:file://path/to/it");
+
+    // Then
+    assertThatExceptionOfType(ResolutionException.class)
+        .isThrownBy(() -> uriResourceFetcher.fetchFileFromUri(uri, ".blob"))
+        .withMessage(
+            "URI '%s' is invalid: java.net.MalformedURLException: "
+                + "unknown protocol: foobar",
+            uri
+        )
+        .withCauseInstanceOf(MalformedURLException.class);
   }
 
   @DisplayName("file URIs are resolved when they exist")
-  @Test
-  void fileUrisAreResolvedWhenTheyExist(@TempDir Path tempDir) throws Exception {
+  @ValueSource(booleans = {true, false})
+  @ParameterizedTest(name = "when MavenSession.isOffline returns {0}")
+  void fileUrisAreResolvedWhenTheyExist(
+      boolean isOffline,
+      @TempDir Path tempDir
+  ) throws Exception {
     // Given
+    when(mavenSession.isOffline())
+        .thenReturn(isOffline);
+
     var file = Files.createFile(tempDir.resolve("nekomata.nya"));
 
     // When
@@ -85,14 +124,96 @@ class UriResourceFetcherTest {
         .isEqualTo(file);
   }
 
-  @DisplayName("file URIs are resolved when they do not exist")
+  @DisplayName("nested file URIs are resolved when they exist")
+  @CsvSource({
+      "jar,  true",
+      "zip,  true",
+      "jar, false",
+      "zip, false"
+  })
+  @ParameterizedTest(name = "for protocol {0}, when MavenSession.isOffline returns {1}")
+  void nestedFileUrisAreResolvedWhenTheyExist(
+      String protocol,
+      boolean isOffline,
+      @TempDir Path tempDir
+  ) throws Exception {
+    // Given
+    when(mavenSession.isOffline())
+        .thenReturn(isOffline);
+
+    var expectedOutputDir = tempDir.resolve("outputs");
+    Files.createDirectories(expectedOutputDir);
+    when(temporarySpace.createTemporarySpace(any(), any()))
+        .thenReturn(expectedOutputDir);
+
+    var archiveFile = tempDir.resolve("inputs").resolve("archive." + protocol);
+    Files.createDirectories(archiveFile.getParent());
+    try (var outputStream = Files.newOutputStream(archiveFile)) {
+      createJar(
+          outputStream,
+          Map.entry("some/file.txt", "some content here"),
+          Map.entry("some/other/file.txt", "some more content here"),
+          Map.entry("foo/bar.txt", "Hello, World!"),
+          Map.entry("yet/another/file.bin", "blah blah blah")
+      );
+    }
+
+    var uri = URI.create(protocol + ":" + archiveFile.toUri() + "!/foo/bar.txt");
+    var digest = Digests.sha1(uri.toASCIIString());
+    var expectedFileName = "bar.txt-" + digest + ".log";
+
+    // When
+    var result = uriResourceFetcher.fetchFileFromUri(uri, ".log");
+
+    // Then
+    assertThat(result)
+        .isPresent()
+        .get(InstanceOfAssertFactories.PATH)
+        .isEqualTo(expectedOutputDir.resolve(expectedFileName))
+        .hasContent("Hello, World!");
+  }
+
+  @DisplayName("file URIs are not resolved when they do not exist")
   @Test
-  void fileUrisAreResolvedWhenTheyDoNotExist(@TempDir Path tempDir) throws Exception {
+  void fileUrisAreNotResolvedWhenTheyDoNotExist(@TempDir Path tempDir) throws Exception {
     // Given
     var file = tempDir.resolve("nekomata.nya");
 
     // When
     var result = uriResourceFetcher.fetchFileFromUri(file.toUri(), ".thiren");
+
+    // Then
+    assertThat(result)
+        .isEmpty();
+  }
+
+  @DisplayName("nested file URIs are not resolved when they do not exist")
+  @ValueSource(strings = {"jar", "zip"})
+  @ParameterizedTest(name = "for protocol {0}")
+  void nestedFileUrisAreNotResolvedWhenTheyDoNotExist(
+      String protocol,
+      @TempDir Path tempDir
+  ) throws Exception {
+    // Given
+    when(temporarySpace.createTemporarySpace(any(), any()))
+        .thenReturn(tempDir);
+
+    var archiveFile = tempDir.resolve("inputs").resolve("archive." + protocol);
+    Files.createDirectories(archiveFile.getParent());
+    try (var outputStream = Files.newOutputStream(archiveFile)) {
+      createJar(
+          outputStream,
+          Map.entry("some/file.txt", "some content here"),
+          Map.entry("some/other/file.txt", "some more content here"),
+          Map.entry("foo/bar.txt", "Hello, World!"),
+          Map.entry("yet/another/file.bin", "blah blah blah")
+      );
+    }
+
+    var uri = URI.create(protocol + ":" + archiveFile.toUri() + "!/missing-file.txt");
+
+    // When
+    var result = uriResourceFetcher.fetchFileFromUri(uri, ".log");
 
     // Then
     assertThat(result)
@@ -115,10 +236,10 @@ class UriResourceFetcherTest {
         .withCauseInstanceOf(IllegalArgumentException.class);
   }
 
-  @DisplayName("other URIs are resolved when they exist")
+  @DisplayName("HTTP URIs are resolved when they exist")
   @ValueSource(strings = {"bar.txt.bin", "foo/bar.txt.bin"})
   @ParameterizedTest(name = "for path {0}")
-  void otherUrisAreResolvedWhenTheyExist(
+  void httpUrisAreResolvedWhenTheyExist(
       String requestedPath,
       @TempDir Path tempDir
   ) throws Exception {
@@ -141,19 +262,102 @@ class UriResourceFetcherTest {
     var finalPath = uriResourceFetcher.fetchFileFromUri(uri, ".textfile");
 
     // Then
+    wireMockClient.verifyThat(getRequestedFor(urlEqualTo("/" + requestedPath)));
+
     assertThat(finalPath)
         .isPresent()
         .get(InstanceOfAssertFactories.PATH)
         .isEqualTo(tempDir.resolve(expectedFileName + "-" + digest + ".textfile"))
         .hasContent("Hello, World!");
-
-    wireMockClient.verifyThat(getRequestedFor(urlEqualTo("/" + requestedPath))
-        .withHeader("User-Agent", equalTo(expectedUserAgent())));
   }
 
-  @DisplayName("other pathless URIs are resolved when they exist")
+  @DisplayName("ZIP nested HTTP URIs are resolved when they exist")
   @Test
-  void otherPathlessUrisAreResolvedWhenTheyExist(
+  void zipNestedHttpUrisAreResolvedWhenTheyExist(
+      @TempDir Path tempDir
+  ) throws Exception {
+    // Given
+    var data = new ByteArrayOutputStream();
+    createJar(
+        data,
+        Map.entry("some/file.txt", "some content here"),
+        Map.entry("some/other/file.txt", "some more content here"),
+        Map.entry("foo/bar/baz.txt", "Hello, World!"),
+        Map.entry("yet/another/file.bin", "blah blah blah")
+    );
+
+    wireMockClient.register(get(urlEqualTo("/some/archive.zip"))
+        .willReturn(aResponse()
+            .withStatus(200)
+            .withHeader("Content-Type", "application/octet-stream")
+            .withBody(data.toByteArray())));
+
+    when(temporarySpace.createTemporarySpace(any(), any()))
+        .thenReturn(tempDir);
+
+    var uri = URI.create("zip:" + wireMockBaseUri
+        + "/some/archive.zip!/foo/bar/baz.txt");
+
+    var digest = Digests.sha1(uri.toASCIIString());
+
+    // When
+    var finalPath = uriResourceFetcher.fetchFileFromUri(uri, ".textfile");
+
+    // Then
+    wireMockClient.verifyThat(getRequestedFor(urlEqualTo("/some/archive.zip")));
+
+    assertThat(finalPath)
+        .isPresent()
+        .get(InstanceOfAssertFactories.PATH)
+        .isEqualTo(tempDir.resolve("baz.txt-" + digest + ".textfile"))
+        .hasContent("Hello, World!");
+  }
+
+  @DisplayName("JAR nested HTTP URIs are resolved when they exist")
+  @Test
+  void jarNestedHttpUrisAreResolvedWhenTheyExist(
+      @TempDir Path tempDir
+  ) throws Exception {
+    // Given
+    var data = new ByteArrayOutputStream();
+    createJar(
+        data,
+        Map.entry("some/file.txt", "some content here"),
+        Map.entry("some/other/file.txt", "some more content here"),
+        Map.entry("foo/bar/baz.txt", "Hello, World!"),
+        Map.entry("yet/another/file.bin", "blah blah blah")
+    );
+
+    wireMockClient.register(get(urlEqualTo("/some/archive.jar"))
+        .willReturn(aResponse()
+            .withStatus(200)
+            .withHeader("Content-Type", "application/octet-stream")
+            .withBody(data.toByteArray())));
+
+    when(temporarySpace.createTemporarySpace(any(), any()))
+        .thenReturn(tempDir);
+
+    var uri = URI.create("jar:" + wireMockBaseUri
+        + "/some/archive.jar!/foo/bar/baz.txt");
+
+    var digest = Digests.sha1(uri.toASCIIString());
+
+    // When
+    var finalPath = uriResourceFetcher.fetchFileFromUri(uri, ".textfile");
+
+    // Then
+    wireMockClient.verifyThat(getRequestedFor(urlEqualTo("/some/archive.jar")));
+
+    assertThat(finalPath)
+        .isPresent()
+        .get(InstanceOfAssertFactories.PATH)
+        .isEqualTo(tempDir.resolve("baz.txt-" + digest + ".textfile"))
+        .hasContent("Hello, World!");
+  }
+
+  @DisplayName("Pathless HTTP URIs are resolved when they exist")
+  @Test
+  void pathlessHttpUrisAreResolvedWhenTheyExist(
       @TempDir Path tempDir
   ) throws Exception {
     // Given
@@ -172,19 +376,18 @@ class UriResourceFetcherTest {
     var finalPath = uriResourceFetcher.fetchFileFromUri(uri, ".textfile");
 
     // Then
+    wireMockClient.verifyThat(getRequestedFor(urlEqualTo("/")));
+
     assertThat(finalPath)
         .isPresent()
         .get(InstanceOfAssertFactories.PATH)
         .isEqualTo(tempDir.resolve(digest + ".textfile"))
         .hasContent("Hello, World!");
-
-    wireMockClient.verifyThat(getRequestedFor(urlEqualTo("/"))
-        .withHeader("User-Agent", equalTo(expectedUserAgent())));
   }
 
-  @DisplayName("other URIs are not resolved when they do not exist")
+  @DisplayName("HTTP URIs are not resolved when they do not exist")
   @Test
-  void otherUrisAreNotResolvedWhenTheyDoNotExist(@TempDir Path tempDir) throws Exception {
+  void httpUrisAreNotResolvedWhenTheyDoNotExist(@TempDir Path tempDir) throws Exception {
     // Given
     wireMockClient.register(get(urlEqualTo("/foo/bar.txt.bin"))
         .willReturn(aResponse().withStatus(404)));
@@ -197,16 +400,15 @@ class UriResourceFetcherTest {
     var finalPath = uriResourceFetcher.fetchFileFromUri(uri, ".textfile");
 
     // Then
+    wireMockClient.verifyThat(getRequestedFor(urlEqualTo("/foo/bar.txt.bin")));
+
     assertThat(finalPath)
         .isEmpty();
-
-    wireMockClient.verifyThat(getRequestedFor(urlEqualTo("/foo/bar.txt.bin"))
-        .withHeader("User-Agent", equalTo(expectedUserAgent())));
   }
 
-  @DisplayName("other URIs raise exceptions if transfer fails")
+  @DisplayName("HTTP URIs raise exceptions if transfer fails")
   @Test
-  void otherUrisRaiseExceptionsIfTransferFails(@TempDir Path tempDir) throws Exception {
+  void httpUrisRaiseExceptionsIfTransferFails(@TempDir Path tempDir) throws Exception {
     // Given
     wireMockClient.register(get(urlEqualTo("/foo/bar.txt.bin"))
         .willReturn(aResponse().withFault(Fault.MALFORMED_RESPONSE_CHUNK)));
@@ -220,20 +422,61 @@ class UriResourceFetcherTest {
         .isThrownBy(() -> uriResourceFetcher.fetchFileFromUri(uri, ".textfile"))
         .withCauseInstanceOf(IOException.class);
 
-    wireMockClient.verifyThat(getRequestedFor(urlEqualTo("/foo/bar.txt.bin"))
-        .withHeader("User-Agent", equalTo(expectedUserAgent())));
+    wireMockClient.verifyThat(getRequestedFor(urlEqualTo("/foo/bar.txt.bin")));
   }
 
-  static String expectedUserAgent() {
-    return String.format(
-        "io.github.ascopes.protobuf-maven-plugin/%s org.apache.maven/%s (Java %s)",
-        requireNonNullElse(
-            // May not be set if we are running within an IDE.
-            UriResourceFetcher.class.getPackage().getImplementationVersion(),
-            "SNAPSHOT"
-        ),
-        Maven.class.getPackage().getImplementationVersion(),
-        Runtime.version().toString()
-    );
+  @DisplayName("HTTP URIs raise exceptions if offline mode is enabled")
+  @Test
+  void httpUrisRaiseExceptionsIfOfflineModeIsEnabled() throws Exception {
+    // Given
+    when(mavenSession.isOffline())
+        .thenReturn(true);
+
+    var uri = URI.create(wireMockBaseUri + "/foo/bar.txt.bin");
+    // Then
+    assertThatExceptionOfType(ResolutionException.class)
+        .isThrownBy(() -> uriResourceFetcher.fetchFileFromUri(uri, ".textfile"))
+        .withMessage(
+            "Cannot resolve URI: %s. Only a limited number of URL protocols "
+                + "are supported in offline mode.",
+            uri
+        );
+
+    wireMockClient.verifyThat(0, anyRequestedFor(anyUrl()));
+  }
+
+  @DisplayName("nested HTTP URIs raise exceptions if offline mode is enabled")
+  @Test
+  void nestedHttpUrisRaiseExceptionsIfOfflineModeIsEnabled() throws Exception {
+    // Given
+    when(mavenSession.isOffline())
+        .thenReturn(true);
+
+    var uri = URI.create("jar:" + wireMockBaseUri + "/foo/bar.txt.bin!/foo.txt");
+    // Then
+    assertThatExceptionOfType(ResolutionException.class)
+        .isThrownBy(() -> uriResourceFetcher.fetchFileFromUri(uri, ".textfile"))
+        .withMessage(
+            "Cannot resolve URI: %s. Only a limited number of URL protocols "
+                + "are supported in offline mode.",
+            uri
+        );
+
+    wireMockClient.verifyThat(0, anyRequestedFor(anyUrl()));
+  }
+
+  @SafeVarargs
+  @SuppressWarnings("vararg")
+  static void createJar(
+      OutputStream outputStream,
+      Map.Entry<String, String>... files
+  ) throws IOException {
+    try (var zipOutputStream = new ZipOutputStream(outputStream)) {
+      for (var file : files) {
+        zipOutputStream.putNextEntry(new ZipEntry(file.getKey()));
+        zipOutputStream.write(file.getValue().getBytes());
+        zipOutputStream.closeEntry();
+      }
+    }
   }
 }

--- a/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/fs/UriResourceFetcherTest.java
+++ b/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/fs/UriResourceFetcherTest.java
@@ -66,6 +66,9 @@ class UriResourceFetcherTest {
   WireMock wireMockClient;
   String wireMockBaseUri;
 
+  @TempDir
+  Path tempDir;
+
   @Mock(strictness = Mock.Strictness.LENIENT)
   MavenSession mavenSession;
 
@@ -104,10 +107,7 @@ class UriResourceFetcherTest {
   @DisplayName("file URIs are resolved when they exist")
   @ValueSource(booleans = {true, false})
   @ParameterizedTest(name = "when MavenSession.isOffline returns {0}")
-  void fileUrisAreResolvedWhenTheyExist(
-      boolean isOffline,
-      @TempDir Path tempDir
-  ) throws Exception {
+  void fileUrisAreResolvedWhenTheyExist(boolean isOffline) throws Exception {
     // Given
     when(mavenSession.isOffline())
         .thenReturn(isOffline);
@@ -134,8 +134,7 @@ class UriResourceFetcherTest {
   @ParameterizedTest(name = "for protocol {0}, when MavenSession.isOffline returns {1}")
   void nestedFileUrisAreResolvedWhenTheyExist(
       String protocol,
-      boolean isOffline,
-      @TempDir Path tempDir
+      boolean isOffline
   ) throws Exception {
     // Given
     when(mavenSession.isOffline())
@@ -175,7 +174,7 @@ class UriResourceFetcherTest {
 
   @DisplayName("file URIs are not resolved when they do not exist")
   @Test
-  void fileUrisAreNotResolvedWhenTheyDoNotExist(@TempDir Path tempDir) throws Exception {
+  void fileUrisAreNotResolvedWhenTheyDoNotExist() throws Exception {
     // Given
     var file = tempDir.resolve("nekomata.nya");
 
@@ -190,10 +189,7 @@ class UriResourceFetcherTest {
   @DisplayName("nested file URIs are not resolved when they do not exist")
   @ValueSource(strings = {"jar", "zip"})
   @ParameterizedTest(name = "for protocol {0}")
-  void nestedFileUrisAreNotResolvedWhenTheyDoNotExist(
-      String protocol,
-      @TempDir Path tempDir
-  ) throws Exception {
+  void nestedFileUrisAreNotResolvedWhenTheyDoNotExist(String protocol) throws Exception {
     // Given
     when(temporarySpace.createTemporarySpace(any(), any()))
         .thenReturn(tempDir);
@@ -239,10 +235,7 @@ class UriResourceFetcherTest {
   @DisplayName("HTTP URIs are resolved when they exist")
   @ValueSource(strings = {"bar.txt.bin", "foo/bar.txt.bin"})
   @ParameterizedTest(name = "for path {0}")
-  void httpUrisAreResolvedWhenTheyExist(
-      String requestedPath,
-      @TempDir Path tempDir
-  ) throws Exception {
+  void httpUrisAreResolvedWhenTheyExist(String requestedPath) throws Exception {
     // Given
     wireMockClient.register(get(urlEqualTo("/" + requestedPath))
         .willReturn(aResponse()
@@ -273,9 +266,7 @@ class UriResourceFetcherTest {
 
   @DisplayName("ZIP nested HTTP URIs are resolved when they exist")
   @Test
-  void zipNestedHttpUrisAreResolvedWhenTheyExist(
-      @TempDir Path tempDir
-  ) throws Exception {
+  void zipNestedHttpUrisAreResolvedWhenTheyExist(@TempDir Path tempDir) throws Exception {
     // Given
     var data = new ByteArrayOutputStream();
     createJar(
@@ -315,9 +306,7 @@ class UriResourceFetcherTest {
 
   @DisplayName("JAR nested HTTP URIs are resolved when they exist")
   @Test
-  void jarNestedHttpUrisAreResolvedWhenTheyExist(
-      @TempDir Path tempDir
-  ) throws Exception {
+  void jarNestedHttpUrisAreResolvedWhenTheyExist() throws Exception {
     // Given
     var data = new ByteArrayOutputStream();
     createJar(
@@ -357,9 +346,7 @@ class UriResourceFetcherTest {
 
   @DisplayName("Pathless HTTP URIs are resolved when they exist")
   @Test
-  void pathlessHttpUrisAreResolvedWhenTheyExist(
-      @TempDir Path tempDir
-  ) throws Exception {
+  void pathlessHttpUrisAreResolvedWhenTheyExist() throws Exception {
     // Given
     wireMockClient.register(get(urlEqualTo("/"))
         .willReturn(aResponse()
@@ -387,7 +374,7 @@ class UriResourceFetcherTest {
 
   @DisplayName("HTTP URIs are not resolved when they do not exist")
   @Test
-  void httpUrisAreNotResolvedWhenTheyDoNotExist(@TempDir Path tempDir) throws Exception {
+  void httpUrisAreNotResolvedWhenTheyDoNotExist() throws Exception {
     // Given
     wireMockClient.register(get(urlEqualTo("/foo/bar.txt.bin"))
         .willReturn(aResponse().withStatus(404)));
@@ -408,7 +395,7 @@ class UriResourceFetcherTest {
 
   @DisplayName("HTTP URIs raise exceptions if transfer fails")
   @Test
-  void httpUrisRaiseExceptionsIfTransferFails(@TempDir Path tempDir) throws Exception {
+  void httpUrisRaiseExceptionsIfTransferFails() throws Exception {
     // Given
     wireMockClient.register(get(urlEqualTo("/foo/bar.txt.bin"))
         .willReturn(aResponse().withFault(Fault.MALFORMED_RESPONSE_CHUNK)));


### PR DESCRIPTION
- Removed user agent injection as it does not consistently propagate to nested URL handlers such as jar:http://...
- Correctly handle FileNotFoundException for nested URLs when the file does not exist, rather than raising a ResolutionException and halting the build. This fixes optional resolution semantics.
- Disallow downloading most URLs if offline mode is enabled. Any URL resolution that does not operate on file:, jar:file:, zip:file:, or jrt: will now trigger an exception during resolution if offline mode is enabled. This fixes behaviour that was enabled for GH-668 in GH-670 that allows users to run this Maven plugin in offline mode (e.g. during NIX builds, or in airgapped systems).
- File scheme matching is now case sensitive to match other behaviours elsewhere.
- Log warnings when files are missing during URI resolution, just like non-file URIs already do.
- Add several new test cases for URI resolution.
- Improve error messages when an unsupported java.net.URL protocol is provided by the user.
- Force disable caching for nested URL resources to work around https://bugs.openjdk.org/browse/JDK-8239054