### PR TITLE
GH-873: Fix typo in documentation for dependency exclusions

### DIFF
--- a/protobuf-maven-plugin/src/site/markdown/dependencies.md
+++ b/protobuf-maven-plugin/src/site/markdown/dependencies.md
@@ -119,12 +119,12 @@ exclusion mechanism.
   <classifier>zip</classifier>
   <scope>compile</scope>
   
-  <excludes>
-    <exclude>
+  <exclusions>
+    <exclusion>
       <groupId>org.example</groupId>
       <artifactId>ticketsystem-beta-user-protos</artifactId>
-    </exclude>
-  </excludes>
+    </exclusion>
+  </exclusions>
 </dependency>
 ```
 


### PR DESCRIPTION
Closes GH-873

[skip ci]