### PR TITLE
Speed up invoker plugin invocations

### DIFF
--- a/protobuf-maven-plugin/src/it/invoker-debug.properties
+++ b/protobuf-maven-plugin/src/it/invoker-debug.properties
@@ -19,6 +19,12 @@
 invoker.debug = true
 invoker.failureBehavior = fail-fast
 invoker.mavenOpts = \
+    ${invoker.mavenOpts} \
+    -Xshare:auto \
+    -XX:TieredStopAtLevel=1 \
+    -XX:+CrashOnOutOfMemoryError \
+    -XX:+TieredCompilation \
+    -XX:+UseParallelGC \
     -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=localhost:5005 \
     -Dorg.slf4j.simpleLogger.log.io.github.ascopes.protobufmavenplugin=TRACE \
     -Djacoco.skip

--- a/protobuf-maven-plugin/src/it/invoker-jfr.properties
+++ b/protobuf-maven-plugin/src/it/invoker-jfr.properties
@@ -19,6 +19,12 @@
 invoker.debug = false
 invoker.failureBehavior = fail-fast
 invoker.mavenOpts = \
+    ${invoker.mavenOpts} \
+    -Xshare:auto \
+    -XX:TieredStopAtLevel=1 \
+    -XX:+CrashOnOutOfMemoryError \
+    -XX:+TieredCompilation \
+    -XX:+UseParallelGC \
     -XX:+FlightRecorder \
     -XX:StartFlightRecording:settings=profile,filename=profile.jfr \
     -Djacoco.skip

--- a/protobuf-maven-plugin/src/it/invoker-path-protoc.properties
+++ b/protobuf-maven-plugin/src/it/invoker-path-protoc.properties
@@ -17,6 +17,12 @@
 # Note that this will disable JaCoCo injection that is configured in the pom.xml
 # of this project.
 invoker.mavenOpts = \
+    ${invoker.mavenOpts} \
+    -Xshare:auto \
+    -XX:TieredStopAtLevel=1 \
+    -XX:+CrashOnOutOfMemoryError \
+    -XX:+TieredCompilation \
+    -XX:+UseParallelGC \
     -Dprotobuf.compiler.version=PATH
 invoker.quiet = false
 invoker.timeoutInSeconds = 300

--- a/protobuf-maven-plugin/src/it/invoker.properties
+++ b/protobuf-maven-plugin/src/it/invoker.properties
@@ -14,5 +14,12 @@
 # limitations under the License.
 #
 
+invoker.mavenOpts = \
+    ${invoker.mavenOpts} \
+    -Xshare:auto \
+    -XX:TieredStopAtLevel=1 \
+    -XX:+CrashOnOutOfMemoryError \
+    -XX:+TieredCompilation \
+    -XX:+UseParallelGC
 invoker.quiet = false
 invoker.timeoutInSeconds = 300


### PR DESCRIPTION
Add JVM options to invoker plugin options to speed up execution.

This may or may not make a material difference here.

If no visible difference is made, this will not be merged.