### PR TITLE
GH-792: Avoid modifying file permissions in ~/.m2 for executables

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,67 +72,56 @@ jobs:
             os-name: macos-13
             java-version: 11
             maven-version: "${{ needs.validate.outputs.default_maven_version }}"
-            pre-script: "brew install bash"
-            
+
           - title: macOS aarch_64, mvn ${{ needs.validate.outputs.default_maven_version }}, jdk11
             os-name: macos-15
             java-version: 11
             maven-version: "${{ needs.validate.outputs.default_maven_version }}"
-            pre-script: "brew install bash"
 
           - title: Windows x86_64, mvn ${{ needs.validate.outputs.default_maven_version }}, jdk11
             os-name: windows-2025
             java-version: 11
             maven-version: "${{ needs.validate.outputs.default_maven_version }}"
-            pre-script: ":"
 
           - title: Windows aarch_64, mvn ${{ needs.validate.outputs.default_maven_version }}, jdk21
             os-name: windows-11-arm
             java-version: 21  # This is the earliest-supported version on Windows ARM
             maven-version: "${{ needs.validate.outputs.default_maven_version }}"
-            pre-script: ":"
 
           - title: Linux aarch_64, mvn ${{ needs.validate.outputs.default_maven_version }}, jdk11
             os-name: ubuntu-24.04-arm
             java-version: 11
             maven-version: "${{ needs.validate.outputs.default_maven_version }}"
-            pre-script: ":"
 
           - title: Linux x86_64, mvn ${{ needs.validate.outputs.default_maven_version }}, jdk11
             os-name: ubuntu-24.04
             java-version: 11
             maven-version: "${{ needs.validate.outputs.default_maven_version }}"
-            pre-script: ":"
 
           - title: Linux x86_64 mvn ${{ needs.validate.outputs.default_maven_version }}, jdk17
             os-name: ubuntu-24.04
             java-version: 17
             maven-version: "${{ needs.validate.outputs.default_maven_version }}"
-            pre-script: ":"
 
           - title: Linux x86_64, mvn ${{ needs.validate.outputs.default_maven_version }}, jdk21
             os-name: ubuntu-24.04
             java-version: 21
             maven-version: "${{ needs.validate.outputs.default_maven_version }}"
-            pre-script: ":"
 
           - title: Linux x86_64, mvn ${{ needs.validate.outputs.default_maven_version }}, jdk24
             os-name: ubuntu-24.04
             java-version: 24
             maven-version: "${{ needs.validate.outputs.default_maven_version }}"
-            pre-script: ":"
 
           - title: Linux x86_64, mvn 3.8.8, jdk11
             os-name: ubuntu-24.04
             java-version: 11
             maven-version: 3.8.8
-            pre-script: ":"
 
           - title: Linux x86_64, mvn 4, jdk17
             os-name: ubuntu-24.04
             java-version: 17
             maven-version: 4.0.0-rc-4
-            pre-script: ":"
 
     steps:
       - name: Checkout repository
@@ -145,17 +134,13 @@ jobs:
           java-version: ${{ matrix.java-version }}
           distribution: 'temurin'
 
-      - name: Set Maven version to ${{ matrix.maven-version }}
-        shell: bash
-        run: |-
-          ./mvnw -B -T1 -q wrapper:wrapper "-Dmaven=${{ matrix.maven-version }}"
-          ./mvnw --version
-
       - name: Configure runner
         shell: bash
         run: |-
-          eval "${{ matrix.pre-script }}"
+          scripts/prepare-runner.sh
           scripts/install-protoc-to-github-runner.sh
+          ./mvnw -B -T1 -q wrapper:wrapper "-Dmaven=${{ matrix.maven-version }}"
+          ./mvnw --version
 
       - name: Build and test
         shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -11,9 +11,14 @@ target/
 # JVM agent descriptors
 .attach*
 
-# Stuff that I generate when I have lost all hope in the world
-/*.log
-temp/
-
 # Version backups after running ./mvnw versions:set
 pom.xml.versionsBackup
+
+# Other junk
+.DS_Store
+*.bak
+*.db
+*.log
+*.save
+*.tmp
+temp/

--- a/protobuf-maven-plugin/pom.xml
+++ b/protobuf-maven-plugin/pom.xml
@@ -173,6 +173,32 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-invoker-plugin</artifactId>
 
+        <configuration>
+          <addTestClassPath>true</addTestClassPath>
+          <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
+          <failIfNoProjects>true</failIfNoProjects>
+          <!-- Warning: placing this inside the cloneProjectsTo path triggers a resolution bug in the plugin -->
+          <localRepositoryPath>${project.basedir}/target/it-repo</localRepositoryPath>
+          <parallelThreads>2C</parallelThreads>
+          <postBuildHookScript>test</postBuildHookScript>
+          <properties>
+            <!-- Acquire locks whereever we run Maven to avoid parallel tests trampling across eachother. -->
+            <aether.syncContext.named.factory>file-lock</aether.syncContext.named.factory>
+            <aether.syncContext.named.nameMapper>file-gav</aether.syncContext.named.nameMapper>
+            <!-- Avoid https://bugs.openjdk.org/browse/JDK-8252883 on Windows -->
+            <aether.named.file-lock.attempts>10</aether.named.file-lock.attempts>
+            <aether.named.file-lock.sleepMillis>500</aether.named.file-lock.sleepMillis>
+          </properties>
+          <setupIncludes>
+            <setupInclude>setup</setupInclude>
+          </setupIncludes>
+          <settingsFile>${project.basedir}/src/it/settings.xml</settingsFile>
+          <showErrors>true</showErrors>
+          <streamLogs>false</streamLogs>
+          <streamLogsOnFailures>true</streamLogsOnFailures>
+          <writeJunitReport>true</writeJunitReport>
+        </configuration>
+
         <executions>
           <execution>
             <id>integration-test</id>
@@ -181,32 +207,6 @@
               <goal>install</goal>
               <goal>run</goal>
             </goals>
-
-            <configuration>
-              <addTestClassPath>true</addTestClassPath>
-              <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
-              <failIfNoProjects>true</failIfNoProjects>
-              <!-- Warning: placing this inside the cloneProjectsTo path triggers a resolution bug in the plugin -->
-              <localRepositoryPath>${project.basedir}/target/it-repo</localRepositoryPath>
-              <parallelThreads>2C</parallelThreads>
-              <postBuildHookScript>test</postBuildHookScript>
-              <properties>
-                <!-- Acquire locks whereever we run Maven to avoid parallel tests trampling across eachother. -->
-                <aether.syncContext.named.factory>file-lock</aether.syncContext.named.factory>
-                <aether.syncContext.named.nameMapper>file-gav</aether.syncContext.named.nameMapper>
-                <!-- Avoid https://bugs.openjdk.org/browse/JDK-8252883 on Windows -->
-                <aether.named.file-lock.attempts>10</aether.named.file-lock.attempts>
-                <aether.named.file-lock.sleepMillis>500</aether.named.file-lock.sleepMillis>
-              </properties>
-              <setupIncludes>
-                <setupInclude>setup</setupInclude>
-              </setupIncludes>
-              <settingsFile>${project.basedir}/src/it/settings.xml</settingsFile>
-              <showErrors>true</showErrors>
-              <streamLogs>false</streamLogs>
-              <streamLogsOnFailures>true</streamLogsOnFailures>
-              <writeJunitReport>true</writeJunitReport>
-            </configuration>
           </execution>
         </executions>
       </plugin>
@@ -325,13 +325,61 @@
             <plugin>
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-invoker-plugin</artifactId>
-              <version>${maven-invoker-plugin.version}</version>
               <configuration>
                 <invokerPropertiesFile>invoker-path-protoc.properties</invokerPropertiesFile>
               </configuration>
             </plugin>
           </plugins>
         </pluginManagement>
+      </build>
+    </profile>
+
+    <profile>
+      <!-- Attempt to use a shorter path name for tests on Windows so that we do not get
+           failures from hitting path length limits. -->
+      <id>invoker-windows-workaround</id>
+      <activation>
+        <os>
+          <family>windows</family>
+        </os>
+      </activation>
+
+      <properties>
+        <invoker-project-path-override>${java.io.tmpdir}/pmp-it</invoker-project-path-override>
+      </properties>
+      
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-clean-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>clean-windows-invoker-path</id>
+                <phase>clean</phase>
+                <goals>
+                  <goal>clean</goal>
+                </goals>
+                <configuration>
+                  <filesets>
+                    <fileset>
+                      <directory>${invoker-project-path-override}</directory>
+                      <useDefaultExcludes>false</useDefaultExcludes>
+                    </fileset>
+                  </filesets>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-invoker-plugin</artifactId>
+            <configuration>
+              <cloneProjectsTo>${invoker-project-path-override}</cloneProjectsTo>
+            </configuration>
+          </plugin>
+        </plugins>
       </build>
     </profile>
   </profiles>

--- a/protobuf-maven-plugin/src/it/WRITING_ITS.md
+++ b/protobuf-maven-plugin/src/it/WRITING_ITS.md
@@ -9,6 +9,11 @@ to capture code coverage.
 All test POMs inherit the `setup/pom.xml` project which acts as the base for defining common 
 versions across all projects. This keeps various concerns simple when updating dependencies.
 
+Note that Windows has very strict file name length limits, and the invoker configuration can result
+in paths that breach this limit, causing builds to spuriously fail. To avoid this, on Windows,
+we run all invoker tests within the user's temporary directory. Be mindful of this when naming
+the test cases.
+
 ## Invocation
 
 To run all integration tests, run:

--- a/protobuf-maven-plugin/src/it/setup/pom.xml
+++ b/protobuf-maven-plugin/src/it/setup/pom.xml
@@ -101,6 +101,19 @@
   </dependencyManagement>
 
   <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+
+        <configuration>
+          <!-- Avoid invoker confusing checkstyle about config locations -->
+          <configLocation>@project.basedir@/../.mvn/checkstyle/checkstyle.xml</configLocation>
+          <suppressionsLocation>@project.basedir@/../.mvn/checkstyle/suppressions.xml</suppressionsLocation>    
+        </configuration>
+      </plugin>
+    </plugins>
+  
     <pluginManagement>
       <plugins>
         <plugin>

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/MavenArtifactPathResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/MavenArtifactPathResolver.java
@@ -36,11 +36,13 @@ public interface MavenArtifactPathResolver {
   /**
    * Resolve a single Maven artifact directly, and do not resolve any transitive dependencies.
    *
+   * <p>The executable bit will be set on the resulting path.
+   *
    * @param artifact the artifact to resolve.
    * @return the path to the resolved artifact.
    * @throws ResolutionException if resolution fails in the backend.
    */
-  Path resolveArtifact(MavenArtifact artifact) throws ResolutionException;
+  Path resolveExecutable(MavenArtifact artifact) throws ResolutionException;
 
   /**
    * Resolve all given dependencies based on their resolution depth semantics.

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherMavenArtifactPathResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherMavenArtifactPathResolver.java
@@ -25,6 +25,7 @@ import io.github.ascopes.protobufmavenplugin.utils.ResolutionException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -89,7 +90,7 @@ final class AetherMavenArtifactPathResolver implements MavenArtifactPathResolver
 
     try {
       log.debug("Copying \"{}\" to \"{}\" and making executable", originalPath, finalPath);
-      Files.copy(originalPath, finalPath);
+      Files.copy(originalPath, finalPath, StandardCopyOption.REPLACE_EXISTING);
       FileUtils.makeExecutable(finalPath);
     } catch (IOException ex) {
       throw new ResolutionException("Failed to process downloaded artifact " + artifact, ex);

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherMavenArtifactPathResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherMavenArtifactPathResolver.java
@@ -85,8 +85,9 @@ final class AetherMavenArtifactPathResolver implements MavenArtifactPathResolver
 
     // GH-792: make a copy and set that as executable rather than changing what is in the
     // repository, as this is racy between concurrent builds and deemed to be unsafe.
+    var digestPart = Digest.compute("SHA-1", artifact.toString()).toHexString();
     var finalPath = temporarySpace.createTemporarySpace("artifacts")
-        .resolve(Digest.compute("SHA-1", artifact.toString()).toHexString() + ".exe");
+        .resolve(artifact.getArtifactId() + "-" + digestPart + ".exe");
 
     try {
       log.debug("Copying \"{}\" to \"{}\" and making executable", originalPath, finalPath);

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/BinaryPluginResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/BinaryPluginResolver.java
@@ -108,8 +108,7 @@ final class BinaryPluginResolver {
     plugin = pluginBuilder.build();
 
     log.debug("Resolving Maven protoc plugin {}", plugin);
-    var path = artifactPathResolver.resolveArtifact(plugin);
-    makeExecutable(path);
+    var path = artifactPathResolver.resolveExecutable(plugin);
     return Optional.of(createResolvedProtocPlugin(plugin, defaultOutputDirectory, path));
   }
 
@@ -138,7 +137,7 @@ final class BinaryPluginResolver {
   ) throws ResolutionException {
     log.debug("Resolving URL protoc plugin {}", plugin);
 
-    var maybePath = urlResourceFetcher.fetchFileFromUri(plugin.getUrl(), ".exe");
+    var maybePath = urlResourceFetcher.fetchFileFromUri(plugin.getUrl(), ".exe", true);
 
     if (maybePath.isEmpty() && plugin.isOptional()) {
       return Optional.empty();
@@ -160,8 +159,6 @@ final class BinaryPluginResolver {
         );
       }
     }
-
-    makeExecutable(path);
 
     return Optional.of(createResolvedProtocPlugin(plugin, defaultOutputDirectory, path));
   }

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/protoc/ProtocResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/protoc/ProtocResolver.java
@@ -116,24 +116,13 @@ public final class ProtocResolver {
       }
     }
 
-    try {
-      FileUtils.makeExecutable(resolvedPath);
-
-    } catch (IOException ex) {
-      throw new ResolutionException(
-          "Failed to set executable bit on protoc binary at \"" + resolvedPath
-              + "\": " + ex,
-          ex
-      );
-    }
-
     return path;
   }
 
   private Optional<Path> resolveFromUri(String uriString) throws ResolutionException {
     try {
       var uri = new URI(uriString);
-      return urlResourceFetcher.fetchFileFromUri(uri, ".exe");
+      return urlResourceFetcher.fetchFileFromUri(uri, ".exe", true);
     } catch (URISyntaxException ex) {
       throw new ResolutionException("Failed to parse URI \"" + uriString + "\"", ex);
     }
@@ -161,6 +150,6 @@ public final class ProtocResolver {
         .classifier(platformClassifierFactory.getClassifier(ARTIFACT_ID))
         .build();
 
-    return Optional.of(artifactPathResolver.resolveArtifact(artifact));
+    return Optional.of(artifactPathResolver.resolveExecutable(artifact));
   }
 }

--- a/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherMavenArtifactPathResolverTest.java
+++ b/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherMavenArtifactPathResolverTest.java
@@ -103,6 +103,7 @@ class AetherMavenArtifactPathResolverTest {
   @Test
   void resolveExecutableResolvesTheArtifact() throws ResolutionException, IOException {
     // Given
+    var artifactId = "someArtifactId-" + someBasicString();
     var inputArtifact = mock(MavenArtifact.class, "SomeArtifact-" + someBasicString());
     var unresolvedArtifact = mock(Artifact.class);
     var resolvedArtifact = mock(Artifact.class);
@@ -111,6 +112,8 @@ class AetherMavenArtifactPathResolverTest {
         "Some expected binary content here " + someBasicString()
     );
 
+    when(inputArtifact.getArtifactId())
+        .thenReturn(artifactId);
     when(aetherArtifactMapper.mapPmpArtifactToEclipseArtifact(any()))
         .thenReturn(unresolvedArtifact);
     when(aetherResolver.resolveRequiredArtifact(any()))
@@ -118,8 +121,11 @@ class AetherMavenArtifactPathResolverTest {
     when(aetherArtifactMapper.mapEclipseArtifactToPath(any()))
         .thenReturn(originalPath);
 
-    var expectedFileName = Digest.compute("SHA-1", inputArtifact.toString())
-        .toHexString() + ".exe";
+    var expectedFileName = artifactId
+        + "-"
+        + Digest.compute("SHA-1", inputArtifact.toString())
+        .toHexString()
+        + ".exe";
 
     // When
     var resolvedPath = resolver.resolveExecutable(inputArtifact);
@@ -141,6 +147,7 @@ class AetherMavenArtifactPathResolverTest {
   void resolveExecutableResolvesTheArtifactWhenAlreadyPresent()
       throws ResolutionException, IOException {
     // Given
+    var artifactId = "someArtifactId-" + someBasicString();
     var inputArtifact = mock(MavenArtifact.class, "SomeArtifact-" + someBasicString());
     var unresolvedArtifact = mock(Artifact.class);
     var resolvedArtifact = mock(Artifact.class);
@@ -149,6 +156,8 @@ class AetherMavenArtifactPathResolverTest {
         "Some expected binary content here " + someBasicString()
     );
 
+    when(inputArtifact.getArtifactId())
+        .thenReturn(artifactId);
     when(aetherArtifactMapper.mapPmpArtifactToEclipseArtifact(any()))
         .thenReturn(unresolvedArtifact);
     when(aetherResolver.resolveRequiredArtifact(any()))
@@ -156,8 +165,11 @@ class AetherMavenArtifactPathResolverTest {
     when(aetherArtifactMapper.mapEclipseArtifactToPath(any()))
         .thenReturn(originalPath);
 
-    var expectedFileName = Digest.compute("SHA-1", inputArtifact.toString())
-        .toHexString() + ".exe";
+    var expectedFileName = artifactId
+        + "-"
+        + Digest.compute("SHA-1", inputArtifact.toString())
+        .toHexString()
+        + ".exe";
 
     // Given some file is already in the location... we don't expect this to fail.
     Files.writeString(temporarySpacePath.resolve(expectedFileName), "some garbage I don't want");

--- a/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherMavenArtifactPathResolverTest.java
+++ b/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherMavenArtifactPathResolverTest.java
@@ -16,6 +16,7 @@
 package io.github.ascopes.protobufmavenplugin.dependencies.aether;
 
 import static io.github.ascopes.protobufmavenplugin.fixtures.RandomFixtures.oneOf;
+import static io.github.ascopes.protobufmavenplugin.fixtures.RandomFixtures.someBasicString;
 import static java.util.Map.entry;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.argumentSet;
@@ -30,7 +31,11 @@ import static org.mockito.Mockito.when;
 
 import io.github.ascopes.protobufmavenplugin.dependencies.DependencyResolutionDepth;
 import io.github.ascopes.protobufmavenplugin.dependencies.MavenArtifact;
+import io.github.ascopes.protobufmavenplugin.digests.Digest;
+import io.github.ascopes.protobufmavenplugin.fs.TemporarySpace;
 import io.github.ascopes.protobufmavenplugin.utils.ResolutionException;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -45,20 +50,28 @@ import org.apache.maven.execution.MavenSession;
 import org.apache.maven.project.MavenProject;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.graph.Dependency;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mock.Strictness;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.stubbing.Answer;
 
 @DisplayName("AetherMavenArtifactPathResolver tests")
 @ExtendWith(MockitoExtension.class)
 class AetherMavenArtifactPathResolverTest {
+
+  @TempDir
+  Path tempDir;
+
+  Path temporarySpacePath;
 
   @Mock
   MavenSession mavenSession;
@@ -72,30 +85,51 @@ class AetherMavenArtifactPathResolverTest {
   @Mock
   AetherResolver aetherResolver;
 
+  @Mock(strictness = Strictness.LENIENT)
+  TemporarySpace temporarySpace;
+
   @InjectMocks
   AetherMavenArtifactPathResolver resolver;
 
+  @BeforeEach
+  void setUp() throws IOException {
+    temporarySpacePath = Files.createDirectories(tempDir.resolve("temporary-space"));
+
+    when(temporarySpace.createTemporarySpace(any(String[].class)))
+        .thenReturn(temporarySpacePath);
+  }
+
   @DisplayName(".resolveExecutable(...) resolves the artifact")
   @Test
-  void resolveExecutableResolvesTheArtifact() throws ResolutionException {
+  void resolveExecutableResolvesTheArtifact() throws ResolutionException, IOException {
     // Given
-    var inputArtifact = mock(MavenArtifact.class);
+    var inputArtifact = mock(MavenArtifact.class, "SomeArtifact-" + someBasicString());
     var unresolvedArtifact = mock(Artifact.class);
     var resolvedArtifact = mock(Artifact.class);
-    var path = mock(Path.class);
+    var originalPath = Files.writeString(
+        tempDir.resolve("some-artifact.exe"),
+        "Some expected binary content here " + someBasicString()
+    );
 
     when(aetherArtifactMapper.mapPmpArtifactToEclipseArtifact(any()))
         .thenReturn(unresolvedArtifact);
     when(aetherResolver.resolveRequiredArtifact(any()))
         .thenReturn(resolvedArtifact);
     when(aetherArtifactMapper.mapEclipseArtifactToPath(any()))
-        .thenReturn(path);
+        .thenReturn(originalPath);
+
+    var expectedFileName = Digest.compute("SHA-1", inputArtifact.toString())
+        .toHexString() + ".exe";
 
     // When
     var resolvedPath = resolver.resolveExecutable(inputArtifact);
 
     // Then
-    assertThat(resolvedPath).isSameAs(path);
+    assertThat(resolvedPath)
+        .isEqualTo(temporarySpacePath.resolve(expectedFileName))
+        .hasSameBinaryContentAs(originalPath)
+        .isExecutable();
+
     verify(aetherArtifactMapper).mapPmpArtifactToEclipseArtifact(inputArtifact);
     verify(aetherResolver).resolveRequiredArtifact(unresolvedArtifact);
     verify(aetherArtifactMapper).mapEclipseArtifactToPath(resolvedArtifact);

--- a/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherMavenArtifactPathResolverTest.java
+++ b/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/dependencies/aether/AetherMavenArtifactPathResolverTest.java
@@ -75,9 +75,9 @@ class AetherMavenArtifactPathResolverTest {
   @InjectMocks
   AetherMavenArtifactPathResolver resolver;
 
-  @DisplayName(".resolveArtifact(...) resolves the artifact")
+  @DisplayName(".resolveExecutable(...) resolves the artifact")
   @Test
-  void resolveArtifactResolvesTheArtifact() throws ResolutionException {
+  void resolveExecutableResolvesTheArtifact() throws ResolutionException {
     // Given
     var inputArtifact = mock(MavenArtifact.class);
     var unresolvedArtifact = mock(Artifact.class);
@@ -92,7 +92,7 @@ class AetherMavenArtifactPathResolverTest {
         .thenReturn(path);
 
     // When
-    var resolvedPath = resolver.resolveArtifact(inputArtifact);
+    var resolvedPath = resolver.resolveExecutable(inputArtifact);
 
     // Then
     assertThat(resolvedPath).isSameAs(path);

--- a/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/fs/UriResourceFetcherTest.java
+++ b/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/fs/UriResourceFetcherTest.java
@@ -47,6 +47,8 @@ import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -133,6 +135,10 @@ class UriResourceFetcherTest {
         .isEqualTo(Files.readString(file));
   }
 
+  @DisabledOnOs(
+      disabledReason = "Windows does not support POSIX permission bits",
+      value = OS.WINDOWS
+  )
   @DisplayName("the executable bit is set on files when requested")
   @ValueSource(booleans = {true, false})
   @ParameterizedTest(name = "when setExecutable = {0}")

--- a/scripts/install-protoc-to-github-runner.sh
+++ b/scripts/install-protoc-to-github-runner.sh
@@ -18,10 +18,14 @@ version=$(./mvnw help:evaluate -Dexpression=protobuf.version -DforceStdout=true 
 
 echo "Checking OS and CPU..."
 
-case "$(uname)" in
-  Linux)
+lower() {
+  tr '[:upper:]' '[:lower:]'
+}
+
+case "$(uname | lower)" in
+  linux*)
     readonly os_name=linux
-    case "$(uname -m)" in
+    case "$(uname -m | lower)" in
       aarch64)
         readonly os_arch=aarch_64
         ;;
@@ -30,10 +34,10 @@ case "$(uname)" in
         ;;
     esac
     ;;
-  Darwin)
+  darwin*)
     # Only support for aarch64 in new macOS versions.
     readonly os_name=osx
-    case "$(uname -m)" in
+    case "$(uname -m | lower)" in
       aarch64)
         readonly os_arch=aarch_64
         ;;
@@ -42,11 +46,15 @@ case "$(uname)" in
         ;;
     esac
     ;;
-  *)
+  windows*|mingw*)
     # No arm64 version available, we assume Prism on ARM for Windows will
     # correctly translate this.
     readonly os_name=windows
     readonly os_arch=x86_64
+    ;;
+  *)
+    echo "ERROR: unknown platform '$(uname)' ($(uname -a))" >&2
+    exit 2
     ;;
 esac
 

--- a/scripts/prepare-runner.sh
+++ b/scripts/prepare-runner.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env sh
+###
+### Configure the GitHub runner for builds.
+###
+### Note that this has to be a POSIX sh script,
+### since bash may be missing or grossly outdated.
+###
+### Author: Ashley Scopes
+###
+set -o errexit
+set -o nounset
+
+echo "Platform: $(uname -a)"
+
+case "$(uname | tr '[:upper:]' '[:lower:]')" in
+  windows|mingw*)
+    echo "Enabling long file paths in the registry if possible..."
+    reg add "HKLM\SYSTEM\CurrentControlSet\Control\FileSystem" -v LongPathsEnabled -t REG_DWORD -d 1 -f || true
+    ;;
+  darwin*)
+    echo "Installing latest version of bash..."
+    brew install bash
+    ;;
+  *)
+    echo "No preparation required."
+    ;;
+esac
+
+java --version
+bash --version
+git --version


### PR DESCRIPTION
- Artifact resolution API now focuses on resolving executables specifically, rather than any artifact types, since we only use it for executables.
- Artifact resolution API now copies resolved executables to the temporary space and marks them as executable. This avoids changing file permissions on artifacts within the local repository, which is deemed racy and unsafe per guidance from @cstamas in https://github.com/apache/maven-resolver/issues/1577
- Removed special handling of file URIs in UriResourceFetcher, as we now want executables on the local file system to be copied rather than modifying their permissions in-place. This also fixes a potential issue where builds could fail if projects relied on a local file owned by a different user.
- UriResourceFetcher now allows setting the executable bit on resolved URLs.
- ProtocResolver and BinaryPluginResolver now hand over the responsibility of setting the executable bit to underlying components.