### PR TITLE
Support GZIP transfer, improve user-agent management

### DIFF
--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/urls/UriResourceFetcher.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/urls/UriResourceFetcher.java
@@ -32,6 +32,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
 import java.util.regex.Pattern;
+import java.util.zip.GZIPInputStream;
 import javax.inject.Inject;
 import javax.inject.Named;
 import org.apache.maven.Maven;
@@ -52,6 +53,14 @@ import org.slf4j.LoggerFactory;
 @MojoExecutionScoped
 @Named
 public final class UriResourceFetcher {
+
+  private static final String GZIP = "gzip";
+  private static final String IDENTITY = "identity";
+
+  private static final String ACCEPT = "Accept";
+  private static final String ACCEPT_VALUE = "*/*";
+  private static final String ACCEPT_ENCODING = "Accept-Encoding";
+  private static final String ACCEPT_ENCODING_VALUE = String.join(", ", GZIP, IDENTITY);
 
   // Protocols that we allow in offline mode.
   private static final Pattern OFFLINE_PROTOCOLS = Pattern.compile("^([A-Za-z0-9-]+:)*file:.*");
@@ -149,7 +158,7 @@ public final class UriResourceFetcher {
 
       try (
           // This should always result in the underlying connections being closed.
-          var responseInputStream = new BufferedInputStream(conn.getInputStream());
+          var responseInputStream = getDecodedResponseBody(conn);
           var fileOutputStream = FileUtils.newBufferedOutputStream(targetFile)
       ) {
         responseInputStream.transferTo(fileOutputStream);
@@ -198,6 +207,8 @@ public final class UriResourceFetcher {
     conn.setDoInput(true);
     conn.setDoOutput(false);
     conn.setReadTimeout(TIMEOUT);
+    conn.addRequestProperty(ACCEPT, ACCEPT_VALUE);
+    conn.addRequestProperty(ACCEPT_ENCODING, ACCEPT_ENCODING_VALUE);
     conn.addRequestProperty(USER_AGENT, USER_AGENT_VALUE);
     conn.setUseCaches(false);
     return conn;
@@ -214,6 +225,16 @@ public final class UriResourceFetcher {
     return temporarySpace
         .createTemporarySpace("url", url.getProtocol())
         .resolve(fileName + extension);
+  }
+
+  private BufferedInputStream getDecodedResponseBody(URLConnection conn) throws IOException {
+    if (GZIP.equalsIgnoreCase(conn.getContentEncoding())) {
+      log.trace("decoding response as GZIP-encoded payload");
+      return new BufferedInputStream(new GZIPInputStream(conn.getInputStream()));
+    }
+
+    log.trace("treating response as an unencoded payload");
+    return new BufferedInputStream(conn.getInputStream());
   }
 
   private static String userAgentValue(@Nullable Object value) {

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/urls/UriResourceFetcher.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/urls/UriResourceFetcher.java
@@ -15,6 +15,8 @@
  */
 package io.github.ascopes.protobufmavenplugin.urls;
 
+import static java.util.Objects.requireNonNullElse;
+
 import io.github.ascopes.protobufmavenplugin.digests.Digest;
 import io.github.ascopes.protobufmavenplugin.fs.FileUtils;
 import io.github.ascopes.protobufmavenplugin.fs.TemporarySpace;
@@ -36,6 +38,7 @@ import org.apache.maven.Maven;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.execution.scope.MojoExecutionScoped;
 import org.eclipse.sisu.Description;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,16 +56,18 @@ public final class UriResourceFetcher {
   // Protocols that we allow in offline mode.
   private static final Pattern OFFLINE_PROTOCOLS = Pattern.compile("^([A-Za-z0-9-]+:)*file:.*");
 
+  private static final String USER_AGENT = "User-Agent";
+
   // Fetch our version from our JAR when it is available. For unit tests, etc., this will usually
-  // be null.
-  private static final String USER_AGENT = String.format(
+  // be null as no MANIFEST.MF will have been created yet.
+  private static final String USER_AGENT_VALUE = String.format(
       "protobuf-maven-plugin/%s (io.github.ascopes) Apache-Maven/%s Java/%s (%s, %s, %s)",
-      UriResourceFetcher.class.getPackage().getImplementationVersion(),
-      Maven.class.getPackage().getImplementationVersion(),
-      System.getProperty("java.version"),
-      System.getProperty("java.vm.name"),
-      System.getProperty("java.vm.version"),
-      System.getProperty("java.vm.vendor")
+      userAgentValue(UriResourceFetcher.class.getPackage().getImplementationVersion()),
+      userAgentValue(Maven.class.getPackage().getImplementationVersion()),
+      userAgentValue(System.getProperty("java.version")),
+      userAgentValue(System.getProperty("java.vm.name")),
+      userAgentValue(System.getProperty("java.vm.version")),
+      userAgentValue(System.getProperty("java.vm.vendor"))
   );
 
   private static final int TIMEOUT = 30_000;
@@ -188,12 +193,12 @@ public final class UriResourceFetcher {
     // even crash JUnit because of this!
     // See https://github.com/junit-team/junit5/issues/4567.
     var conn = url.openConnection();
-    conn.addRequestProperty("User-Agent", USER_AGENT);
     conn.setAllowUserInteraction(false);
     conn.setConnectTimeout(TIMEOUT);
     conn.setDoInput(true);
     conn.setDoOutput(false);
     conn.setReadTimeout(TIMEOUT);
+    conn.addRequestProperty(USER_AGENT, USER_AGENT_VALUE);
     conn.setUseCaches(false);
     return conn;
   }
@@ -209,5 +214,9 @@ public final class UriResourceFetcher {
     return temporarySpace
         .createTemporarySpace("url", url.getProtocol())
         .resolve(fileName + extension);
+  }
+
+  private static String userAgentValue(@Nullable Object value) {
+    return requireNonNullElse(value, "unspecified").toString();
   }
 }

--- a/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/urls/UriResourceFetcherTest.java
+++ b/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/urls/UriResourceFetcherTest.java
@@ -36,6 +36,7 @@ import io.github.ascopes.protobufmavenplugin.fs.FileUtils;
 import io.github.ascopes.protobufmavenplugin.fs.TemporarySpace;
 import io.github.ascopes.protobufmavenplugin.utils.ResolutionException;
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -46,6 +47,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.stream.Stream;
+import java.util.zip.GZIPOutputStream;
 import org.apache.maven.execution.MavenSession;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -142,7 +144,7 @@ class UriResourceFetcherTest {
   @ParameterizedTest(name = "for URI {0}")
   void urisAreResolvedAndStoredInLocalFiles(URI uri) throws Exception {
     // Given
-    var url = someUrlWithResolvedContent(uri, "foobar");
+    var url = someUrlWithResolvedContent(uri, false, "foobar");
     when(urlFactory.create(any()))
         .thenReturn(url);
 
@@ -176,12 +178,54 @@ class UriResourceFetcherTest {
     verify(temporarySpace).createTemporarySpace("url", uri.getScheme());
   }
 
+  @DisplayName("URIs with GZIPped contents are resolved, decompressed, and stored in local files")
+  @MethodSource("remoteUris")
+  @ParameterizedTest(name = "for URI {0}")
+  void urisWithGzippedContentsAreResolvedDecompressedAndStoredInLocalFiles(URI uri)
+      throws Exception {
+
+    // Given
+    var url = someUrlWithResolvedContent(uri, true, "foobar");
+    when(urlFactory.create(any()))
+        .thenReturn(url);
+
+    Path expectedFile;
+    if (uri.getPath() == null) {
+      expectedFile = temporarySpaceDir
+          .resolve(
+              Digest.compute("SHA-1", url.toExternalForm()).toHexString()
+                  + ".ext"
+          );
+    } else {
+      expectedFile = temporarySpaceDir
+          .resolve(
+              uri.getPath().substring(uri.getPath().lastIndexOf("/") + 1)
+                  + "-"
+                  + Digest.compute("SHA-1", url.toExternalForm()).toHexString()
+                  + ".ext"
+          );
+    }
+
+    // When
+    var result = uriResourceFetcher.fetchFileFromUri(uri, ".ext", false);
+
+    // Then
+    assertThat(result)
+        .get(PATH)
+        .isEqualTo(expectedFile)
+        .hasBinaryContent("foobar".getBytes(StandardCharsets.UTF_8));
+
+    verify(urlFactory).create(uri);
+    verify(temporarySpace).createTemporarySpace("url", uri.getScheme());
+  }
+
+
   @DisplayName("URLConnections are configured with the expected attributes")
   @Test
   void urlConnectionsAreConfiguredWithTheExpectedAttributes() throws Exception {
     // Given
     var uri = URI.create("some://google.com/foo/bar/baz.txt");
-    var url = someUrlWithResolvedContent(uri, "bazbork");
+    var url = someUrlWithResolvedContent(uri, false, "bazbork");
     when(urlFactory.create(any()))
         .thenReturn(url);
 
@@ -217,7 +261,7 @@ class UriResourceFetcherTest {
     try (var fileUtilsMock = mockStatic(FileUtils.class, Answers.CALLS_REAL_METHODS)) {
       // Given
       var uri = URI.create("some://google.com/foo/bar/baz.txt");
-      var url = someUrlWithResolvedContent(uri, "bazbork");
+      var url = someUrlWithResolvedContent(uri, false, "bazbork");
       when(urlFactory.create(any()))
           .thenReturn(url);
 
@@ -259,7 +303,7 @@ class UriResourceFetcherTest {
   void urlConnectFailuresResultInAnExceptionBeingRaised() throws Exception {
     // Given
     var uri = URI.create("some://google.com/foo/bar/baz.txt");
-    var url = someUrlWithResolvedContent(uri, "bazbork");
+    var url = someUrlWithResolvedContent(uri, false, "bazbork");
     when(urlFactory.create(any()))
         .thenReturn(url);
     var cause = new IOException("bang");
@@ -286,7 +330,7 @@ class UriResourceFetcherTest {
   void urlTransferFailuresResultInAnExceptionBeingRaised() throws Exception {
     // Given
     var uri = URI.create("some://google.com/foo/bar/baz.txt");
-    var url = someUrlWithResolvedContent(uri, "bazbork");
+    var url = someUrlWithResolvedContent(uri, false, "bazbork");
     when(urlFactory.create(any()))
         .thenReturn(url);
 
@@ -318,7 +362,7 @@ class UriResourceFetcherTest {
   void fileNotFoundExceptionsRaisedDuringUrlConnectReturnEmptyResult() throws Exception {
     // Given
     var uri = URI.create("some://google.com/foo/bar/baz.txt");
-    var url = someUrlWithResolvedContent(uri, "bazbork");
+    var url = someUrlWithResolvedContent(uri, false, "bazbork");
     when(urlFactory.create(any()))
         .thenReturn(url);
     var cause = new FileNotFoundException("bang");
@@ -338,7 +382,7 @@ class UriResourceFetcherTest {
   void fileNotFoundExceptionsRaisedDuringUrlTransferReturnEmptyResult() throws Exception {
     // Given
     var uri = URI.create("some://google.com/foo/bar/baz.txt");
-    var url = someUrlWithResolvedContent(uri, "bazbork");
+    var url = someUrlWithResolvedContent(uri, false, "bazbork");
     when(urlFactory.create(any()))
         .thenReturn(url);
 
@@ -385,12 +429,29 @@ class UriResourceFetcherTest {
         .map(URI::create);
   }
 
-  static URL someUrlWithResolvedContent(URI uri, String content) throws Exception {
-    return someUrlWithResolvedContent(uri, content.getBytes(StandardCharsets.UTF_8));
+  static URL someUrlWithResolvedContent(URI uri, boolean gzip, String content) throws Exception {
+    return someUrlWithResolvedContent(uri, gzip, content.getBytes(StandardCharsets.UTF_8));
   }
 
-  static URL someUrlWithResolvedContent(URI uri, byte[] content) throws Exception {
+  static URL someUrlWithResolvedContent(URI uri, boolean gzip, byte[] content) throws Exception {
     var connection = mock(URLConnection.class);
+
+    if (gzip) {
+      lenient().when(connection.getContentEncoding())
+          .thenReturn("gzip");
+
+      try (var baos = new ByteArrayOutputStream()) {
+        var gzos = new GZIPOutputStream(baos);
+        gzos.write(content);
+        // Needed to finish writing the zlib footer.
+        gzos.close();
+        content = baos.toByteArray();
+      }
+    } else {
+      lenient().when(connection.getContentEncoding())
+          .thenReturn(null);
+    }
+
     lenient().when(connection.getInputStream())
         .thenReturn(new ByteArrayInputStream(content));
 


### PR DESCRIPTION
- Fix null values in `User-Agent` headers for URL transfers.
- Add missing `Accept` headers in URL transfers.
- Add support for consuming `gzip`-encoded response streams to reduce network footprint.