### PR TITLE
Wrong flag value for code generation plugin

### DIFF
--- a/protobuf-maven-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/protobuf-maven-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -28,7 +28,7 @@
 			<action>
 				<execute>
 					<runOnIncremental>true</runOnIncremental>
-					<runOnConfiguration>false</runOnConfiguration>
+					<runOnConfiguration>true</runOnConfiguration>
 				</execute>
 			</action>
 		</pluginExecution>


### PR DESCRIPTION
Sorry, I didn't read the docs correctly (https://eclipse.dev/m2e/documentation/m2e-making-maven-plugins-compat.html). This change should fix it so the plugin actually runs when we need it.