### PR TITLE
Add missing tests for ApacheUrlStreamHandlerFactory

### DIFF
--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/urls/AbstractNestingUrlConnection.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/urls/AbstractNestingUrlConnection.java
@@ -38,7 +38,7 @@ abstract class AbstractNestingUrlConnection extends URLConnection {
 
   AbstractNestingUrlConnection(URL url, URL nestedUrl) {
     super(url);
-    this.nestedUrl = nestedUrl;
+    this.nestedUrl = requireNonNull(nestedUrl);
 
     // No output for you.
     setDoOutput(false);
@@ -87,7 +87,10 @@ abstract class AbstractNestingUrlConnection extends URLConnection {
   }
 
   private InputStream constructInputStream() throws NestedUrlException {
-    requireNonNull(nestedConnection, "not connected");
+    requireNonNull(
+        nestedConnection,
+        () -> "internals are not connected to '" + nestedUrl + "', this is a bug!"
+    );
 
     try {
       // Side effects - eww.

--- a/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/urls/AbstractNestingUrlConnectionTest.java
+++ b/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/urls/AbstractNestingUrlConnectionTest.java
@@ -306,7 +306,7 @@ class AbstractNestingUrlConnectionTest {
     // Then
     assertThatExceptionOfType(NullPointerException.class)
         .isThrownBy(connection::getInputStream)
-        .withMessage("not connected");
+        .withMessage("internals are not connected to '%s', this is a bug!", innerUrl);
   }
 
   @DisplayName("the exception is reraised if the nested input stream raises a NestedUrlException")

--- a/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/urls/ApacheArchiveUrlStreamHandlerFactoryTest.java
+++ b/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/urls/ApacheArchiveUrlStreamHandlerFactoryTest.java
@@ -15,17 +15,141 @@
  */
 package io.github.ascopes.protobufmavenplugin.urls;
 
-import org.junit.jupiter.api.Disabled;
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayOutputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 @DisplayName("ApacheArchiveUrlStreamHandlerFactory tests")
 class ApacheArchiveUrlStreamHandlerFactoryTest {
 
-  @Disabled("TODO")
-  @DisplayName("ApacheArchiveUrlStreamHandlerFactory test case")
+  UrlFactory urlFactory;
+
+  ApacheArchiveUrlStreamHandlerFactory urlStreamHandlerFactory;
+
+  @BeforeEach
+  void setUp() {
+    urlFactory = mock();
+    urlStreamHandlerFactory = new ApacheArchiveUrlStreamHandlerFactory(
+        urlFactory,
+        TarArchiveInputStream::new,
+        "tar"
+    );
+  }
+
+  @DisplayName("missing path fragments (xxx!/yyy) are invalid")
+  @ValueSource(strings = {
+      "tar:/",
+      "tar:/foo",
+      "tar:http://example.com",
+      "tar:file:foo/bar/baz",
+  })
+  @ParameterizedTest(name = "for URL \"{0}\"")
+  void missingPathFragmentsAreInvalid(String rawUrl) throws Exception {
+    // Given
+    var url = urlOf(rawUrl);
+
+    // Then
+    assertThatExceptionOfType(IOException.class)
+        .isThrownBy(url::openConnection)
+        .withMessage(
+            "URI '%s' was missing a nested path fragment (e.g. "
+                + "'tar:http://some-website.com/some-file!/path/within/archive')",
+            rawUrl
+        );
+  }
+
+  @DisplayName("FileNotFoundException is raised if no entry matching the given name is found")
+  @ValueSource(strings = {
+      "",
+      "./.",
+      "missing.txt",
+      "./missing.txt"
+  })
+  @ParameterizedTest(name = "for requested TAR entry \"{0}\"")
+  void fileNotFoundExceptionRaisedIfNoEntryMatchingGivenNameIsFound(
+      String missingTarEntry
+  ) throws Exception {
+    // Given
+    var safeTarEntry = missingTarEntry.replaceAll("^\\./", "");
+    var tarFileUrl = urlForTestFile("example.tar");
+    var url = urlOf("tar", tarFileUrl, missingTarEntry);
+    when(urlFactory.create(any())).thenReturn(tarFileUrl);
+
+    // When
+    var conn = url.openConnection();
+    conn.connect();
+
+    // Then
+    assertThatExceptionOfType(AbstractNestingUrlConnection.NestedUrlException.class)
+        .isThrownBy(conn::getInputStream)
+        .withMessage(
+            "Failed to transfer '%s' wrapped with handler for protocol 'tar', an inner "
+                + "exception was raised: %s: Could not find '%s' within %s",
+            tarFileUrl,
+            FileNotFoundException.class.getName(),
+            safeTarEntry,
+            TarArchiveInputStream.class.getSimpleName()
+        )
+        .havingCause()
+        .isInstanceOf(FileNotFoundException.class)
+        .withMessage(
+            "Could not find '%s' within %s",
+            safeTarEntry,
+            TarArchiveInputStream.class.getSimpleName()
+        );
+  }
+
+  @DisplayName("file contents are read successfully from the archive")
   @Test
-  void apacheArchiveUrlStreamHandlerFactoryTest() {
-    // Nothing
+  void fileContentsAreReadSuccessfullyFromTheArchive() throws Exception {
+    // Given
+    var tarFileUrl = urlForTestFile("example.tar");
+    var url = urlOf("tar", tarFileUrl, "foo.txt");
+    when(urlFactory.create(any())).thenReturn(tarFileUrl);
+
+    // When
+    var baos = new ByteArrayOutputStream();
+    var conn = url.openConnection();
+    conn.connect();
+    try (var is = conn.getInputStream()) {
+      is.transferTo(baos);
+    }
+
+    // Then
+    assertThat(baos.toString(StandardCharsets.UTF_8))
+        .as("contents extracted from %s", url)
+        .isEqualTo("this is called foo\n");
+  }
+
+  URL urlOf(String scheme, URL inner, String path) throws Exception {
+    return urlOf(scheme + ":" + inner + "!/" + path);
+  }
+
+  URL urlOf(String spec) throws Exception {
+    return new URL(null, spec, urlStreamHandlerFactory.createURLStreamHandler("tar"));
+  }
+
+  URL urlForTestFile(String name) throws Exception {
+    var path = Path.of("src", "test", "resources");
+    for (var frag : getClass().getPackageName().split("\\.")) {
+      path = path.resolve(frag);
+    }
+    return path.resolve(name).toUri().toURL();
   }
 }


### PR DESCRIPTION
Adds the rest of the URL test cases we were missing.