### PR TITLE
Run ErrorProne and NullAway as part of the build

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,3 +1,13 @@
 -XX:+CrashOnOutOfMemoryError
 -XX:+TieredCompilation
 -XX:TieredStopAtLevel=1
+--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,7 @@
     <!-- Dependencies -->
     <assertj.version>4.0.0-M1</assertj.version>
     <commons-compress.version>1.28.0</commons-compress.version>
+    <errorprone.version>2.44.0</errorprone.version>
     <immutables.version>2.11.6</immutables.version>
     <javax-annotation.version>1.3.2</javax-annotation.version>
     <jspecify.version>1.0.0</jspecify.version>
@@ -103,6 +104,7 @@
     <maven-resolver-api.version>1.9.24</maven-resolver-api.version>
     <memoryfilesystem.version>2.8.2</memoryfilesystem.version>
     <mockito.version>5.20.0</mockito.version>
+    <nullaway.version>0.12.12</nullaway.version>
     <protobuf.version>4.33.0</protobuf.version>
     <slf4j.version>2.0.17</slf4j.version>
     <wiremock.version>3.13.1</wiremock.version>
@@ -397,7 +399,14 @@
           <version>${maven-compiler-plugin.version}</version>
 
           <configuration>
-            <compilerArgs>
+            <annotationProcessorPaths combine.children="append">
+              <annotationProcessorPath>
+                <groupId>org.immutables</groupId>
+                <artifactId>value-processor</artifactId>
+                <version>${immutables.version}</version>
+              </annotationProcessorPath>
+            </annotationProcessorPaths>
+            <compilerArgs combine.children="append">
               <compilerArg>-Xlint:all,-classfile,-processing,-requires-automatic,-serial</compilerArg>
             </compilerArgs>
             <failOnWarning>true</failOnWarning>

--- a/protobuf-maven-plugin/pom.xml
+++ b/protobuf-maven-plugin/pom.xml
@@ -164,12 +164,6 @@
   <build>
     <plugins>
       <plugin>
-        <!-- Java compiler config. -->
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-      </plugin>
-
-      <plugin>
         <!-- Used for Mockito agent support in JDK21+. We have to know the JAR path of the dependency. -->
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
@@ -297,10 +291,8 @@
 
   <profiles>
     <profile>
-      <!--
-          Enabling this profile will enable the Java debugger socket and pause
-          execution of test projects until a remote debugger is attached.
-      -->
+      <!-- Enabling this profile will enable the Java debugger socket and pause
+           execution of test projects until a remote debugger is attached. -->
       <id>invoker-debug</id>
       <build>
         <pluginManagement>
@@ -324,10 +316,8 @@
     </profile>
 
     <profile>
-      <!--
-          Enabling this profile will force all tests to run using the
-          protoc binary that is on the system path.
-      -->
+      <!-- Enabling this profile will force all tests to run using the
+           protoc binary that is on the system path. -->
       <id>invoker-path-protoc</id>
       <build>
         <pluginManagement>
@@ -387,6 +377,61 @@
             <artifactId>maven-invoker-plugin</artifactId>
             <configuration>
               <cloneProjectsTo>${invoker-project-path-override}</cloneProjectsTo>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <!-- ErrorProne only works with Java 21 and newer. If we're on Java 17, we cannot
+           enable it within the compiler. This is somewhat unfortunate but should be okay
+           as a workaround for now since we build on multiple JDKs on GitHub. -->
+      <id>errorprone</id>
+      <activation>
+        <jdk>[21,)</jdk>
+      </activation>
+
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+
+            <configuration>
+              <annotationProcessorPaths>
+                <annotationProcessorPath>
+                  <groupId>com.google.errorprone</groupId>
+                  <artifactId>error_prone_core</artifactId>
+                  <version>${errorprone.version}</version>
+                </annotationProcessorPath>
+                <annotationProcessorPath>
+                  <!-- Override what Maven is pulling in. This is fine during compilation as our
+                       code doesn't use Guava at all. This is needed for ErrorProne to not crash
+                       on startup. -->
+                  <groupId>com.google.guava</groupId>
+                  <artifactId>guava</artifactId>
+                  <version>[33,)</version>
+                </annotationProcessorPath>
+                <annotationProcessorPath>
+                  <groupId>com.uber.nullaway</groupId>
+                  <artifactId>nullaway</artifactId>
+                  <version>${nullaway.version}</version>
+                </annotationProcessorPath>
+              </annotationProcessorPaths>
+
+              <compilerArgs>
+                <compilerArg>--should-stop=ifError=FLOW</compilerArg>
+                <compilerArg>
+                  -Xplugin:ErrorProne
+                  -XepDisableWarningsInGeneratedCode
+                  -XepExcludedPaths:.*/(target/generated.*|src/test)/.*
+                  -XepOpt:NullAway:AnnotatedPackages=io.github.ascopes.protobufmavenplugin
+                  <!-- See https://github.com/uber/NullAway/issues/1319 -->
+                  -XepOpt:NullAway:ExcludedFieldAnnotations=org.apache.maven.plugins.annotations.Parameter
+                </compilerArg>
+                <compilerArg>-XDcompilePolicy=simple</compilerArg>
+              </compilerArgs>
             </configuration>
           </plugin>
         </plugins>

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/fs/PathPlexusConverter.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/fs/PathPlexusConverter.java
@@ -67,8 +67,8 @@ public final class PathPlexusConverter extends FileConverter {
         lookup, configuration, type, enclosingType, loader, evaluator, listener
     );
 
-    return result instanceof File
-        ? ((File) result).toPath()
+    return result instanceof File file
+        ? file.toPath()
         : result;
   }
 }


### PR DESCRIPTION
Enable nullability analysis as part of builds.

A lot of hacking around with compiler config was needed to get ErrorProne to play ball with the project correctly. For now, I've moved it into a profile so I can easily disable it if it becomes more hassle than it is worth to enable it. It also has the issue of only supporting Java 21 or newer, so I've had to disable it on Java 17.