### PR TITLE
GH-822: provisionally deprecate functionality that is unhelpful/confusing

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,6 @@ and then proceed to generate gRPC wrappers and Reactor gRPC wrappers.
 </plugin>
 ```
 
-## Stars
+---
 
 [![Star History Chart](https://api.star-history.com/svg?repos=ascopes/protobuf-maven-plugin&type=Timeline&theme=dark)](https://www.star-history.com/#ascopes/protobuf-maven-plugin&Timeline)

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/AbstractGenerateMojo.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/AbstractGenerateMojo.java
@@ -300,16 +300,22 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
   /**
    * Enable generating C++ sources and headers from the protobuf sources.
    *
+   * @deprecated will be removed in v4.0.0. Users wishing to generate C++ sources
+   *     should use the {@code arguments} to specify {@code --cpp_out=path}.
    * @since 1.1.0
    */
+  @Deprecated(since = "3.10.1", forRemoval = true)
   @Parameter(defaultValue = DEFAULT_FALSE)
   boolean cppEnabled;
 
   /**
    * Enable generating C# sources from the protobuf sources.
    *
+   * @deprecated will be removed in v4.0.0. Users wishing to generate C# sources
+   *     should use the {@code arguments} to specify {@code --csharp_out=path}.
    * @since 1.1.0
    */
+  @Deprecated(since = "3.10.1", forRemoval = true)
   @Parameter(defaultValue = DEFAULT_FALSE)
   boolean csharpEnabled;
 
@@ -422,8 +428,10 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    * <p>Prior to {@code v2.4.0}, any invalid dependencies would result in an error being raised
    * and the build being aborted. In {@code v2.4.0}, this has been relaxed.
    *
+   * @deprecated will be removed in v4.0.0: invalid dependencies will be ignored.
    * @since 2.4.0
    */
+  @Deprecated(since = "3.10.1", forRemoval = true)
   @Parameter(defaultValue = DEFAULT_FALSE)
   boolean failOnInvalidDependencies;
 
@@ -435,8 +443,10 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    * this reason, the plugin defaults this setting to being enabled. If you wish to not fail, you
    * can explicitly set this to {@code false} instead.
    *
+   * @deprecated will be removed in v4.0.0: missing sources will always be an error.
    * @since 0.5.0
    */
+  @Deprecated(since = "3.10.1", forRemoval = true)
   @Parameter(defaultValue = DEFAULT_TRUE)
   boolean failOnMissingSources;
 
@@ -688,8 +698,11 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
   /**
    * Generate Objective-C sources from the protobuf sources.
    *
+   * @deprecated will be removed in v4.0.0. Users wishing to generate Objective-C sources
+   *     should use the {@code arguments} to specify {@code --objc_out=path}.
    * @since 1.1.0
    */
+  @Deprecated(since = "3.10.1", forRemoval = true)
   @Parameter(defaultValue = DEFAULT_FALSE)
   boolean objcEnabled;
 
@@ -794,8 +807,11 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
   /**
    * Generate PHP sources from the protobuf sources.
    *
+   * @deprecated will be removed in v4.0.0. Users wishing to generate PHP sources
+   *     should use the {@code arguments} to specify {@code --php_out=path}.
    * @since 1.1.0
    */
+  @Deprecated(since = "3.10.1", forRemoval = true)
   @Parameter(defaultValue = DEFAULT_FALSE)
   boolean phpEnabled;
 
@@ -900,8 +916,11 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
   /**
    * Generate Rust sources from the protobuf sources.
    *
+   * @deprecated will be removed in v4.0.0. Users wishing to generate Rust sources
+   *     should use the {@code arguments} to specify {@code --rust_out=path}.
    * @since 1.1.0
    */
+  @Deprecated(since = "3.10.1", forRemoval = true)
   @Parameter(defaultValue = DEFAULT_FALSE)
   boolean rustEnabled;
 
@@ -1108,6 +1127,7 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    * @throws MojoFailureException   if an error occurs.
    */
   @Override
+  @SuppressWarnings("removal")
   public void execute() throws MojoExecutionException, MojoFailureException {
     if (skip) {
       log.info("Execution of this plugin has been skipped in the configuration");

--- a/protobuf-maven-plugin/src/site/markdown/other-language-support.md
+++ b/protobuf-maven-plugin/src/site/markdown/other-language-support.md
@@ -21,18 +21,6 @@ To enable other languages, use the following attributes within your `configurati
   </thead>
   <tbody>
     <tr>
-      <td>C++</td>
-      <td><code>cppEnabled</code></td>
-      <td><code>false</code></td>
-      <td/>
-    </tr>
-    <tr>
-      <td>C#</td>
-      <td><code>csharpEnabled</code></td>
-      <td><code>false</code></td>
-      <td/>
-    </tr>
-    <tr>
       <td>Java</td>
       <td><code>javaEnabled</code></td>
       <td><code>true</code></td>
@@ -43,18 +31,6 @@ To enable other languages, use the following attributes within your `configurati
       <td><code>kotlinEnabled</code></td>
       <td><code>false</code></td>
       <td>Generates JVM Kotlin descriptors. You should also ensure <code>javaEnabled</code> is true.</td>
-    </tr>
-    <tr>
-      <td>Objective-C</td>
-      <td><code>objcEnabled</code></td>
-      <td><code>false</code></td>
-      <td/>
-    </tr>
-    <tr>
-      <td>PHP</td>
-      <td><code>phpEnabled</code></td>
-      <td><code>false</code></td>
-      <td/>
     </tr>
     <tr>
       <td>Python</td>
@@ -74,14 +50,11 @@ To enable other languages, use the following attributes within your `configurati
       <td><code>false</code></td>
       <td/>
     </tr>
-    <tr>
-      <td>Rust</td>
-      <td><code>rustEnabled</code></td>
-      <td><code>false</code></td>
-      <td/>
-    </tr>
   </tbody>
 </table>
+
+Any other languages natively available in `protoc` can be enabled by passing `<arguments/>`
+in the plugin configuration (e.g. `--cpp_out=target/cpp` for C++).
 
 Any other language integrations can be provided to this plugin in the shape of
 third-party custom `protoc` plugins.

--- a/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/mojo/AbstractGenerateMojoTestTemplate.java
+++ b/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/mojo/AbstractGenerateMojoTestTemplate.java
@@ -76,6 +76,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.quality.Strictness;
 
+@SuppressWarnings("removal")
 abstract class AbstractGenerateMojoTestTemplate<A extends AbstractGenerateMojo> {
 
   @TempDir


### PR DESCRIPTION
Deprecate for removal any functionality we do not wish to continue to maintain.

---

* Native protoc outputs with no native tooling/toolchains, or that is otherwise difficult to test
    * Objective-C - no common tooling exists in Maven.
    * C++ - no common tooling exists in Maven.
    * C# - Plexus tooling exists, but users are encouraged to use MSBuild or similar.
    * PHP - no common tooling exists.
    * Rust - no common tooling exists, users will prefer to use Cargo.
    * Support for languages with JVM implementations, or GraalVM implementations, **will be kept**. This includes Java, Kotlin, Ruby (via JRuby and GraalRuby), Python (via Jython and GraalPython), and Python stubs (complimenting Python).
    * Users utilising deprecated languages can move to passing the flags directly via `<arguments/>` to continue to support their builds through version 4.

* Unhelpful functionality:
    * Failing on invalid dependencies - we will always ignore invalid dependencies, leaving the user to verify the integrity of the rest of their project via Maven warnings. This is already the default, but users almost never have full control of their entire dependency graph, and full project level validation is out of scope for this Maven plugin.
    * Failing on missing sources - we do this by default, and moving forward, we plan to always enforce this. Users performing builds with no input sources is almost always indicative of a further configuration issue. Users should ensure correct project configuration where possible and set `<skip/>` in cases where they know that nothing will be built.

---

These points are all up for further discussion prior to v4.0.0; if valid use cases are presented, the decision can be reverted.

Please discuss on GH-822.

The plan for now is to mark these attributes as deprecated for removal in the next patch release.