### PR TITLE
Implement mitigations for path length on windows (JDK-8315405)

### DIFF
--- a/protobuf-maven-plugin/src/it/gh-135-compile-dependencies/test.groovy
+++ b/protobuf-maven-plugin/src/it/gh-135-compile-dependencies/test.groovy
@@ -25,9 +25,8 @@ Path dependencyDirectory = baseDirectory
     .resolve("some-project")
     .resolve("target")
     .resolve("protobuf-maven-plugin")
-    .resolve("generate")
-    .resolve("default")
-    .resolve("archives")
+    // SHA-256 of "\0".join("generate", "default", "archives")
+    .resolve("0a499ddd05c090f574ae588c7326a72fa6b7799765ebd89a7a9450830353312b")
 
 assertThat(dependencyDirectory).isDirectory()
 

--- a/protobuf-maven-plugin/src/it/gh-302-runtime-scope-direct-resolution/test.groovy
+++ b/protobuf-maven-plugin/src/it/gh-302-runtime-scope-direct-resolution/test.groovy
@@ -52,9 +52,8 @@ assertThat(runtimeDependenciesRuntimeProto)
 // Compile dependencies are included in the archives directory.
 Path runtimeDependenciesArchivesDir = runtimeDependencyTargetDir
     .resolve("protobuf-maven-plugin")
-    .resolve("generate")
-    .resolve("default")
-    .resolve("archives")
+    // SHA-256 of "\0".join("generate", "default", "archives")
+    .resolve("0a499ddd05c090f574ae588c7326a72fa6b7799765ebd89a7a9450830353312b")
 
 assertThat(Files.list(runtimeDependenciesArchivesDir))
     .withFailMessage { "Expected protobuf-java-* directory to be present" }
@@ -87,9 +86,8 @@ assertThat(projectTargetCompilerProto)
 // Compile dependencies are included in the archives directory.
 Path projectTargetDirArchives = projectTargetDir
     .resolve("protobuf-maven-plugin")
-    .resolve("generate")
-    .resolve("default")
-    .resolve("archives")
+    // SHA-256 of "\0".join("generate", "default", "archives")
+    .resolve("0a499ddd05c090f574ae588c7326a72fa6b7799765ebd89a7a9450830353312b")
 
 assertThat(Files.list(projectTargetDirArchives))
     .filteredOn { it.getFileName().toString().startsWith("protobuf-java-") }

--- a/protobuf-maven-plugin/src/it/gh-302-runtime-scope-transitive-resolution/test.groovy
+++ b/protobuf-maven-plugin/src/it/gh-302-runtime-scope-transitive-resolution/test.groovy
@@ -52,9 +52,8 @@ assertThat(transitiveRuntimeDependenciesRuntimeProto)
 // Compile dependencies are included in the archives directory.
 Path transitiveRuntimeDependenciesArchivesDir = transitiveRuntimeDependencyTargetDir
     .resolve("protobuf-maven-plugin")
-    .resolve("generate")
-    .resolve("default")
-    .resolve("archives")
+    // SHA-256 of "\0".join("generate", "default", "archives")
+    .resolve("0a499ddd05c090f574ae588c7326a72fa6b7799765ebd89a7a9450830353312b")
 
 assertThat(Files.list(transitiveRuntimeDependenciesArchivesDir))
     .withFailMessage { "Expected protobuf-java-* directory to be present" }
@@ -87,9 +86,8 @@ assertThat(projectTargetCompilerProto)
 // Compile dependencies are included in the archives directory.
 Path projectTargetDirArchives = projectTargetDir
     .resolve("protobuf-maven-plugin")
-    .resolve("generate")
-    .resolve("default")
-    .resolve("archives")
+    // SHA-256 of "\0".join("generate", "default", "archives")
+    .resolve("0a499ddd05c090f574ae588c7326a72fa6b7799765ebd89a7a9450830353312b")
 
 assertThat(Files.list(projectTargetDirArchives))
     .filteredOn { it.getFileName().toString().startsWith("protobuf-java-") }

--- a/protobuf-maven-plugin/src/it/gh-359-modular-jar-plugin/test.groovy
+++ b/protobuf-maven-plugin/src/it/gh-359-modular-jar-plugin/test.groovy
@@ -32,10 +32,16 @@ Path expectedGeneratedFile = baseProjectDir.resolve("some-project")
 Path expectedScriptsDirectory = baseProjectDir.resolve("some-project")
     .resolve("target")
     .resolve("protobuf-maven-plugin")
-    .resolve("generate")
-    .resolve("default")
-    .resolve("plugins")
-    .resolve("jvm")
+    // SHA-256 of "\0".join(
+    //    "generate",
+    //    "default",
+    //    "plugins",
+    //    "jvm",
+    //    "08ce24621df7fd2139fd50dc82690c2638b232a98-0"
+    // )
+    // Where 08ce24621df7fd2139fd50dc82690c2638b232a98 is the SHA-1 digest of the
+    // protoc-plugin-frontend plugin and 0 is the plugin index.
+    .resolve("4b74c1002112236045d985915202761b573d141b1d4d1e152d194b39fc0db86f")
 
 // Verify compilation succeeded but that no JAR was created for the plugin itself.
 assertThat(protocPluginFrontendTargetDir).isDirectory()
@@ -52,10 +58,7 @@ assertThat(expectedGeneratedFile)
     .hasContent("org/example/helloworld.proto")
 
 // Verify we invoked the JVM with a module path.
-assertThat(Files.list(expectedScriptsDirectory))
-    .singleElement(InstanceOfAssertFactories.PATH)
-    .isDirectory()
-    .extracting({ dir -> dir.resolve("args.txt") }, InstanceOfAssertFactories.PATH)
+assertThat(expectedScriptsDirectory.resolve("args.txt"))
     .isRegularFile()
     .content()
     .contains("--module-path")

--- a/protobuf-maven-plugin/src/it/gh-575-configuration-import-dependencies-exclusions/test.groovy
+++ b/protobuf-maven-plugin/src/it/gh-575-configuration-import-dependencies-exclusions/test.groovy
@@ -33,9 +33,8 @@ Path dependencyDirectory = baseDirectory
     .resolve("channels")
     .resolve("target")
     .resolve("protobuf-maven-plugin")
-    .resolve("generate")
-    .resolve("default")
-    .resolve("archives")
+    // SHA-256 of "\0".join("generate", "default", "archives")
+    .resolve("0a499ddd05c090f574ae588c7326a72fa6b7799765ebd89a7a9450830353312b")
 
 assertThat(dependencyDirectory).isDirectory()
 

--- a/protobuf-maven-plugin/src/it/test-dependency-resolution/test.groovy
+++ b/protobuf-maven-plugin/src/it/test-dependency-resolution/test.groovy
@@ -34,12 +34,17 @@ Path mainProjectTargetDir = resolve(baseDirectory, "main-project", "target")
 // `test-dependency' output expectations //
 ///////////////////////////////////////////
 
+Path testDependencyGenerateDefaultArchivesDir = testDependencyTargetDir
+    .resolve("protobuf-maven-plugin")
+    // SHA-256 of "\0".join("generate", "default", "archives")
+    .resolve("0a499ddd05c090f574ae588c7326a72fa6b7799765ebd89a7a9450830353312b")
+
 assertThat(testDependencyTargetDir).isDirectory()
 assertThat(resolve(testDependencyTargetDir, "classes", "org", "example", "test", "TestSuite.class"))
     .isRegularFile()
 assertThat(resolve(testDependencyTargetDir, "classes", "org", "example", "test", "test.proto"))
     .isRegularFile()
-assertThat(Files.list(resolve(testDependencyTargetDir, "protobuf-maven-plugin", "generate", "default", "archives")))
+assertThat(Files.list(testDependencyGenerateDefaultArchivesDir))
     .withFailMessage { "Expected protobuf-java-* directory to be present" }
     .filteredOn { it.getFileName().toString().startsWith("protobuf-java-") }
     .hasSize(1)
@@ -48,17 +53,22 @@ assertThat(Files.list(resolve(testDependencyTargetDir, "protobuf-maven-plugin", 
 // `test-project' output expectations //
 ////////////////////////////////////////
 
+Path testProjectGenerateTestDefaultArchivesDir = testProjectTargetDir
+    .resolve("protobuf-maven-plugin")
+    // SHA-256 of "\0".join("generate-test", "default", "archives")
+    .resolve("0adb9f47535fa69ba04c54f2533a170de99e89478c2513bb0dcc0b6ea5ba3ee5")
+
 assertThat(testProjectTargetDir).isDirectory()
 assertThat(resolve(testProjectTargetDir, "test-classes", "org", "example", "compiler", "Compiler.class"))
     .isRegularFile()
 assertThat(resolve(testProjectTargetDir, "test-classes", "org", "example", "compiler", "compiler.proto"))
     .isRegularFile()
-assertThat(Files.list(resolve(testProjectTargetDir, "protobuf-maven-plugin", "generate-test", "default", "archives")))
+assertThat(Files.list(testProjectGenerateTestDefaultArchivesDir))
     .withFailMessage { "Expected protobuf-java-* directory to be present" }
     .filteredOn { it.getFileName().toString().startsWith("protobuf-java-") }
     .hasSize(1)
 // We should include test sources in the test goal execution.
-assertThat(Files.list(resolve(testProjectTargetDir, "protobuf-maven-plugin", "generate-test", "default", "archives")))
+assertThat(Files.list(testProjectGenerateTestDefaultArchivesDir))
     .withFailMessage { "Expected test-dependency-* directory to be present" }
     .filteredOn { it.getFileName().toString().startsWith("test-dependency-") }
     .hasSize(1)
@@ -67,17 +77,23 @@ assertThat(Files.list(resolve(testProjectTargetDir, "protobuf-maven-plugin", "ge
 // `main-project' output expectations //
 ////////////////////////////////////////
 
+Path mainProjectGenerateDefaultArchivesDir = mainProjectTargetDir
+    .resolve("protobuf-maven-plugin")
+    // SHA-256 of "\0".join("generate", "default", "archives")
+    .resolve("0a499ddd05c090f574ae588c7326a72fa6b7799765ebd89a7a9450830353312b")
+
+
 assertThat(mainProjectTargetDir).isDirectory()
 assertThat(resolve(mainProjectTargetDir,"classes", "org", "example", "compiler", "Compiler.class"))
     .isRegularFile()
 assertThat(resolve(mainProjectTargetDir,"classes", "org", "example", "compiler", "compiler.proto"))
     .isRegularFile()
-assertThat(Files.list(resolve(mainProjectTargetDir, "protobuf-maven-plugin", "generate", "default", "archives")))
+assertThat(Files.list(mainProjectGenerateDefaultArchivesDir))
     .withFailMessage { "Expected protobuf-java-* directory to be present" }
     .filteredOn { it.getFileName().toString().startsWith("protobuf-java-") }
     .hasSize(1)
 // We should exclude test sources in the main goal execution.
-assertThat(Files.list(resolve(mainProjectTargetDir, "protobuf-maven-plugin", "generate", "default", "archives")))
+assertThat(Files.list(mainProjectGenerateDefaultArchivesDir))
     .withFailMessage { "Expected test-dependency-* directory to not be present" }
     .filteredOn { it.getFileName().toString().startsWith("test-dependency-") }
     .isEmpty()

--- a/protobuf-maven-plugin/src/site/markdown/known-issues.md
+++ b/protobuf-maven-plugin/src/site/markdown/known-issues.md
@@ -10,3 +10,42 @@ If you have found a problem. Please [raise an issue on GitHub](https://github.co
 Note that any issues fixed in newer versions of both this software and other pieces of software
 will not be documented here. Please ensure you are using the latest version of dependencies and
 plugins where possible prior to raising an issue.
+
+---
+
+## Windows path length issues
+
+Microsoft Windows historically enforces that executables do not have an absolute path that is
+more than 260 characters in size. This has been lifted for Windows 11 but requires JDK changes
+to be compatible, and at the time of writing, this has not been implemented.
+
+For users, this means that running builds within overly nested hierarchies, or using very long
+directory names on Windows may result in builds failing. This generally looks like the following
+error:
+
+```text
+java.io.IOException: Cannot run program "C:\some\very\long\path\to\a\script-or-executable.exe": CreateProcess error=2, The system cannot find the file specified
+```
+
+At the time of writing, the only real workaround for this is to use a shorter absolute path, which
+means moving your build nearer to the root directory of your drive you are building from 
+(e.g. `C:\`).
+
+For now, a workaround has been implemented that translates internal generated paths to SHA-256
+digests with the aim of reducing the length of overly verbose path names, but past this, there
+is not much else that can be reasonably done to fix this until OpenJDK actively address this
+issue and release a fix in the JDK.
+
+See:
+
+- [(OpenJDK Bug) JDK-8315405 - Can't start process in directory with very long path](https://bugs.openjdk.org/browse/JDK-8315405) 
+- [(OpenJDK Bug) JDK-8348664 - Enable long path support in manifest for java.exe and javaw.exe on Windows](https://bugs.openjdk.org/browse/JDK-8348664)
+- [(Microsoft) Maximum File Path Limitation](https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=registry)
+- [(Microsoft) CreateProcessW function (processthreadsapi.h)](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessw) 
+
+If this blocks you, please mention it on the first bug to help bring further attention to it.
+
+In the meantime, any further bugs relating to this on the `protobuf-maven-plugin` will not be fixed
+unless a suitable workaround is available.
+
+This does **not** affect users on Linux or macOS.

--- a/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/fs/TemporarySpaceTest.java
+++ b/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/fs/TemporarySpaceTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 
+import io.github.ascopes.protobufmavenplugin.digests.Digest;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
@@ -87,15 +88,14 @@ class TemporarySpaceTest {
     var actualPath = temporarySpace.createTemporarySpace("foo", "bar", "baz", id);
 
     // Then
+    var expectedDigestComponent = String.join("\0", goal, executionId, "foo", "bar", "baz", id);
+    var expectedDigestDir = Digest.compute("SHA-256", expectedDigestComponent)
+            .toHexString();
+
     assertThat(actualPath)
         .isEqualTo(tempDir
             .resolve("protobuf-maven-plugin")
-            .resolve(goal)
-            .resolve(executionId)
-            .resolve("foo")
-            .resolve("bar")
-            .resolve("baz")
-            .resolve(id))
+            .resolve(expectedDigestDir))
         .isDirectory();
   }
 
@@ -104,14 +104,12 @@ class TemporarySpaceTest {
   void nothingHappensIfTheTemporaryDirectoryAlreadyExists() throws IOException {
     // Given
     var id = someBasicString();
+    var expectedDigestComponent = String.join("\0", goal, executionId, "foo", "bar", "baz", id);
+    var expectedDigestDir = Digest.compute("SHA-256", expectedDigestComponent)
+        .toHexString();
     var existingPath = tempDir
         .resolve("protobuf-maven-plugin")
-        .resolve(goal)
-        .resolve(executionId)
-        .resolve("foo")
-        .resolve("bar")
-        .resolve("baz")
-        .resolve(id);
+        .resolve(expectedDigestDir);
     Files.createDirectories(existingPath);
 
     // When


### PR DESCRIPTION
At the time of writing, two OpenJDK bugs exist that cause us hassle on Windows:

- https://bugs.openjdk.org/browse/JDK-8315405
- https://bugs.openjdk.org/browse/JDK-8348664

On Windows, historical decisions mean that when invoking a native executable via the CreateProcessW API
(https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessw), the executable path cannot be longer than 260 characters.

For our hierarchy of generated directories to ensure build reproducibility, this poses a visible issue, especially in our CI workflows (and as such, may impact other users using a similar setup), since the path lengths when concatenated to the base directory the project is cloned to will breach the 260 character limit.

A workaround is available as part of
https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=registry but this requires active system changes on Windows and possibly a set of changes to OpenJDK itself, as discussed in JDK-8348664 above. At the time of writing, this has not been implemented.

As a result, this commit changes how temporary spaces work to remove the nested directory hierarchy that is provided by TemporarySpace APIs used internally for build organization, and replaces them with a wrapper that names directories using a fixed length SHA-256 digest of the previous components. This provides enough "entropy" to avoid the risk of collisions in names, while providing a reproducible file length until the problem is resolved. This should reduce the cases where this issue arises until such a time that the problem is addressed properly, where we can then revert this commit.