### PR TITLE
Correctly buffer input/output streams for files

### DIFF
--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/fs/FileUtils.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/fs/FileUtils.java
@@ -15,10 +15,15 @@
  */
 package io.github.ascopes.protobufmavenplugin.fs;
 
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystemNotFoundException;
 import java.nio.file.Files;
+import java.nio.file.OpenOption;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.PosixFilePermission;
@@ -145,5 +150,19 @@ public final class FileUtils {
     }
 
     return Collections.unmodifiableList(newPaths);
+  }
+
+  public static InputStream newBufferedInputStream(
+      Path path,
+      OpenOption... options
+  ) throws IOException {
+    return new BufferedInputStream(Files.newInputStream(path, options));
+  }
+
+  public static OutputStream newBufferedOutputStream(
+      Path path,
+      OpenOption... options
+  ) throws IOException {
+    return new BufferedOutputStream(Files.newOutputStream(path, options));
   }
 }

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/JvmPluginResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/JvmPluginResolver.java
@@ -258,9 +258,10 @@ final class JvmPluginResolver {
   ) throws ResolutionException {
     try (
         var zip = FileUtils.openZipAsFileSystem(pluginPath);
-        var manifestStream = Files.newInputStream(zip.getPath("META-INF", "MANIFEST.MF"))
+        var manifestInputStream = FileUtils.newBufferedInputStream(
+            zip.getPath("META-INF", "MANIFEST.MF"))
     ) {
-      return new Manifest(manifestStream)
+      return new Manifest(manifestInputStream)
           .getMainAttributes()
           .getValue("Main-Class");
     } catch (IOException ex) {

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/sources/ProtoSourceResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/sources/ProtoSourceResolver.java
@@ -98,7 +98,7 @@ final class ProtoSourceResolver {
       return Optional.empty();
     }
 
-    try (var inputStream = Files.newInputStream(descriptorFilePath)) {
+    try (var inputStream = FileUtils.newBufferedInputStream(descriptorFilePath)) {
       return FileDescriptorSet.parseFrom(inputStream)
           .getFileList()
           .stream()

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/sources/incremental/IncrementalCacheManager.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/sources/incremental/IncrementalCacheManager.java
@@ -15,6 +15,7 @@
  */
 package io.github.ascopes.protobufmavenplugin.sources.incremental;
 
+import io.github.ascopes.protobufmavenplugin.fs.FileUtils;
 import io.github.ascopes.protobufmavenplugin.fs.TemporarySpace;
 import io.github.ascopes.protobufmavenplugin.sources.DescriptorListing;
 import io.github.ascopes.protobufmavenplugin.sources.FilesToCompile;
@@ -198,7 +199,7 @@ public final class IncrementalCacheManager {
   private FutureTask<Map.Entry<Path, String>> generateFileDigest(Path file) {
     return concurrentExecutor.submit(() -> {
       log.trace("Generating digest for {}", file);
-      try (var inputStream = Files.newInputStream(file)) {
+      try (var inputStream = FileUtils.newBufferedInputStream(file)) {
         var digest = Digests.sha512ForStream(inputStream);
         return Map.entry(file, digest);
       }

--- a/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/fs/FileUtilsTest.java
+++ b/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/fs/FileUtilsTest.java
@@ -20,6 +20,10 @@ import static org.assertj.core.api.Assertions.assertThatException;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
 import io.github.ascopes.protobufmavenplugin.fixtures.TestFileSystem;
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -251,5 +255,43 @@ class FileUtilsTest {
               newDir2.resolve("ccc.txt")
           );
     }
+  }
+
+  @DisplayName(".newBufferedInputStream(Path, OpenOption... reads a file with a buffer")
+  @Test
+  void newBufferedInputStreamReadsFileWithBuffer(@TempDir Path dir) throws IOException {
+    // Given
+    var file = dir.resolve("file.txt");
+    Files.writeString(file, "Hello, World!");
+
+    // When
+    var os = new ByteArrayOutputStream();
+    try (var is = FileUtils.newBufferedInputStream(file)) {
+      assertThat(is).isInstanceOf(BufferedInputStream.class);
+      is.transferTo(os);
+    }
+
+    // Then
+    assertThat(os).asString().isEqualTo("Hello, World!");
+  }
+
+  @DisplayName(".newBufferedOutputStream(Path, OpenOption... writes a file with a buffer")
+  @Test
+  void newBufferedOutputStreamWritesFileWithBuffer(@TempDir Path dir) throws IOException {
+    // Given
+    var file = dir.resolve("file.txt");
+
+    // When
+    var is = new ByteArrayInputStream("Hello, World!".getBytes());
+    try (var os = FileUtils.newBufferedOutputStream(file)) {
+      assertThat(os).isInstanceOf(BufferedOutputStream.class);
+      is.transferTo(os);
+    }
+
+    // Then
+    assertThat(file)
+        .isRegularFile()
+        .content()
+        .isEqualTo("Hello, World!");
   }
 }


### PR DESCRIPTION
This will provide a slight performance improvement on very large input/output files that are being analysed by the build process.