### PR TITLE
Remove outdated doc regarding output dirs being cleaned by default

### DIFF
--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/AbstractGenerateMojo.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/AbstractGenerateMojo.java
@@ -109,7 +109,7 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
   /**
    * Binary plugins to use with the protobuf compiler, sourced from a Maven repository.
    *
-   * <p>Bianry plugins are {@code protoc} plugins that are regular executables, and thus can work
+   * <p>Binary plugins are {@code protoc} plugins that are regular executables, and thus can work
    * with {@code protoc} out of the box.
    *
    * <p>Plugin artifacts must be a <strong>native executable</strong>. By default, the OS and CPU
@@ -168,7 +168,7 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
   /**
    * Binary plugins to use with the protobuf compiler, sourced from the system {@code PATH}.
    *
-   * <p>Bianry plugins are {@code protoc} plugins that are regular executables, and thus can work
+   * <p>Binary plugins are {@code protoc} plugins that are regular executables, and thus can work
    * with {@code protoc} out of the box.
    *
    * <p>For example:
@@ -224,7 +224,7 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
   /**
    * Binary plugins to use with the protobuf compiler, specified as a valid URL.
    *
-   * <p>Bianry plugins are {@code protoc} plugins that are regular executables, and thus can work
+   * <p>Binary plugins are {@code protoc} plugins that are regular executables, and thus can work
    * with {@code protoc} out of the box.
    *
    * <p>For example:
@@ -582,9 +582,6 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
    * <p>When enabled, this plugin will track changes to sources and importable protobuf
    * dependencies between builds, making a best-effort attempt to only rebuild files when
    * changes have been made since the last build.
-   *
-   * <p>Note that when disabled, any output directories and their contents will be deleted prior
-   * to invoking protoc to ensure clean builds.
    *
    * @since 2.7.0
    */


### PR DESCRIPTION
If I understand it correctly, the output directories are only cleaned when explicitly enabled, so that part of the documentation was probably a leftover from the original implementation. See also https://github.com/ascopes/protobuf-maven-plugin/issues/719#issuecomment-3016438823.