### PR TITLE
GH-853: Fix minimum version for Sisu, add missing converters

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,6 +69,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - title: lnx/x86/mvn3.9.6/jdk17
+            os-name: ubuntu-24.04
+            java-version: 17
+            maven-version: 3.9.6  # Minimun version
+
           # Note: this runner is expensive!
           - title: osx/arm/mvn${{ needs.validate.outputs.default_maven_version }}/jdk17
             os-name: macos-15

--- a/protobuf-maven-plugin/pom.xml
+++ b/protobuf-maven-plugin/pom.xml
@@ -31,7 +31,8 @@
   <packaging>maven-plugin</packaging>
 
   <prerequisites>
-    <maven>3.9</maven>
+    <!-- Versions before 3.9.6 cannot handle Java 17 bytecode in Eclipse Sisu. -->
+    <maven>3.9.6</maven>
   </prerequisites>
 
   <dependencies>

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/fs/PathPlexusConverter.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/fs/PathPlexusConverter.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2023 - 2025, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.ascopes.protobufmavenplugin.fs;
+
+import java.io.File;
+import java.nio.file.Path;
+import org.codehaus.plexus.component.configurator.ComponentConfigurationException;
+import org.codehaus.plexus.component.configurator.ConfigurationListener;
+import org.codehaus.plexus.component.configurator.converters.basic.FileConverter;
+import org.codehaus.plexus.component.configurator.converters.lookup.ConverterLookup;
+import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluator;
+import org.codehaus.plexus.configuration.PlexusConfiguration;
+import org.jspecify.annotations.Nullable;
+
+
+/**
+ * Plexus/Sisu parameter converter for Path objects on the root file system.
+ *
+ * <p>We provide this to avoid using the URL and File APIs in the Mojo interface.
+ *
+ * <p>Newer versions of Plexus/Sisu provide this for us, so in the future, we can remove these
+ * components (looks to be supported from Maven 3.9.8).
+ *
+ * @author Ashley Scopes
+ * @since 3.1.3
+ */
+public final class PathPlexusConverter extends FileConverter {
+
+  @Override
+  public boolean canConvert(Class<?> type) {
+    return Path.class.equals(type);
+  }
+
+  @Override
+  public Object fromConfiguration(
+      ConverterLookup lookup,
+      PlexusConfiguration configuration,
+      Class<?> type,
+      @Nullable Class<?> enclosingType,
+      @Nullable ClassLoader loader,
+      ExpressionEvaluator evaluator,
+      @Nullable ConfigurationListener listener
+  ) throws ComponentConfigurationException {
+    // GH-689: we need to consider paths as relative to the Maven project directory rather
+    // than relative to the current working directory. This is important when running nested
+    // Maven modules that are expected to assume the submodule directory rather than the launch
+    // site directory.
+    //
+    // For now, we do the same thing that Sisu is doing in Maven 3.9.x to retain backwards and
+    // forwards compatibility. This handles any other niche cases we might miss as well.
+    // See https://github.com/eclipse-sisu/sisu-project/blob/e86e5005ff03b57aab8c7eb7f54f41e85914e2dd/org.eclipse.sisu.plexus/src/main/java/org/codehaus/plexus/component/configurator/converters/basic/PathConverter.java#L33
+
+    var result = super.fromConfiguration(
+        lookup, configuration, type, enclosingType, loader, evaluator, listener
+    );
+
+    return result instanceof File
+        ? ((File) result).toPath()
+        : result;
+  }
+}

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/ProtobufMavenPluginConfigurator.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/ProtobufMavenPluginConfigurator.java
@@ -16,6 +16,8 @@
 package io.github.ascopes.protobufmavenplugin.mojo;
 
 import io.github.ascopes.protobufmavenplugin.digests.DigestPlexusConverter;
+import io.github.ascopes.protobufmavenplugin.fs.PathPlexusConverter;
+import io.github.ascopes.protobufmavenplugin.urls.UriPlexusConverter;
 import javax.inject.Named;
 import javax.inject.Singleton;
 import org.codehaus.plexus.component.configurator.BasicComponentConfigurator;
@@ -37,5 +39,7 @@ public class ProtobufMavenPluginConfigurator extends BasicComponentConfigurator 
 
   ProtobufMavenPluginConfigurator() {
     converterLookup.registerConverter(new DigestPlexusConverter());
+    converterLookup.registerConverter(new PathPlexusConverter());
+    converterLookup.registerConverter(new UriPlexusConverter());
   }
 }

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/urls/UriPlexusConverter.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/urls/UriPlexusConverter.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2023 - 2025, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.ascopes.protobufmavenplugin.urls;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import org.codehaus.plexus.component.configurator.ComponentConfigurationException;
+import org.codehaus.plexus.component.configurator.converters.basic.AbstractBasicConverter;
+
+
+/**
+ * Plexus/Sisu parameter converter for URIs.
+ *
+ * <p>We provide this to avoid using the URL and File APIs in the Mojo interface. URLs do an
+ * immediate lookup for the URL scheme's appropriate URLStreamHandlerProvider upon construction, and
+ * we have no control over how that works. We have no ability to inject custom URL handlers at this
+ * point because the URL class is hardcoded to only consider the system classloader. Since Maven
+ * uses ClassWorlds to run multiple classloaders for each plugin and component, we will not be
+ * loaded as part of that default classloader. By deferring this operation to as late as possible
+ * (i.e. in {@link UriResourceFetcher}), we can
+ * ensure we provide the desired URL handler directly instead. This allows us to hook custom URL
+ * handlers in via {@link java.util.ServiceLoader} dynamically, like we would be able to outside a
+ * Maven plugin running in Plexus.
+ *
+ * <p>Newer versions of Plexus/Sisu provide this for us, so in the future, we can remove these
+ * components (looks to be supported from Maven 3.9.8).
+ *
+ * @author Ashley Scopes
+ * @since 3.1.3
+ */
+public final class UriPlexusConverter extends AbstractBasicConverter {
+
+  @Override
+  public boolean canConvert(Class<?> type) {
+    return URI.class.equals(type);
+  }
+
+  @Override
+  protected Object fromString(String str) throws ComponentConfigurationException {
+    try {
+      return new URI(str);
+    } catch (URISyntaxException ex) {
+      // GH-689: align with the same error format as Sisu provides in Maven 3.9.x for
+      // forwards compatibility.
+      throw new ComponentConfigurationException("Cannot convert '" + str + "' to URI", ex);
+    }
+  }
+}

--- a/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/fs/PathPlexusConverterTest.java
+++ b/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/fs/PathPlexusConverterTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (C) 2023 - 2025, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.ascopes.protobufmavenplugin.fs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.nio.file.Path;
+import org.codehaus.plexus.component.configurator.ComponentConfigurationException;
+import org.codehaus.plexus.component.configurator.converters.lookup.DefaultConverterLookup;
+import org.codehaus.plexus.component.configurator.expression.DefaultExpressionEvaluator;
+import org.codehaus.plexus.configuration.DefaultPlexusConfiguration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+@DisplayName("PathPlexusConverter tests")
+class PathPlexusConverterTest {
+
+  PathPlexusConverter converter;
+
+  @BeforeEach
+  void setUp() {
+    converter = new PathPlexusConverter();
+  }
+
+  @DisplayName("only the expected types are convertible")
+  @CsvSource({
+      "     java.nio.file.Path,  true",
+      "           java.net.URI, false",
+      "       java.lang.Object, false",
+      "      java.lang.Integer, false",
+      "        java.lang.Class, false",
+      "       java.lang.String, false",
+      "java.lang.StringBuilder, false",
+      "           java.io.File, false",
+      "           java.net.URL, false",
+  })
+  @ParameterizedTest(name = "for {0}, expect {1}")
+  void onlyTheExpectedTypesAreConvertible(Class<?> type, boolean expectedResult) {
+    // Then
+    assertThat(converter.canConvert(type))
+        .isEqualTo(expectedResult);
+  }
+
+  @DisplayName("Relative paths can be parsed successfully")
+  @Test
+  void relativePathsCanBeParsedSuccessfully(
+      @TempDir Path baseDir
+  ) throws ComponentConfigurationException {
+    // Given
+    var expectedAbsolutePath = baseDir.resolve("foo").resolve("bar").resolve("baz.txt")
+        .toAbsolutePath();
+    var expectedPath = baseDir
+        .relativize(expectedAbsolutePath);
+    var converterLookup = new DefaultConverterLookup();
+    var configuration = new DefaultPlexusConfiguration("path", expectedPath.toString());
+    var evaluator = new SomeDirectoryRelativeExpressionEvaluator(baseDir);
+
+    // When
+    var result = converter.fromConfiguration(
+        converterLookup,
+        configuration,
+        Path.class,
+        null,
+        getClass().getClassLoader(),
+        evaluator,
+        null
+    );
+
+    // Then
+    assertThat(result).isInstanceOf(Path.class);
+    var resultPath = (Path) result;
+
+    assertThat(resultPath.toAbsolutePath())
+        .hasToString("%s", expectedAbsolutePath);
+  }
+
+  @DisplayName("Absolute paths can be parsed successfully")
+  @Test
+  void absolutePathsCanBeParsedSuccessfully(
+      @TempDir Path baseDir
+  ) throws ComponentConfigurationException {
+    // Given
+    var expectedPath = baseDir.resolve("foo").resolve("bar").resolve("baz.txt")
+        .toAbsolutePath();
+    var converterLookup = new DefaultConverterLookup();
+    var configuration = new DefaultPlexusConfiguration("path", expectedPath.toString());
+    var evaluator = new SomeDirectoryRelativeExpressionEvaluator(baseDir);
+
+    // When
+    var result = converter.fromConfiguration(
+        converterLookup,
+        configuration,
+        Path.class,
+        null,
+        getClass().getClassLoader(),
+        evaluator,
+        null
+    );
+
+    // Then
+    assertThat(result).isInstanceOf(Path.class);
+    var resultPath = (Path) result;
+
+    assertThat(resultPath.toAbsolutePath())
+        .hasToString("%s", expectedPath.toAbsolutePath());
+  }
+
+  @DisplayName("Null values are returned directly")
+  @Test
+  void nullValuesAreReturnedDirectly(
+      @TempDir Path baseDir
+  ) throws ComponentConfigurationException {
+    // Given
+    var converterLookup = new DefaultConverterLookup();
+    var configuration = new DefaultPlexusConfiguration("path", null);
+    var evaluator = new SomeDirectoryRelativeExpressionEvaluator(baseDir);
+
+    // When
+    var result = converter.fromConfiguration(
+        converterLookup,
+        configuration,
+        Path.class,
+        null,
+        getClass().getClassLoader(),
+        evaluator,
+        null
+    );
+
+    // Then
+    assertThat(result).isNull();
+  }
+
+  // Roughly equivalent to what Maven does, for the sake of this test.
+  static final class SomeDirectoryRelativeExpressionEvaluator extends DefaultExpressionEvaluator {
+
+    private final Path baseDir;
+
+    SomeDirectoryRelativeExpressionEvaluator(Path baseDir) {
+      this.baseDir = baseDir.toAbsolutePath();
+    }
+
+    @Override
+    public File alignToBaseDirectory(File file) {
+      if (file.isAbsolute()) {
+        return file;
+      }
+
+      var path = file.toPath();
+      var fullPath = baseDir;
+      for (var part : path) {
+        fullPath = fullPath.resolve(part);
+      }
+      return fullPath.toFile();
+    }
+  }
+}

--- a/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/urls/UriPlexusConverterTest.java
+++ b/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/urls/UriPlexusConverterTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2023 - 2025, Ashley Scopes.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.ascopes.protobufmavenplugin.urls;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import org.codehaus.plexus.component.configurator.ComponentConfigurationException;
+import org.codehaus.plexus.component.configurator.converters.lookup.DefaultConverterLookup;
+import org.codehaus.plexus.component.configurator.expression.DefaultExpressionEvaluator;
+import org.codehaus.plexus.configuration.DefaultPlexusConfiguration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+@DisplayName("UriPlexusConverter tests")
+class UriPlexusConverterTest {
+
+  UriPlexusConverter converter;
+
+  @BeforeEach
+  void setUp() {
+    converter = new UriPlexusConverter();
+  }
+
+  @DisplayName("only the expected types are convertible")
+  @CsvSource({
+      "           java.net.URI,  true",
+      "     java.nio.file.Path, false",
+      "       java.lang.Object, false",
+      "      java.lang.Integer, false",
+      "        java.lang.Class, false",
+      "       java.lang.String, false",
+      "java.lang.StringBuilder, false",
+      "           java.io.File, false",
+      "           java.net.URL, false",
+  })
+  @ParameterizedTest(name = "for {0}, expect {1}")
+  void onlyTheExpectedTypesAreConvertible(Class<?> type, boolean expectedResult) {
+    // Then
+    assertThat(converter.canConvert(type))
+        .isEqualTo(expectedResult);
+  }
+
+  @DisplayName("URIs can be parsed successfully")
+  @Test
+  void urisCanBeParsedSuccessfully() throws ComponentConfigurationException {
+    // Given
+    var uri = URI.create("https://google.com");
+    var converterLookup = new DefaultConverterLookup();
+    var configuration = new DefaultPlexusConfiguration("uri", uri.toString());
+    var evaluator = new DefaultExpressionEvaluator();
+
+    // When
+    var result = converter.fromConfiguration(
+        converterLookup,
+        configuration,
+        URI.class,
+        null,
+        getClass().getClassLoader(),
+        evaluator
+    );
+
+    // Then
+    assertThat(converter.fromString(uri.toString()))
+        .isEqualTo(uri);
+  }
+
+  @DisplayName("Invalid URIs raise an exception during parsing")
+  @Test
+  void invalidUrisRaiseAnExceptionDuringParsing() {
+    // Given
+    var converterLookup = new DefaultConverterLookup();
+    var configuration = new DefaultPlexusConfiguration("uri", "foo\\bar");
+    var evaluator = new DefaultExpressionEvaluator();
+
+    // Then
+    assertThatExceptionOfType(ComponentConfigurationException.class)
+        .isThrownBy(() -> converter.fromConfiguration(
+            converterLookup,
+            configuration,
+            URI.class,
+            null,
+            getClass().getClassLoader(),
+            evaluator,
+            null
+        ))
+        // Ignore the message here, it varies based on the platform the test is running.
+        // Windows produces a different issue since backslashes have a special meaning there.
+        .havingCause()
+        .isInstanceOf(URISyntaxException.class);
+  }
+
+  @DisplayName("Null values are returned directly")
+  @Test
+  void nullValuesAreReturnedDirectly() throws ComponentConfigurationException {
+    // Given
+    var converterLookup = new DefaultConverterLookup();
+    var configuration = new DefaultPlexusConfiguration("uri", null);
+    var evaluator = new DefaultExpressionEvaluator();
+
+    // When
+    var result = converter.fromConfiguration(
+        converterLookup,
+        configuration,
+        URI.class,
+        null,
+        getClass().getClassLoader(),
+        evaluator
+    );
+
+    // Then
+    assertThat(result).isNull();
+  }
+}


### PR DESCRIPTION
The version of Sisu used before Maven 3.9.6 is incompatible with Java 17 bytecode, so we must force a minimum version of 3.9.6.

It also appears that prior to 3.9.8, the Path and URI plexus converters are missing from Sisu, so reintroduce those.

Fixes GH-853.