### PR TITLE
GH-700: Windows 11 ARM plugin compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,10 +78,10 @@ jobs:
             java-version: 11
             maven-version: "${{ needs.validate.outputs.default_maven_version }}"
 
-          #- title: Windows arm64 - jdk21
-          #  os-name: windows-11-arm
-          #  java-version: 21  # This is the earliest-supported version on Windows ARM
-          #  maven-version: "${{ needs.validate.outputs.default_maven_version }}"
+          - title: Windows arm64 - jdk21
+            os-name: windows-11-arm
+            java-version: 21  # This is the earliest-supported version on Windows ARM
+            maven-version: "${{ needs.validate.outputs.default_maven_version }}"
 
           - title: Linux arm64 - jdk11
             os-name: ubuntu-24.04-arm

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/PlatformClassifierFactory.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/PlatformClassifierFactory.java
@@ -54,7 +54,16 @@ public final class PlatformClassifierFactory {
       "amd64", "windows-x86_64",
       "x86", "windows-x86_32",
       "x86_32", "windows-x86_32",
-      "x86_64", "windows-x86_64"
+      "x86_64", "windows-x86_64",
+      // Protoc's developers have no plans to support an ARM release of
+      // protoc. The Prism emulator is included in Windows 10 and Windows
+      // 11 to execute x86 binaries on the ARM instruction set.
+      // Reportedly, Windows 10 only supports 32-bit ARM emulation, whereas
+      // Windows 11 supports both.
+      // At this time, we pin to the 64 bit version since Windows 10 is
+      // near EOL at the time of writing, and more support in protoc
+      // plugins will be available by vendors for 64 bit releases.
+      "aarch64", "windows-x86_64"
   );
 
   private static final Map<String, String> FALLBACK_MAPPING = Map.of();

--- a/protobuf-maven-plugin/src/site/markdown/requirements.md
+++ b/protobuf-maven-plugin/src/site/markdown/requirements.md
@@ -54,6 +54,7 @@ architectures and operating systems. These are listed below:
         <ul>
           <li>amd64 (x86_64)</li>
           <li>x86 (x86_32)</li>
+          <li>aarch64</li>
         </ul>
       </td>
       <td>
@@ -77,16 +78,15 @@ Refer to the `protocVersion` parameter documentation on the
 
 ### Windows on ARM
 
-As of right now, no official binaries for `aarch64` Windows systems are provided.
-You may be able to use x86 emulation to get this to work. To do this, refer to
-the Microsoft ARM emulation documentation.
+As of right now, no official binaries for `aarch64` Windows systems are provided,
+and there has been no sign of plans at the time of writing to support this from
+Google.
 
-Pass the `-Dos.arch=x86_64 -Dos.name=Windows` flag to Maven to force the use of the
-amd64 binary for Windows.
+Windows 11 ARM releases support x86 emulation via the Prism emulator.
 
-Alternatively, you can build `protoc` yourself. Refer to the `protobufCompiler` 
-parameter documentation on the [goals page](plugin-info.html) for how you can override
-the binary being used.
+To enable users to build on Windows ARM machines, this plugin will always download the
+x86_64 release of `protoc` and any corresponding plugins, with the assumption that
+emulation will work successfully.
 
 ### BSDs, Linux on unsupported CPUs, MINIX, Solaris, etc
 

--- a/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/dependencies/PlatformClassifierFactoryTest.java
+++ b/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/dependencies/PlatformClassifierFactoryTest.java
@@ -95,7 +95,8 @@ class PlatformClassifierFactoryTest {
         arguments(windows().and(arch("amd64")), "windows-x86_64"),
         arguments(windows().and(arch("x86_64")), "windows-x86_64"),
         arguments(windows().and(arch("x86")), "windows-x86_32"),
-        arguments(windows().and(arch("x86_32")), "windows-x86_32")
+        arguments(windows().and(arch("x86_32")), "windows-x86_32"),
+        arguments(windows().and(arch("aarch64")), "windows-x86_64")
     );
   }
 

--- a/scripts/install-protoc-to-github-runner.sh
+++ b/scripts/install-protoc-to-github-runner.sh
@@ -10,7 +10,7 @@ set -o errexit
 set -o nounset
 [[ -n ${DEBUG+defined} ]] && set -o xtrace
 
-readonly version=4.30.1
+readonly version=4.31.1
 
 case "$(uname)" in
   Linux)


### PR DESCRIPTION
Force Windows 11 ARM builds to use the x86_64 release of protoc and related plugins to enable interop via Prism emulation.

This enables Windows 11 ARM to use this plugin out of the box.

Fixes GH-700.