### PR TITLE
Replace hardcoded digest aliases with dynamic equivalence

### DIFF
--- a/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/digests/DigestPlexusConverterTest.java
+++ b/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/digests/DigestPlexusConverterTest.java
@@ -223,7 +223,7 @@ class DigestPlexusConverterTest {
         ))
         .withMessage(
             "Failed to parse digest 'sha-69420:1a2b3c4d5e': "
-                + "%s: Digest 'SHA-69420' is not supported by this JVM",
+                + "%s: Digest 'sha-69420' is not supported by this JVM",
             DigestException.class.getName()
         )
         .withCauseInstanceOf(DigestException.class);


### PR DESCRIPTION
Replace the existing hardcoded digest alias mapping that maps variants of strings such as 'sha256' and 'sha-256' back to the JVM supported algorithm name 'SHA-256' with a treemap comparator that compares inputs ignoring case and separators such as '-'.

This allows the list to dynamically support whatever the current JVM allows in the list of supported aliases.