### PR TITLE
Fix a bug in digest hex representations for byte values <10

### DIFF
--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/digests/Digest.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/digests/Digest.java
@@ -172,7 +172,14 @@ public final class Digest {
   private static String encodeHex(byte[] data) {
     var sb = new StringBuilder();
     for (var b : data) {
-      sb.append(Integer.toHexString(Byte.toUnsignedInt(b)));
+      // If the hex digit is less than 10 (base10) in value, it will not
+      // have a leading 0, so will be only one digit long and thus produce
+      // broken results.
+      var hexDigit = Integer.toHexString(Byte.toUnsignedInt(b));
+      if (hexDigit.length() == 1) {
+        sb.append('0');
+      }
+      sb.append(hexDigit);
     }
     return sb.toString();
   }

--- a/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/digests/DigestTest.java
+++ b/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/digests/DigestTest.java
@@ -117,20 +117,20 @@ class DigestTest {
   @Test
   void toStringReturnsTheExpectedValue() {
     // Given
-    var digest = new Digest("SHA-940", bytes(0xDE, 0xAD, 0xBE, 0xEF, 0x69, 0x42));
+    var digest = new Digest("SHA-940", bytes(0xDE, 0xAD, 0xBE, 0xEF, 0x69, 0x42, 0x0, 0x1, 0x2));
 
     // Then
-    assertThat(digest).hasToString("SHA-940:deadbeef6942");
+    assertThat(digest).hasToString("SHA-940:deadbeef6942000102");
   }
 
   @DisplayName(".toHexString() returns the expexted value")
   @Test
   void toHexStringReturnsTheExpectedValue() {
     // Given
-    var digest = new Digest("SHA-940", bytes(0xDE, 0xAD, 0xBE, 0xEF, 0x69, 0x42));
+    var digest = new Digest("SHA-940", bytes(0xDE, 0xAD, 0xBE, 0xEF, 0x69, 0x42, 0x0, 0x1, 0x2));
 
     // Then
-    assertThat(digest.toHexString()).isEqualTo("deadbeef6942");
+    assertThat(digest.toHexString()).isEqualTo("deadbeef6942000102");
   }
 
   @DisplayName(".verify(InputStream) succeeds if the digest matches the content")
@@ -163,9 +163,9 @@ class DigestTest {
         .isThrownBy(() -> digest.verify(stream))
         .withMessage(
             "Actual digest"
-                + " 'SHA-256:41d8dfe07cfa2111d75a6b318c4e35e2f6bab9daf0d5b0748acb162bb99fa4'"
+                + " 'SHA-256:41d8dfe07cfa2111d75a6b318c4e35e2f6bab9daf0d5b0748acb162bb909fa04'"
                 + " does not match expected digest"
-                + " 'SHA-256:9ca7e4eaa6e8ae9c7d261167129184883644d7dfba7cbfbc4c8a2e836d5b'"
+                + " 'SHA-256:09ca7e4eaa6e8ae9c7d261167129184883644d07dfba7cbfbc4c8a2e08360d5b'"
         );
   }
 


### PR DESCRIPTION
A bug is present where bytes <10 in decimal value produce invalid digests because toHexString produces a non-zero padded hex digit pair.

This addresses that issue to compute digests correctly in that edge case.

Example:

```
- Before 41d8dfe07cfa2111d75a6b318c4e35e2f6bab9daf0d5b0748acb162bb99fa4
- After  41d8dfe07cfa2111d75a6b318c4e35e2f6bab9daf0d5b0748acb162bb909fa04
                                                                   ^   ^
```