### PR TITLE
Build on Maven 4 by default, test against Maven 3.9 in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,14 +68,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - title: macOS arm64, mvn ${{ needs.validate.outputs.default_maven_version }}, jdk11
+          - title: macOS arm64, mvn ${{ needs.validate.outputs.default_maven_version }}, jdk17
             os-name: macos-15
-            java-version: 11
+            java-version: 17
             maven-version: "${{ needs.validate.outputs.default_maven_version }}"
 
-          - title: Windows amd64, mvn ${{ needs.validate.outputs.default_maven_version }}, jdk11
+          - title: Windows amd64, mvn ${{ needs.validate.outputs.default_maven_version }}, jdk17
             os-name: windows-2025
-            java-version: 11
+            java-version: 17
             maven-version: "${{ needs.validate.outputs.default_maven_version }}"
 
           - title: Windows arm64, mvn ${{ needs.validate.outputs.default_maven_version }}, jdk21
@@ -83,14 +83,9 @@ jobs:
             java-version: 21  # This is the earliest-supported version on Windows ARM
             maven-version: "${{ needs.validate.outputs.default_maven_version }}"
 
-          - title: Linux arm64, mvn ${{ needs.validate.outputs.default_maven_version }}, jdk11
+          - title: Linux arm64, mvn ${{ needs.validate.outputs.default_maven_version }}, jdk17
             os-name: ubuntu-24.04-arm
-            java-version: 11
-            maven-version: "${{ needs.validate.outputs.default_maven_version }}"
-
-          - title: Linux amd64, mvn ${{ needs.validate.outputs.default_maven_version }}, jdk11
-            os-name: ubuntu-24.04
-            java-version: 11
+            java-version: 17
             maven-version: "${{ needs.validate.outputs.default_maven_version }}"
 
           - title: Linux amd64, mvn ${{ needs.validate.outputs.default_maven_version }}, jdk17
@@ -113,10 +108,10 @@ jobs:
             java-version: 11
             maven-version: 3.8.8
 
-          - title: Linux amd64, mvn 4, jdk17
+          - title: Linux amd64, mvn 3.9.10, jdk11
             os-name: ubuntu-24.04
-            java-version: 17
-            maven-version: 4.0.0-rc-4
+            java-version: 11
+            maven-version: 3.9.10
 
     steps:
       - name: Checkout repository
@@ -159,6 +154,7 @@ jobs:
             **/build.log
             **/maven-status/**
             **/surefire-reports/**.txt
+            **/invoker-reports/**.txt
           compression-level: 9
           retention-days: 7
           include-hidden-files: true

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -16,4 +16,4 @@
 # under the License.
 wrapperVersion=3.3.2
 distributionType=only-script
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.10/apache-maven-3.9.10-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/4.0.0-rc-4/apache-maven-4.0.0-rc-4-bin.zip


### PR DESCRIPTION
Changes the Maven version in the repository from 3.9.10 to 4.0.0-rc-4 so that local builds will default to using Maven 4.

We retain testing on Maven 3.9 and 3.8 within CI.

This improves testing for Maven 4.0 compatibility as we get closer to the release date.