### PR TITLE
GH-856: Disable automated release notes that are noisy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -144,7 +144,7 @@ jobs:
         with:
           tag: v${{ needs.prepare.outputs.release_version }}
           name: v${{ needs.prepare.outputs.release_version }}
-          generateReleaseNotes: true
+          generateReleaseNotes: false
           token: ${{ secrets.GITHUB_TOKEN }}
 
   github-pages:


### PR DESCRIPTION
For now, I'll be writing the notes manually to keep them clearer for users.

Closes GH-856.