### PR TITLE
GH-762: Allow passing additional flags to protoc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>io.github.ascopes</groupId>
   <artifactId>protobuf-maven-plugin-parent</artifactId>
-  <version>3.7.1-SNAPSHOT</version>
+  <version>3.8.0-SNAPSHOT</version>
 
   <name>Protobuf Maven Plugin Parent</name>
   <description>Parent POM for the Protobuf Maven Plugin.</description>

--- a/protobuf-maven-plugin/pom.xml
+++ b/protobuf-maven-plugin/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes</groupId>
     <artifactId>protobuf-maven-plugin-parent</artifactId>
-    <version>3.7.1-SNAPSHOT</version>
+    <version>3.8.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>protobuf-maven-plugin</artifactId>

--- a/protobuf-maven-plugin/src/it/gh-762-additional-args/invoker.properties
+++ b/protobuf-maven-plugin/src/it/gh-762-additional-args/invoker.properties
@@ -1,0 +1,17 @@
+#
+# Copyright (C) 2023 - 2025, Ashley Scopes.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+invoker.goals = clean package

--- a/protobuf-maven-plugin/src/it/gh-762-additional-args/pom.xml
+++ b/protobuf-maven-plugin/src/it/gh-762-additional-args/pom.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2023 - 2025, Ashley Scopes.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>@project.groupId@.it</groupId>
+    <artifactId>integration-test-parent</artifactId>
+    <version>@project.version@</version>
+    <relativePath>../setup/pom.xml</relativePath>
+  </parent>
+
+  <groupId>gh-762-additional-args</groupId>
+  <artifactId>gh-762-additional-args</artifactId>
+
+  <properties>
+    <!-- Frozen to a very old version that still kept optional as experimental.
+         This allows testing the enabling flag. -->
+    <protobuf.version>3.12.4</protobuf.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <scope>compile</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+
+        <configuration>
+          <arguments>
+            <argument>--experimental_allow_proto3_optional</argument>
+          </arguments>
+        </configuration>
+
+        <executions>
+          <execution>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/protobuf-maven-plugin/src/it/gh-762-additional-args/selector.groovy
+++ b/protobuf-maven-plugin/src/it/gh-762-additional-args/selector.groovy
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2023 - 2025, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Only execute on x86 systems, aarch64 ports do not exist for all platforms
+// we use in our CI pipeline for the old version of protoc we use for this
+// test.
+if (!System.getProperty("os.arch").equalsIgnoreCase("amd64")) {
+  println("Skipping this test case as the system is not x86_64")
+  return false
+} else {
+  return true
+}

--- a/protobuf-maven-plugin/src/it/gh-762-additional-args/src/main/protobuf/helloworld.proto
+++ b/protobuf-maven-plugin/src/it/gh-762-additional-args/src/main/protobuf/helloworld.proto
@@ -1,0 +1,28 @@
+//
+// Copyright (C) 2023 - 2025, Ashley Scopes.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "org.example.helloworld";
+
+package org.example.helloworld;
+
+message GreetingRequest {
+  string name = 1;
+  optional string remark = 2;
+}
+

--- a/protobuf-maven-plugin/src/it/gh-762-additional-args/src/test/java/org/example/helloworld/ProtobufTest.java
+++ b/protobuf-maven-plugin/src/it/gh-762-additional-args/src/test/java/org/example/helloworld/ProtobufTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2023 - 2025, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.example.helloworld;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.util.ArrayList;
+import org.junit.jupiter.api.Test;
+
+class ProtobufTest {
+  @Test
+  void generatedProtobufSourcesAreFullMessages() throws Throwable {
+    // When
+    var superClasses = new ArrayList<String>();
+    Class<?> superClass = GreetingRequest.class;
+
+    do {
+      superClasses.add(superClass.getName());
+      superClass = superClass.getSuperclass();
+    } while (superClass != null);
+
+    // Then
+    // GeneratedMessageV3 for protobuf-java 3.25.3 and older.
+    // GeneratedMessage for protobuf-java 4.26.0 and newer.
+    assertTrue(superClasses.contains("com.google.protobuf.GeneratedMessageV3"));
+  }
+
+  @Test
+  void generatedProtobufSourcesAreValid() throws Throwable {
+    // Given
+    var expectedGreetingRequest = GreetingRequest
+        .newBuilder()
+        .setName("Ashley")
+        .build();
+
+    // When
+    var baos = new ByteArrayOutputStream();
+    expectedGreetingRequest.writeTo(baos);
+    var actualGreetingRequest = GreetingRequest.parseFrom(baos.toByteArray());
+
+    assertNotEquals(0, baos.toByteArray().length);
+
+    // Then
+    assertEquals(expectedGreetingRequest.getName(), actualGreetingRequest.getName());
+  }
+}

--- a/protobuf-maven-plugin/src/it/gh-762-additional-args/test.groovy
+++ b/protobuf-maven-plugin/src/it/gh-762-additional-args/test.groovy
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2023 - 2025, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import java.nio.file.Path
+
+import static org.assertj.core.api.Assertions.assertThat
+
+Path baseDirectory = basedir.toPath().toAbsolutePath()
+Path generatedSourcesDir = baseDirectory.resolve("target/generated-sources/protobuf")
+Path classesDir = baseDirectory.resolve("target/classes")
+List<String> expectedGeneratedFiles = [
+    "org/example/helloworld/Helloworld",
+    "org/example/helloworld/GreetingRequest",
+    "org/example/helloworld/GreetingRequestOrBuilder",
+]
+
+assertThat(generatedSourcesDir).isDirectory()
+
+assertThat(classesDir).isDirectory()
+
+expectedGeneratedFiles.forEach {
+  assertThat(generatedSourcesDir.resolve("${it}.java"))
+      .exists()
+      .isNotEmptyFile()
+  assertThat(classesDir.resolve("${it}.class"))
+      .exists()
+      .isNotEmptyFile()
+}
+
+return true

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generation/GenerationRequest.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generation/GenerationRequest.java
@@ -38,6 +38,13 @@ import org.jspecify.annotations.Nullable;
 public interface GenerationRequest {
 
   /**
+   * Additional arguments to pass to {@code protoc}.
+   *
+   * @return the arguments list.
+   */
+  List<String> getArguments();
+
+  /**
    * Binary {@code protoc} plugins that should be resolved from Maven
    * repositories.
    *

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generation/ProtobufBuildOrchestrator.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/generation/ProtobufBuildOrchestrator.java
@@ -386,6 +386,7 @@ public final class ProtobufBuildOrchestrator {
         .collect(Collectors.toUnmodifiableList());
 
     return ImmutableProtocInvocation.builder()
+        .arguments(request.getArguments())
         .descriptorSourceFiles(filesToCompile.getDescriptorFiles())
         .environmentVariables(request.getEnvironmentVariables())
         .fatalWarnings(request.isFatalWarnings())

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/AbstractGenerateMojo.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/AbstractGenerateMojo.java
@@ -99,6 +99,20 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
   MavenProjectHelper mavenProjectHelper;
 
   /**
+   * Additional arguments to pass to {@code protoc}.
+   *
+   * <p>Note that generally, you should not need to use this. It is useful, however, if your
+   * use-case is not covered by other configuration parameters in this goal.
+   *
+   * <p>Configuring arguments that are covered by other parameters in this goal is undefined
+   * behaviour and should be avoided.
+   *
+   * @since 3.8.0
+   */
+  @Parameter
+  @Nullable List<String> arguments;
+
+  /**
    * Binary plugins to use with the protobuf compiler, sourced from a Maven repository.
    *
    * <p>Plugin artifacts must be a <strong>native executable</strong>. By default, the OS and CPU
@@ -1069,6 +1083,7 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
         .build();
 
     var request = ImmutableGenerationRequest.builder()
+        .arguments(nonNullList(arguments))
         .binaryMavenPlugins(nonNullList(binaryMavenPlugins))
         .binaryPathPlugins(nonNullList(binaryPathPlugins))
         .binaryUrlPlugins(nonNullList(binaryUrlPlugins))
@@ -1180,7 +1195,7 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
     return requireNonNullElseGet(list, List::of);
   }
 
-  private static <K, V> Map<K, V>  nonNullMap(@Nullable Map<K, V> map) {
+  private static <K, V> Map<K, V> nonNullMap(@Nullable Map<K, V> map) {
     return requireNonNullElseGet(map, Map::of);
   }
 }

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/protoc/ProtocExecutor.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/protoc/ProtocExecutor.java
@@ -82,6 +82,7 @@ public final class ProtocExecutor {
 
   private ArgumentFileBuilder createArgumentFileBuilder(ProtocInvocation invocation) {
     return new ArgumentFileBuilder()
+        .applyForEach(invocation.getArguments(), ArgumentFileBuilder::add)
         .addIfTrue(invocation.isFatalWarnings(), () -> "--fatal_warnings")
         .applyForEach(invocation.getTargets(), this::applyProtocTargetArguments)
         .addIfTrue(

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/protoc/ProtocInvocation.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/protoc/ProtocInvocation.java
@@ -38,6 +38,9 @@ public interface ProtocInvocation {
   // Fail if we get warnings, rather than continuing.
   boolean isFatalWarnings();
 
+  // Additional arguments to pass to protoc.
+  List<String> getArguments();
+
   // Environment variables to explicitly set.
   Map<String, String> getEnvironmentVariables();
 

--- a/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/mojo/AbstractGenerateMojoTestTemplate.java
+++ b/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/mojo/AbstractGenerateMojoTestTemplate.java
@@ -209,6 +209,42 @@ abstract class AbstractGenerateMojoTestTemplate<A extends AbstractGenerateMojo> 
         .withCause(exceptionCause);
   }
 
+  @DisplayName("when arguments is null, expect an empty list in the request")
+  @NullAndEmptySource
+  @ParameterizedTest(name = "when {0}")
+  void whenArgumentsNullExpectEmptyListInRequest(
+      @Nullable List<String> arguments
+  ) throws Throwable {
+    // Given
+    mojo.arguments = arguments;
+
+    // When
+    mojo.execute();
+
+    // Then
+    var captor = ArgumentCaptor.forClass(GenerationRequest.class);
+    verify(mojo.sourceCodeGenerator).generate(captor.capture());
+    var actualRequest = captor.getValue();
+    assertThat(actualRequest.getArguments()).isEmpty();
+  }
+
+  @DisplayName("when arguments are provided, expect the arguments in the request")
+  @Test
+  void whenArgumentsProvidedExpectArgumentsInRequest() throws Throwable {
+    // Given
+    List<String> arguments = List.of("foo", "bar");
+    mojo.arguments = arguments;
+
+    // When
+    mojo.execute();
+
+    // Then
+    var captor = ArgumentCaptor.forClass(GenerationRequest.class);
+    verify(mojo.sourceCodeGenerator).generate(captor.capture());
+    var actualRequest = captor.getValue();
+    assertThat(actualRequest.getArguments()).isEqualTo(arguments);
+  }
+
   @DisplayName("when binaryMavenPlugins is null, expect an empty list in the request")
   @NullAndEmptySource
   @ParameterizedTest(name = "when {0}")


### PR DESCRIPTION
This enables users pinned to old versions of protoc to utilise flags such as `--experimental_allow_proto3_optional`.

Closes GH-762.