### PR TITLE
Implement support for custom per-plugin output paths

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>io.github.ascopes</groupId>
   <artifactId>protobuf-maven-plugin-parent</artifactId>
-  <version>3.2.4-SNAPSHOT</version>
+  <version>3.3.0-SNAPSHOT</version>
 
   <name>Protobuf Maven Plugin Parent</name>
   <description>Parent POM for the Protobuf Maven Plugin.</description>

--- a/protobuf-maven-plugin/pom.xml
+++ b/protobuf-maven-plugin/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes</groupId>
     <artifactId>protobuf-maven-plugin-parent</artifactId>
-    <version>3.2.4-SNAPSHOT</version>
+    <version>3.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>protobuf-maven-plugin</artifactId>

--- a/protobuf-maven-plugin/src/it/grpc-plugin/test.groovy
+++ b/protobuf-maven-plugin/src/it/grpc-plugin/test.groovy
@@ -24,6 +24,7 @@ def expectedGeneratedFiles = [
     "org/example/helloworld/Helloworld",
     "org/example/helloworld/GreetingRequest",
     "org/example/helloworld/GreetingRequestOrBuilder",
+    "org/example/helloworld/GreetingServiceGrpc",
 ]
 
 assertThat(generatedSourcesDir).isDirectory()

--- a/protobuf-maven-plugin/src/it/per-plugin-output-paths/invoker.properties
+++ b/protobuf-maven-plugin/src/it/per-plugin-output-paths/invoker.properties
@@ -1,0 +1,17 @@
+#
+# Copyright (C) 2023 - 2025, Ashley Scopes.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+invoker.goals = clean package

--- a/protobuf-maven-plugin/src/it/per-plugin-output-paths/pom.xml
+++ b/protobuf-maven-plugin/src/it/per-plugin-output-paths/pom.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2023 - 2025, Ashley Scopes.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>@project.groupId@.it</groupId>
+    <artifactId>integration-test-parent</artifactId>
+    <version>@project.version@</version>
+    <relativePath>../setup/pom.xml</relativePath>
+  </parent>
+
+  <groupId>per-plugin-output-paths</groupId>
+  <artifactId>per-plugin-output-paths</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.salesforce.servicelibs</groupId>
+      <artifactId>reactor-grpc-stub</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-protobuf</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-netty</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-stub</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.projectreactor</groupId>
+      <artifactId>reactor-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+
+        <configuration>
+          <binaryMavenPlugins>
+            <binaryMavenPlugin>
+              <groupId>io.grpc</groupId>
+              <artifactId>protoc-gen-grpc-java</artifactId>
+              <version>${grpc.version}</version>
+              <!-- See https://github.com/grpc/grpc-java/issues/9179 -->
+              <options>@generated=omit</options>
+              <outputDirectory>${project.basedir}/target/generated-sources/grpc</outputDirectory>
+            </binaryMavenPlugin>
+
+            <binaryMavenPlugin>
+              <groupId>com.salesforce.servicelibs</groupId>
+              <artifactId>reactor-grpc</artifactId>
+              <version>${reactor-grpc.version}</version>
+              <outputDirectory>${project.basedir}/target/generated-sources/reactor</outputDirectory>
+            </binaryMavenPlugin>
+          </binaryMavenPlugins>
+
+          <outputDirectory>${project.basedir}/target/generated-sources/proto</outputDirectory>
+        </configuration>
+
+        <executions>
+          <execution>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/protobuf-maven-plugin/src/it/per-plugin-output-paths/src/main/java/org/example/helloworld/ReactorGreetingServiceImpl.java
+++ b/protobuf-maven-plugin/src/it/per-plugin-output-paths/src/main/java/org/example/helloworld/ReactorGreetingServiceImpl.java
@@ -13,31 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.github.ascopes.protobufmavenplugin.plugins;
+package org.example.helloworld;
 
-import java.nio.file.Path;
-import java.util.Optional;
-import org.immutables.value.Value.Immutable;
+import reactor.core.publisher.Mono;
 
-/**
- * Model that holds details about a resolved protoc plugin.
- *
- * <p>Only used internally, never exposed via the plugin API to users.
- *
- * @author Ashley Scopes
- */
-@Immutable
-public interface ResolvedProtocPlugin {
-
-  String getId();
-
-  Optional<String> getOptions();
-
-  int getOrder();
-
-  Path getOutputDirectory();
-
-  Optional<Boolean> getRegisterAsCompilationRoot();
-
-  Path getPath();
+public class ReactorGreetingServiceImpl extends ReactorGreetingServiceGrpc.GreetingServiceImplBase {
+  @Override
+  public Mono<GreetingResponse> greet(Mono<GreetingRequest> request) {
+    return request.map(body -> GreetingResponse.newBuilder()
+            .setText("Hello, " + body.getName() + "!")
+            .build());
+  }
 }

--- a/protobuf-maven-plugin/src/it/per-plugin-output-paths/src/main/protobuf/helloworld.proto
+++ b/protobuf-maven-plugin/src/it/per-plugin-output-paths/src/main/protobuf/helloworld.proto
@@ -1,0 +1,35 @@
+//
+// Copyright (C) 2023 - 2025, Ashley Scopes.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "org.example.helloworld";
+
+package org.example.helloworld;
+
+message GreetingRequest {
+  string name = 1;
+}
+
+message GreetingResponse {
+  string text = 1;
+}
+
+service GreetingService {
+  rpc Greet(GreetingRequest) returns (GreetingResponse);
+}
+

--- a/protobuf-maven-plugin/src/it/per-plugin-output-paths/src/test/java/org/example/helloworld/ReactorGreetingServiceImplTest.java
+++ b/protobuf-maven-plugin/src/it/per-plugin-output-paths/src/test/java/org/example/helloworld/ReactorGreetingServiceImplTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2023 - 2025, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.example.helloworld;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.ServerBuilder;
+import org.junit.jupiter.api.Test;
+
+class ReactorGreetingServiceImplTest {
+  @Test
+  void greetingServiceWorksAsExpected() throws Throwable {
+    // Given
+    var service = new ReactorGreetingServiceImpl();
+    var server = ServerBuilder
+        .forPort(8083)
+        .addService(service)
+        .build();
+    var channel = ManagedChannelBuilder.forAddress("localhost", 8083)
+        .usePlaintext()
+        .build();
+    var stub = ReactorGreetingServiceGrpc.newReactorStub(channel);
+
+    try {
+      server.start();
+
+      // When
+      var request = GreetingRequest
+          .newBuilder()
+          .setName("Dave")
+          .build();
+      var response = stub.greet(request).block();
+
+      // Then
+      assertEquals("Hello, Dave!", response.getText());
+    } finally {
+      server.shutdown();
+      server.awaitTermination();
+    }
+  }
+}

--- a/protobuf-maven-plugin/src/it/per-plugin-output-paths/test.groovy
+++ b/protobuf-maven-plugin/src/it/per-plugin-output-paths/test.groovy
@@ -17,27 +17,53 @@ import java.nio.file.Path
 
 import static org.assertj.core.api.Assertions.assertThat
 
-Path  baseDirectory = basedir.toPath().toAbsolutePath()
-Path generatedSourcesDir = baseDirectory.resolve("target/generated-sources/protobuf")
+Path baseDirectory = basedir.toPath().toAbsolutePath()
+Path protoGeneratedSourcesDir = baseDirectory.resolve("target/generated-sources/proto")
+Path grpcGeneratedSourcesDir = baseDirectory.resolve("target/generated-sources/grpc")
+Path reactorGeneratedSourcesDir = baseDirectory.resolve("target/generated-sources/reactor")
 Path classesDir = baseDirectory.resolve("target/classes")
-List<String> expectedGeneratedFiles = [
+
+List<String> expectedProtoGeneratedFiles = [
     "org/example/helloworld/Helloworld",
     "org/example/helloworld/GreetingRequest",
     "org/example/helloworld/GreetingRequestOrBuilder",
+]
+
+List<String> expectedGrpcGeneratedFiles = [
     "org/example/helloworld/GreetingServiceGrpc",
+]
+
+List<String> expectedReactorGeneratedFiles = [
     "org/example/helloworld/ReactorGreetingServiceGrpc",
 ]
 
-assertThat(generatedSourcesDir).isDirectory()
+assertThat(protoGeneratedSourcesDir).isDirectory()
 
 assertThat(classesDir).isDirectory()
 
-expectedGeneratedFiles.forEach {
-  assertThat(generatedSourcesDir.resolve("${it}.java"))
+expectedProtoGeneratedFiles.forEach {
+  assertThat(protoGeneratedSourcesDir.resolve("${it}.java"))
       .exists()
       .isNotEmptyFile()
   assertThat(classesDir.resolve("${it}.class"))
       .exists()
       .isNotEmptyFile()
+}
 
+expectedGrpcGeneratedFiles.forEach {
+  assertThat(grpcGeneratedSourcesDir.resolve("${it}.java"))
+      .exists()
+      .isNotEmptyFile()
+  assertThat(classesDir.resolve("${it}.class"))
+      .exists()
+      .isNotEmptyFile()
+}
+
+expectedReactorGeneratedFiles.forEach {
+  assertThat(reactorGeneratedSourcesDir.resolve("${it}.java"))
+      .exists()
+      .isNotEmptyFile()
+  assertThat(classesDir.resolve("${it}.class"))
+      .exists()
+      .isNotEmptyFile()
 }

--- a/protobuf-maven-plugin/src/it/reactor-grpc-jvm-plugin/test.groovy
+++ b/protobuf-maven-plugin/src/it/reactor-grpc-jvm-plugin/test.groovy
@@ -24,6 +24,8 @@ List<String> expectedGeneratedFiles = [
     "org/example/helloworld/Helloworld",
     "org/example/helloworld/GreetingRequest",
     "org/example/helloworld/GreetingRequestOrBuilder",
+    "org/example/helloworld/GreetingServiceGrpc",
+    "org/example/helloworld/ReactorGreetingServiceGrpc",
 ]
 
 assertThat(generatedSourcesDir).isDirectory()

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generation/ProtobufBuildOrchestrator.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generation/ProtobufBuildOrchestrator.java
@@ -338,7 +338,6 @@ public final class ProtobufBuildOrchestrator {
     resolvedPlugins.stream()
         .map(plugin -> ImmutablePluginProtocTarget.builder()
             .plugin(plugin)
-            .outputPath(request.getOutputDirectory())
             .build())
         .forEach(targets::add);
 

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generation/ProtobufBuildOrchestrator.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generation/ProtobufBuildOrchestrator.java
@@ -15,6 +15,8 @@
  */
 package io.github.ascopes.protobufmavenplugin.generation;
 
+import static java.util.function.Function.identity;
+
 import io.github.ascopes.protobufmavenplugin.fs.FileUtils;
 import io.github.ascopes.protobufmavenplugin.plugins.ProjectPluginResolver;
 import io.github.ascopes.protobufmavenplugin.plugins.ResolvedProtocPlugin;
@@ -38,8 +40,10 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.TreeSet;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.inject.Inject;
@@ -120,11 +124,11 @@ public final class ProtobufBuildOrchestrator {
       return handleMissingTargets(request);
     }
 
-    createOutputDirectories(request);
+    createOutputDirectories(request, resolvedPlugins);
 
     // GH-438: We now register the source roots before generating anything. This ensures we still
     // call Javac with the sources even if we incrementally compile with zero changes.
-    registerSourceRoots(request);
+    registerSourceRoots(request, resolvedPlugins);
 
     // Determine the sources we need to regenerate. This will be all the sources usually but
     // if incremental compilation is enabled then we will only output the files that have changed
@@ -203,46 +207,54 @@ public final class ProtobufBuildOrchestrator {
         .orElseThrow(() -> new ResolutionException("Protoc binary was not found"));
   }
 
-  private void createOutputDirectories(GenerationRequest request) throws IOException {
-    var directory = request.getOutputDirectory();
-    log.debug("Creating {}", directory);
+  private void createOutputDirectories(
+      GenerationRequest request,
+      Collection<ResolvedProtocPlugin> resolvedProtocPlugins
+  ) throws IOException {
+    var outputDirectories = Stream
+        .of(
+            // Project output directory.
+            Stream.of(request.getOutputDirectory()),
+            // Output descriptor file location, if non-null.
+            Optional.ofNullable(request.getOutputDescriptorFile())
+                .map(p -> p.toAbsolutePath().getParent())
+                .stream(),
+            // Custom output directories for plugins, if overriding the project defaults.
+            resolvedProtocPlugins.stream()
+                .map(ResolvedProtocPlugin::getOutputDirectory)
+                .filter(Objects::nonNull)
+        )
+        .flatMap(identity())
+        .collect(Collectors.toUnmodifiableList());
 
-    // Having .jar on the output directory makes protoc generate a JAR with a
-    // Manifest. This will break our logic because generated sources will be
-    // inaccessible for the compilation phase later. For now, just prevent this
-    // edge case entirely.
-    FileUtils.getFileExtension(directory)
-        .filter(".jar"::equalsIgnoreCase)
-        .ifPresent(ext -> {
-          throw new IllegalArgumentException(
-              "The output directory '" + directory
-                  + "' cannot be a path with a JAR file extension, due to "
-                  + "limitations with how protoc operates on file names."
-          );
-        });
-
-    Files.createDirectories(directory);
-
-    Optional.ofNullable(request.getOutputDescriptorFile())
-        .map(p -> p.toAbsolutePath().getParent())
-        .ifPresent(p -> {
-          try {
-            Files.createDirectories(p);
-          } catch (IOException e) {
-            throw new IllegalStateException(
-                "Failed to create output directory for descriptor file '"
-                    + p + "'", e);
-          }
-        });
+    for (var outputDirectory : outputDirectories) {
+      log.debug("Creating {}", outputDirectory);
+      Files.createDirectories(outputDirectory);
+    }
   }
 
-  private void registerSourceRoots(GenerationRequest request) {
-    if (request.isRegisterAsCompilationRoot()) {
-      request.getSourceRootRegistrar().registerSourceRoot(
-          mavenSession,
-          request.getOutputDirectory()
-      );
-    }
+  private void registerSourceRoots(
+      GenerationRequest request,
+      Collection<ResolvedProtocPlugin> resolvedProtocPlugins
+  ) {
+    var registrar = request.getSourceRootRegistrar();
+    Stream
+        .of(
+            // Project output directory, if we allow registration of compilation roots.
+            Stream.of(request.getOutputDirectory())
+                .filter(dir -> request.isRegisterAsCompilationRoot()),
+
+            // Custom output directories for plugins, if we explicitly allow them to be used as
+            // compilation roots, or if we do not override the behaviour and the project default is
+            // to use them as compilation roots anyway.
+            resolvedProtocPlugins.stream()
+                .filter(plugin -> plugin.getRegisterAsCompilationRoot()
+                    .orElseGet(request::isRegisterAsCompilationRoot))
+                .map(ResolvedProtocPlugin::getOutputDirectory)
+                .filter(Objects::nonNull)
+        )
+        .flatMap(identity())
+        .forEach(outputDirectory -> registrar.registerSourceRoot(mavenSession, outputDirectory));
   }
 
   // TODO: migrate this logic to a compilation strategy.

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/AbstractGenerateMojo.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/AbstractGenerateMojo.java
@@ -133,6 +133,9 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    *   <li>{@code skip} - set to {@code true} to skip invoking this plugin -
    *       useful if you want to control whether the plugin runs via a
    *       property - optional.</li>
+   *   <li>{@code outputDirectory} - where to write the generated outputs to.
+           - if unspecified, then the {@link #outputDirectory} on the Maven
+           plugin is used instead - optional.</li>
    * </ul>
    *
    * @since 0.3.0
@@ -169,6 +172,9 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    *   <li>{@code skip} - set to {@code true} to skip invoking this plugin -
    *       useful if you want to control whether the plugin runs via a
    *       property - optional.</li>
+   *   <li>{@code outputDirectory} - where to write the generated outputs to.
+           - if unspecified, then the {@link #outputDirectory} on the Maven
+           plugin is used instead - optional.</li>
    * </ul>
    *
    * <p>On Linux, macOS, and other POSIX-like systems, resolution looks for an executable
@@ -234,6 +240,9 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    *   <li>{@code skip} - set to {@code true} to skip invoking this plugin -
    *       useful if you want to control whether the plugin runs via a
    *       property - optional.</li>
+   *   <li>{@code outputDirectory} - where to write the generated outputs to.
+           - if unspecified, then the {@link #outputDirectory} on the Maven
+           plugin is used instead - optional.</li>
    * </ul>
    *
    * @since 2.0.0
@@ -535,6 +544,9 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    *   <li>{@code skip} - set to {@code true} to skip invoking this plugin -
    *       useful if you want to control whether the plugin runs via a
    *       property - optional.</li>
+   *   <li>{@code outputDirectory} - where to write the generated outputs to.
+           - if unspecified, then the {@link #outputDirectory} on the Maven
+           plugin is used instead - optional.</li>
    *   <li>{@code mainClass} - if the plugin is not an assembled JAR at the time
    *       the {@code protobuf-maven-plugin} is run, then you will need to provide
    *       the fully qualified class name of the plugin entrypoint here. This is

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/AbstractGenerateMojo.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/AbstractGenerateMojo.java
@@ -134,8 +134,15 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    *       useful if you want to control whether the plugin runs via a
    *       property - optional.</li>
    *   <li>{@code outputDirectory} - where to write the generated outputs to.
-           - if unspecified, then the {@link #outputDirectory} on the Maven
-           plugin is used instead - optional.</li>
+   *       - if unspecified, then the {@link #outputDirectory} on the Maven
+   *       plugin is used instead - optional.</li>
+   *   <li>{@code registerAsCompilationRoot} - whether to register the output
+   *       directory as a source directory for later compilation steps. If
+   *       unspecified/null, then {@link #registerAsCompilationRoot} is used.
+   *       If the {@code outputDirectory} is not overridden, this setting has
+   *       no effect, and the project-wide setting is used. If explicitly
+   *       specified, then the project setting is ignored in favour of this
+   *       value instead.</li>
    * </ul>
    *
    * @since 0.3.0
@@ -173,8 +180,15 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    *       useful if you want to control whether the plugin runs via a
    *       property - optional.</li>
    *   <li>{@code outputDirectory} - where to write the generated outputs to.
-           - if unspecified, then the {@link #outputDirectory} on the Maven
-           plugin is used instead - optional.</li>
+   *       - if unspecified, then the {@link #outputDirectory} on the Maven
+   *       plugin is used instead - optional.</li>
+   *   <li>{@code registerAsCompilationRoot} - whether to register the output
+   *       directory as a source directory for later compilation steps. If
+   *       unspecified/null, then {@link #registerAsCompilationRoot} is used.
+   *       If the {@code outputDirectory} is not overridden, this setting has
+   *       no effect, and the project-wide setting is used. If explicitly
+   *       specified, then the project setting is ignored in favour of this
+   *       value instead.</li>
    * </ul>
    *
    * <p>On Linux, macOS, and other POSIX-like systems, resolution looks for an executable
@@ -241,8 +255,15 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    *       useful if you want to control whether the plugin runs via a
    *       property - optional.</li>
    *   <li>{@code outputDirectory} - where to write the generated outputs to.
-           - if unspecified, then the {@link #outputDirectory} on the Maven
-           plugin is used instead - optional.</li>
+   *       - if unspecified, then the {@link #outputDirectory} on the Maven
+   *       plugin is used instead - optional.</li>
+   *   <li>{@code registerAsCompilationRoot} - whether to register the output
+   *       directory as a source directory for later compilation steps. If
+   *       unspecified/null, then {@link #registerAsCompilationRoot} is used.
+   *       If the {@code outputDirectory} is not overridden, this setting has
+   *       no effect, and the project-wide setting is used. If explicitly
+   *       specified, then the project setting is ignored in favour of this
+   *       value instead.</li>
    * </ul>
    *
    * @since 2.0.0
@@ -545,8 +566,15 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    *       useful if you want to control whether the plugin runs via a
    *       property - optional.</li>
    *   <li>{@code outputDirectory} - where to write the generated outputs to.
-           - if unspecified, then the {@link #outputDirectory} on the Maven
-           plugin is used instead - optional.</li>
+   *       - if unspecified, then the {@link #outputDirectory} on the Maven
+   *       plugin is used instead - optional.</li>
+   *   <li>{@code registerAsCompilationRoot} - whether to register the output
+   *       directory as a source directory for later compilation steps. If
+   *       unspecified/null, then {@link #registerAsCompilationRoot} is used.
+   *       If the {@code outputDirectory} is not overridden, this setting has
+   *       no effect, and the project-wide setting is used. If explicitly
+   *       specified, then the project setting is ignored in favour of this
+   *       value instead.</li>
    *   <li>{@code mainClass} - if the plugin is not an assembled JAR at the time
    *       the {@code protobuf-maven-plugin} is run, then you will need to provide
    *       the fully qualified class name of the plugin entrypoint here. This is

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/ProjectPluginResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/ProjectPluginResolver.java
@@ -61,11 +61,25 @@ public final class ProjectPluginResolver {
   public Collection<ResolvedProtocPlugin> resolveProjectPlugins(
       GenerationRequest request
   ) throws ResolutionException {
+    // XXX: we could run this in parallel
     var plugins = new ArrayList<ResolvedProtocPlugin>();
-    plugins.addAll(binaryPluginResolver.resolveMavenPlugins(request.getBinaryMavenPlugins()));
-    plugins.addAll(binaryPluginResolver.resolvePathPlugins(request.getBinaryPathPlugins()));
-    plugins.addAll(binaryPluginResolver.resolveUrlPlugins(request.getBinaryUrlPlugins()));
-    plugins.addAll(jvmPluginResolver.resolveMavenPlugins(request.getJvmMavenPlugins()));
+    plugins.addAll(binaryPluginResolver.resolveMavenPlugins(
+        request.getBinaryMavenPlugins(),
+        request.getOutputDirectory()
+    ));
+    plugins.addAll(binaryPluginResolver.resolvePathPlugins(
+        request.getBinaryPathPlugins(),
+        request.getOutputDirectory()
+    ));
+    plugins.addAll(binaryPluginResolver.resolveUrlPlugins(
+        request.getBinaryUrlPlugins(),
+        request.getOutputDirectory()
+    ));
+    plugins.addAll(jvmPluginResolver.resolveMavenPlugins(
+        request.getJvmMavenPlugins(),
+        request.getOutputDirectory()
+    ));
+    plugins.trimToSize();
     return Collections.unmodifiableList(plugins);
   }
 }

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/ProtocPlugin.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/ProtocPlugin.java
@@ -15,6 +15,7 @@
  */
 package io.github.ascopes.protobufmavenplugin.plugins;
 
+import java.nio.file.Path;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -28,7 +29,13 @@ import org.jspecify.annotations.Nullable;
  */
 public interface ProtocPlugin {
 
-  @Nullable String getOptions();
+  default @Nullable String getOptions() {
+    return null;
+  }
+
+  default @Nullable Path getOutputDirectory() {
+    return null;
+  }
 
   default int getOrder() {
     return 0;

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/ProtocPlugin.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/ProtocPlugin.java
@@ -37,6 +37,10 @@ public interface ProtocPlugin {
     return null;
   }
 
+  default @Nullable Boolean isRegisterAsCompilationRoot() {
+    return null;
+  }
+
   default int getOrder() {
     return 0;
   }

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/ResolvedProtocPlugin.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/ResolvedProtocPlugin.java
@@ -29,11 +29,13 @@ import org.immutables.value.Value.Immutable;
 @Immutable
 public interface ResolvedProtocPlugin {
 
-  Path getPath();
-
   String getId();
 
   Optional<String> getOptions();
 
   int getOrder();
+
+  Path getOutputDirectory();
+
+  Path getPath();
 }

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/protoc/ProtocExecutor.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/protoc/ProtocExecutor.java
@@ -130,7 +130,7 @@ public final class ProtocExecutor {
     var plugin = target.getPlugin();
     builder
         .add("--plugin=protoc-gen-" + plugin.getId() + "=" + plugin.getPath())
-        .add("--" + plugin.getId() + "_out=" + target.getOutputPath());
+        .add("--" + plugin.getId() + "_out=" + plugin.getOutputDirectory());
     plugin.getOptions()
         .map(options -> "--" + plugin.getId() + "_opt=" + options)
         .ifPresent(builder::add);

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/protoc/targets/PluginProtocTarget.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/protoc/targets/PluginProtocTarget.java
@@ -30,8 +30,6 @@ import org.immutables.value.Value.Immutable;
 public interface PluginProtocTarget extends ProtocTarget {
   ResolvedProtocPlugin getPlugin();
 
-  Path getOutputPath();
-
   @Derived
   @Override
   default int getOrder() {

--- a/protobuf-maven-plugin/src/site/markdown/using-protoc-plugins.md
+++ b/protobuf-maven-plugin/src/site/markdown/using-protoc-plugins.md
@@ -10,6 +10,9 @@ covered by the protoc executable, you can add custom plugins to your build.
 Each plugin is defined as an XML object with various attributes. Many depend on the type of plugin
 you are adding (see the sections below), but all plugins share some common attributes:
 
+- `outputDirectory` - directory to write generated code to. The default is for this to be
+  unspecified, which will result in the output directory specified on the Maven plugin to be used
+  instead.
 - `options` - a string value that can be passed to the plugin as a parameter. Defaults to being
   unspecified.
 - `order` - an integer that controls the plugin execution order relative to other plugins.

--- a/protobuf-maven-plugin/src/site/markdown/using-protoc-plugins.md
+++ b/protobuf-maven-plugin/src/site/markdown/using-protoc-plugins.md
@@ -13,12 +13,16 @@ you are adding (see the sections below), but all plugins share some common attri
 - `outputDirectory` - directory to write generated code to. The default is for this to be
   unspecified, which will result in the output directory specified on the Maven plugin to be used
   instead.
+- `registerAsCompilationRoot` - overrides the project-global setting for registering output
+  code directories as compilation roots for future compiler steps in the Maven build. If 
+  unspecified/null, the project global setting will be used. Otherwise, the explicitly provided
+  value will be used instead.
 - `options` - a string value that can be passed to the plugin as a parameter. Defaults to being
   unspecified.
 - `order` - an integer that controls the plugin execution order relative to other plugins.
   Smaller numbers make plugins run before those with larger numbers. Defaults to `100000`, meaning
   you can place plugins before or after those that do not define an order if you wish.
-- `skip` - a boolean that, when true, skips the execution of the plugin entierly. Defaults to
+- `skip` - a boolean that, when true, skips the execution of the plugin entirely. Defaults to
   `false`.
 
 ## Binary plugins

--- a/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/plugins/ProjectPluginResolverTest.java
+++ b/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/plugins/ProjectPluginResolverTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2023 - 2025, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.ascopes.protobufmavenplugin.plugins;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import io.github.ascopes.protobufmavenplugin.generation.GenerationRequest;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@DisplayName("ProjectPluginResolver tests")
+@ExtendWith(MockitoExtension.class)
+class ProjectPluginResolverTest {
+
+  @Mock
+  BinaryPluginResolver binaryPluginResolver;
+
+  @Mock
+  JvmPluginResolver jvmPluginResolver;
+
+  @InjectMocks
+  ProjectPluginResolver projectPluginResolver;
+
+  @DisplayName(".resolveProjectPlugins(...) delegates to the internal plugin resolvers")
+  @Test
+  void resolveProjectPluginsDelegatesToTheInternalPluginResolvers() throws Exception {
+    // Given
+    var resolvedBinaryMavenPlugins = List.<ResolvedProtocPlugin>of(mock(), mock(), mock());
+    when(binaryPluginResolver.resolveMavenPlugins(any(), any()))
+        .thenReturn(resolvedBinaryMavenPlugins);
+
+    var resolvedBinaryPathPlugins = List.<ResolvedProtocPlugin>of(mock(), mock());
+    when(binaryPluginResolver.resolvePathPlugins(any(), any()))
+        .thenReturn(resolvedBinaryPathPlugins);
+
+    var resolvedBinaryUrlPlugins = List.<ResolvedProtocPlugin>of(mock(), mock());
+    when(binaryPluginResolver.resolveUrlPlugins(any(), any()))
+        .thenReturn(resolvedBinaryUrlPlugins);
+
+    var resolvedJvmMavenPlugins = List.<ResolvedProtocPlugin>of(mock(), mock(), mock());
+    when(jvmPluginResolver.resolveMavenPlugins(any(), any()))
+        .thenReturn(resolvedJvmMavenPlugins);
+
+    var expectedResult = Stream
+        .of(
+            resolvedBinaryMavenPlugins,
+            resolvedBinaryPathPlugins,
+            resolvedBinaryUrlPlugins,
+            resolvedJvmMavenPlugins
+        )
+        .flatMap(Collection::stream)
+        .collect(Collectors.toUnmodifiableList());
+
+    var binaryMavenPlugins = List.<MavenProtocPlugin>of(mock(), mock(), mock());
+    var binaryPathPlugins = List.<PathProtocPlugin>of(mock(), mock());
+    var binaryUrlPlugins = List.<UriProtocPlugin>of(mock(), mock());
+    var jvmMavenPlugins = List.<MavenProtocPlugin>of(mock(), mock(), mock());
+    var outputDirectory = mock(Path.class);
+
+    var generationRequest = mock(GenerationRequest.class);
+
+    // Use .thenAnswer to work around generic wildcards.
+    when(generationRequest.getBinaryMavenPlugins())
+        .thenAnswer(ctx -> binaryMavenPlugins);
+    when(generationRequest.getBinaryPathPlugins())
+        .thenAnswer(ctx -> binaryPathPlugins);
+    when(generationRequest.getBinaryUrlPlugins())
+        .thenAnswer(ctx -> binaryUrlPlugins);
+    when(generationRequest.getJvmMavenPlugins())
+        .thenAnswer(ctx -> jvmMavenPlugins);
+    when(generationRequest.getOutputDirectory())
+        .thenAnswer(ctx -> outputDirectory);
+
+    // When
+    var actualResult = projectPluginResolver.resolveProjectPlugins(generationRequest);
+
+    // Then
+    assertThat(actualResult)
+        .containsExactlyInAnyOrderElementsOf(expectedResult);
+
+    verify(binaryPluginResolver)
+        .resolveMavenPlugins(binaryMavenPlugins, outputDirectory);
+    verify(binaryPluginResolver)
+        .resolvePathPlugins(binaryPathPlugins, outputDirectory);
+    verify(binaryPluginResolver)
+        .resolveUrlPlugins(binaryUrlPlugins, outputDirectory);
+    verify(jvmPluginResolver)
+        .resolveMavenPlugins(jvmMavenPlugins, outputDirectory);
+
+    verifyNoMoreInteractions(binaryPluginResolver, jvmPluginResolver);
+  }
+}

--- a/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/plugins/ProtocPluginTest.java
+++ b/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/plugins/ProtocPluginTest.java
@@ -25,6 +25,28 @@ import org.junit.jupiter.api.Test;
 @DisplayName("ProtocPlugin tests")
 class ProtocPluginTest {
 
+  @DisplayName("the default value for getOptions is the expected value")
+  @Test
+  void theDefaultValueForGetOptionsIsTheExpectedValue() {
+    // Given
+    var obj = mock(ProtocPlugin.class);
+    when(obj.getOptions()).thenCallRealMethod();
+
+    // Then
+    assertThat(obj.getOptions()).isNull();
+  }
+
+  @DisplayName("the default value for getOutputDirectory is the expected value")
+  @Test
+  void theDefaultValueForGetOutputDirectoryIsTheExpectedValue() {
+    // Given
+    var obj = mock(ProtocPlugin.class);
+    when(obj.getOutputDirectory()).thenCallRealMethod();
+
+    // Then
+    assertThat(obj.getOutputDirectory()).isNull();
+  }
+
   @DisplayName("the default value for isSkip is the expected value")
   @Test
   void theDefaultValueForIsSkipIsTheExpectedValue() {
@@ -34,5 +56,16 @@ class ProtocPluginTest {
 
     // Then
     assertThat(obj.isSkip()).isFalse();
+  }
+
+  @DisplayName("the default value for getOrder is the expected value")
+  @Test
+  void theDefaultValueForGetOrderIsTheExpectedValue() {
+    // Given
+    var obj = mock(ProtocPlugin.class);
+    when(obj.getOrder()).thenCallRealMethod();
+
+    // Then
+    assertThat(obj.getOrder()).isZero();
   }
 }

--- a/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/protoc/targets/PluginProtocTargetTest.java
+++ b/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/protoc/targets/PluginProtocTargetTest.java
@@ -21,7 +21,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.github.ascopes.protobufmavenplugin.plugins.ResolvedProtocPlugin;
-import java.nio.file.Path;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -37,7 +36,6 @@ class PluginProtocTargetTest {
 
     var target = ImmutablePluginProtocTarget.builder()
         .plugin(plugin)
-        .outputPath(Path.of("i", "am", "potato"))
         .build();
 
     // Then


### PR DESCRIPTION
Users can now target specific paths for specific plugins in the same execution by overriding the overall output directory with one that is set per plugin.

Remaining work:

- Integration tests