### PR TITLE
Support overriding envvars passed to protoc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>io.github.ascopes</groupId>
   <artifactId>protobuf-maven-plugin-parent</artifactId>
-  <version>3.6.2-SNAPSHOT</version>
+  <version>3.7.0-SNAPSHOT</version>
 
   <name>Protobuf Maven Plugin Parent</name>
   <description>Parent POM for the Protobuf Maven Plugin.</description>

--- a/protobuf-maven-plugin/pom.xml
+++ b/protobuf-maven-plugin/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes</groupId>
     <artifactId>protobuf-maven-plugin-parent</artifactId>
-    <version>3.6.2-SNAPSHOT</version>
+    <version>3.7.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>protobuf-maven-plugin</artifactId>

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generation/GenerationRequest.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generation/GenerationRequest.java
@@ -24,6 +24,7 @@ import io.github.ascopes.protobufmavenplugin.plugins.UriProtocPlugin;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.immutables.value.Value.Immutable;
 import org.jspecify.annotations.Nullable;
@@ -88,6 +89,11 @@ public interface GenerationRequest {
    * @return the collection of glob patterns.
    */
   List<String> getExcludes();
+
+  /**
+   * Additional environment variables to set when calling {@code protoc}.
+   */
+  Map<String, String> getEnvironmentVariables();
 
   /**
    * Additional user-defined Maven dependencies to include in the {@code protoc}

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generation/ProtobufBuildOrchestrator.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generation/ProtobufBuildOrchestrator.java
@@ -387,6 +387,7 @@ public final class ProtobufBuildOrchestrator {
 
     return ImmutableProtocInvocation.builder()
         .descriptorSourceFiles(filesToCompile.getDescriptorFiles())
+        .environmentVariables(request.getEnvironmentVariables())
         .fatalWarnings(request.isFatalWarnings())
         .importPaths(importPaths)
         .inputDescriptorFiles(inputDescriptorFiles)

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/AbstractGenerateMojo.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/AbstractGenerateMojo.java
@@ -35,6 +35,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -340,6 +341,24 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    */
   @Parameter(defaultValue = DEFAULT_FALSE)
   boolean embedSourcesInClassOutputs;
+
+  /**
+   * Additional environment variables to pass to the {@code protoc} subprocess.
+   *
+   * <p>This can be used to override some internal behaviours within {@code protoc} or any
+   * associated {@code protoc} plugins during execution.
+   *
+   * <p>By default, any environment variables made visible to Maven will be passed to
+   * {@code protoc}. Any environment variables specified here will be appended to the default
+   * environment variables, overwriting any that have duplicate names.
+   *
+   * <p>Note that this will not allow overriding aspects like the system path, as those are
+   * resolved statically prior to any invocation.
+   *
+   * @since 3.7.0
+   */
+  @Parameter
+  @Nullable Map<String, String> environmentVariables;
 
   /**
    * Source paths to exclude from compilation.
@@ -1057,6 +1076,7 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
         .dependencyResolutionDepth(dependencyResolutionDepth)
         .dependencyScopes(dependencyScopes())
         .embedSourcesInClassOutputs(embedSourcesInClassOutputs)
+        .environmentVariables(nonNullMap(environmentVariables))
         .enabledLanguages(enabledLanguages)
         .excludes(nonNullList(excludes))
         .failOnInvalidDependencies(failOnInvalidDependencies)
@@ -1158,5 +1178,9 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
 
   private static <T> List<T> nonNullList(@Nullable List<T> list) {
     return requireNonNullElseGet(list, List::of);
+  }
+
+  private static <K, V> Map<K, V>  nonNullMap(@Nullable Map<K, V> map) {
+    return requireNonNullElseGet(map, Map::of);
   }
 }

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/protoc/ProtocExecutor.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/protoc/ProtocExecutor.java
@@ -65,7 +65,9 @@ public final class ProtocExecutor {
     log.debug("Protoc argument file:\n{}", argumentFileBuilder);
 
     var procBuilder = new ProcessBuilder(invocation.getProtocPath().toString(), "@" + argumentFile);
-    procBuilder.environment().putAll(System.getenv());
+    var env = procBuilder.environment();
+    env.putAll(System.getenv());
+    env.putAll(invocation.getEnvironmentVariables());
 
     try {
       return runProcess(procBuilder);

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/protoc/ProtocInvocation.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/protoc/ProtocInvocation.java
@@ -18,6 +18,7 @@ package io.github.ascopes.protobufmavenplugin.protoc;
 import io.github.ascopes.protobufmavenplugin.protoc.targets.ProtocTarget;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 import java.util.SortedSet;
 import org.immutables.value.Value.Immutable;
 
@@ -36,6 +37,9 @@ public interface ProtocInvocation {
 
   // Fail if we get warnings, rather than continuing.
   boolean isFatalWarnings();
+
+  // Environment variables to explicitly set.
+  Map<String, String> getEnvironmentVariables();
 
   // Paths to proto source files on the root file system to compile.
   List<Path> getImportPaths();

--- a/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/mojo/AbstractGenerateMojoTestTemplate.java
+++ b/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/mojo/AbstractGenerateMojoTestTemplate.java
@@ -48,6 +48,7 @@ import java.util.Collection;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.Spliterators.AbstractSpliterator;
@@ -394,6 +395,38 @@ abstract class AbstractGenerateMojoTestTemplate<A extends AbstractGenerateMojo> 
     assertThat(actualRequest.getDependencyScopes())
         .containsExactlyInAnyOrderElementsOf(combination);
   }
+
+  @DisplayName("the environmentVariables are set to the specified value")
+  @Test
+  void environmentVariablesAreSetToTheSpecifiedValue() throws Throwable {
+    mojo.environmentVariables = Map.of("foo", "bar", "baz", "bork");
+
+    // When
+    mojo.execute();
+
+    // Then
+    var captor = ArgumentCaptor.forClass(GenerationRequest.class);
+    verify(mojo.sourceCodeGenerator).generate(captor.capture());
+    var actualRequest = captor.getValue();
+    assertThat(actualRequest.getEnvironmentVariables())
+        .isEqualTo(Map.of("foo", "bar", "baz", "bork"));
+  }
+
+  @DisplayName("the environmentVariables are set to an empty map if unspecified")
+  @Test
+  void environmentVariablesAreSetToAnEmptyMapIfUnspecified() throws Throwable {
+    mojo.environmentVariables = null;
+
+    // When
+    mojo.execute();
+
+    // Then
+    var captor = ArgumentCaptor.forClass(GenerationRequest.class);
+    verify(mojo.sourceCodeGenerator).generate(captor.capture());
+    var actualRequest = captor.getValue();
+    assertThat(actualRequest.getEnvironmentVariables()).isEmpty();
+  }
+
 
   @DisplayName("failOnInvalidDependencies is set to the specified value")
   @ValueSource(booleans = {true, false})


### PR DESCRIPTION
I have observed that the internals of protoc have several magic environment variables dotted around that can be set to influence internal behaviours. Likewise, protoc plugins may wish to use various environment variables as overrides for internal settings.

This change adds support for overriding environment variables that are passed to protoc internally.