### PR TITLE
GHSA-J2PC-V64R-MV4F: Fix digest not being verified for system path protoc

### DIFF
--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/protoc/ProtocResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/protoc/ProtocResolver.java
@@ -88,19 +88,20 @@ public final class ProtocResolver {
       );
     }
 
-    if (version.equalsIgnoreCase("PATH")) {
-      return systemPathResolver.resolve(EXECUTABLE_NAME);
-    }
+    Optional<Path> path;
 
-    // It is likely a URL, not a version string.
-    var path = version.contains(":")
-        ? resolveFromUri(version)
-        : resolveFromMavenRepositories(version);
+    if (version.equalsIgnoreCase("PATH")) {
+      path = systemPathResolver.resolve(EXECUTABLE_NAME);
+    } else if (version.contains(":")) {
+      path = resolveFromUri(version);
+    } else {
+      path = resolveFromMavenRepositories(version);
+    }
 
     if (path.isEmpty()) {
       return Optional.empty();
-
     }
+
     var resolvedPath = path.get();
 
     if (digest != null) {


### PR DESCRIPTION
Fixes an issue raised by GHSA-J2PC-V64R-MV4F which resulted in digest verification on the system path being ignored.

This was evaluated to have a very low CVS4 rating (1/10), and relies on the system already being in a compromised state to be exploited, so should likely have little to no real implications, however, it is unexpected and surprising behaviour and thus is fixed here, and will be backported under v3.9.2.