### PR TITLE
Use BOM for immutables

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -219,8 +219,10 @@
 
       <dependency>
         <groupId>org.immutables</groupId>
-        <artifactId>value</artifactId>
+        <artifactId>bom</artifactId>
         <version>${immutables.version}</version>
+        <scope>import</scope>
+        <type>pom</type>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Use the Immutables BOM for `dependencyManagement` so that other immutables features can be included in the future as needed.