### PR TITLE
GH-968: deprecate protocDigest and move inside protocDistribution models

### DIFF
--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/AbstractGenerateMojo.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/mojo/AbstractGenerateMojo.java
@@ -522,15 +522,14 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
   /**
    * Optional digest to verify {@code protoc} against.
    *
-   * <p>Generally, users should not need to provide this, as the Maven Central
-   * {@code protoc} binaries will already be digest-verified as part of distribution. Users may wish
-   * to specify this if using a {@code PATH}-based binary, or using a URL for {@code protoc}.
-   *
-   * <p>This is a string in the format {@code sha512:1a2b3c...}, using any
-   * message digest algorithm supported by the current JDK.
-   *
    * @since 3.5.0
+   * @deprecated this is deprecated for removal in a future version. Use
+   *     the {@code <digest/>} attribute on the path and URL protoc distribution
+   *     objects instead, moving forwards. See
+   *     <a href="https://ascopes.github.io/protobuf-maven-plugin/changing-protoc-versions.html">
+   *     "changing protoc versions"</a> for usage examples and documentation.
    */
+  @Deprecated(since = "5.1.4", forRemoval = true)
   @Parameter(property = "protobuf.compiler.digest")
   @Nullable Digest protocDigest;
 

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/ProtocPluginResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/plugins/ProtocPluginResolver.java
@@ -269,13 +269,13 @@ public final class ProtocPluginResolver {
       return;
     }
 
-    log.debug("Verifying digest of \"{}\" against \"{}\"", name, digest);
+    log.debug("Verifying digest of \"{}\" at \"{}\" against \"{}\"", name, file, digest);
 
     try (var is = new BufferedInputStream(Files.newInputStream(file))) {
       digest.verify(is);
     } catch (IOException ex) {
       throw new ResolutionException(
-          "Failed to compute digest of \"" + name + "\": " + ex,
+          "Failed to compute digest of \"" + name + "\" at \"" + file + "\": " + ex,
           ex
       );
     }

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/protoc/ProtocResolver.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/protoc/ProtocResolver.java
@@ -36,6 +36,8 @@ import javax.inject.Named;
 import org.apache.maven.execution.scope.MojoExecutionScoped;
 import org.eclipse.sisu.Description;
 import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Resolver for the {@code protoc} executable.
@@ -46,6 +48,8 @@ import org.jspecify.annotations.Nullable;
 @MojoExecutionScoped
 @Named
 public final class ProtocResolver {
+
+  private static final Logger log = LoggerFactory.getLogger(ProtocResolver.class);
 
   private final MavenArtifactPathResolver artifactPathResolver;
   private final PlatformClassifierFactory platformClassifierFactory;
@@ -69,36 +73,22 @@ public final class ProtocResolver {
       ProtocDistribution distribution,
       @Nullable Digest digest
   ) throws ResolutionException {
-    Optional<Path> path;
+    Optional<Path> maybePath;
 
     if (distribution instanceof BinaryMavenProtocDistribution bmpd) {
-      path = resolveBinaryMavenDistribution(bmpd);
+      maybePath = resolveBinaryMavenDistribution(bmpd);
     } else if (distribution instanceof PathProtocDistribution ppd) {
-      path = resolvePathDistribution(ppd);
+      maybePath = resolvePathDistribution(ppd);
     } else if (distribution instanceof UriProtocDistribution upd) {
-      path = resolveUriDistribution(upd);
+      maybePath = resolveUriDistribution(upd);
     } else {
       throw new UnsupportedOperationException("unsupported distribution " + distribution);
     }
 
-    if (path.isEmpty()) {
-      return Optional.empty();
-    }
+    // Deprecated for removal.
+    verifyDigest(distribution.toString(), maybePath.orElse(null), digest);
 
-    var resolvedPath = path.get();
-
-    if (digest != null) {
-      try (var is = new BufferedInputStream(Files.newInputStream(resolvedPath))) {
-        digest.verify(is);
-      } catch (IOException ex) {
-        throw new ResolutionException(
-            "Failed to compute digest of \"" + resolvedPath + "\": " + ex,
-            ex
-        );
-      }
-    }
-
-    return path;
+    return maybePath;
   }
 
   private Optional<Path> resolveBinaryMavenDistribution(
@@ -118,12 +108,43 @@ public final class ProtocResolver {
   private Optional<Path> resolveUriDistribution(
       UriProtocDistribution distribution
   ) throws ResolutionException {
-    return urlResourceFetcher.fetchFileFromUri(distribution.getUrl(), ".exe", true);
+    var maybePath = urlResourceFetcher.fetchFileFromUri(distribution.getUrl(), ".exe", true);
+
+    verifyDigest(
+        distribution.getUrl().toString(),
+        maybePath.orElse(null),
+        distribution.getDigest()
+    );
+
+    return maybePath;
   }
 
   private Optional<Path> resolvePathDistribution(
       PathProtocDistribution distribution
   ) throws ResolutionException {
-    return systemPathResolver.resolve(distribution.getName());
+    var maybePath = systemPathResolver.resolve(distribution.getName());
+
+    verifyDigest(distribution.getName(), maybePath.orElse(null), distribution.getDigest());
+
+    return maybePath;
+  }
+
+  private void verifyDigest(String name, @Nullable Path file, @Nullable Digest digest)
+      throws ResolutionException {
+
+    if (file == null || digest == null) {
+      return;
+    }
+
+    log.debug("Verifying digest of \"{}\" at \"{}\" against \"{}\"", name, file, digest);
+
+    try (var is = new BufferedInputStream(Files.newInputStream(file))) {
+      digest.verify(is);
+    } catch (IOException ex) {
+      throw new ResolutionException(
+          "Failed to compute digest of \"" + name + "\" at \"" + file + "\": " + ex,
+          ex
+      );
+    }
   }
 }

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/protoc/distributions/PathProtocDistribution.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/protoc/distributions/PathProtocDistribution.java
@@ -15,10 +15,12 @@
  */
 package io.github.ascopes.protobufmavenplugin.protoc.distributions;
 
+import io.github.ascopes.protobufmavenplugin.digests.Digest;
 import io.github.ascopes.protobufmavenplugin.plexus.KindHint;
 import org.immutables.value.Value.Default;
 import org.immutables.value.Value.Immutable;
 import org.immutables.value.Value.Modifiable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Model base for a {@code protoc} distribution that is located on the system {@code $PATH}.
@@ -42,4 +44,11 @@ public abstract non-sealed class PathProtocDistribution implements ProtocDistrib
   public String getName() {
     return "protoc";
   }
+
+  /**
+   * Get the digest.
+   *
+   * @return the digest or {@code null} if unset.
+   */
+  public abstract @Nullable Digest getDigest();
 }

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/protoc/distributions/UriProtocDistribution.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/protoc/distributions/UriProtocDistribution.java
@@ -15,10 +15,13 @@
  */
 package io.github.ascopes.protobufmavenplugin.protoc.distributions;
 
+import io.github.ascopes.protobufmavenplugin.digests.Digest;
 import io.github.ascopes.protobufmavenplugin.plexus.KindHint;
 import java.net.URI;
 import org.immutables.value.Value.Immutable;
 import org.immutables.value.Value.Modifiable;
+import org.jspecify.annotations.Nullable;
+
 
 /**
  * Model base for a {@code protoc} distribution that is located at a URI.
@@ -37,4 +40,11 @@ public abstract non-sealed class UriProtocDistribution implements ProtocDistribu
    * @return the URI.
    */
   public abstract URI getUrl();
+
+  /**
+   * Get the digest.
+   *
+   * @return the digest or {@code null} if unset.
+   */
+  public abstract @Nullable Digest getDigest();
 }

--- a/protobuf-maven-plugin/src/site/markdown/changing-protoc-versions.md
+++ b/protobuf-maven-plugin/src/site/markdown/changing-protoc-versions.md
@@ -100,6 +100,19 @@ be searched for files where their name matches `protoc` case-insensitively, igno
 extension. The file extension must match one of the extensions specified in the `%PATHEXT%`
 environment variable. The above example would match `protoc.exe` on Windows, as an example.
 
+Users can include a digest to verify the binary contents against if they require reproducible
+builds:
+
+```xml
+<protoc kind="path">
+  <name>protoc</name>
+  <digest>sha1:e4c905a33adcb9a589896d09f3604a7c5653b2c0</digest>
+</protoc>
+```
+
+The digest algorithm can be any algorithm supported by your JDK, such as `md5`, `sha1`,
+`sha256`, `sha512`, etc.
+
 ## Using protoc from a specific path
 
 You may wish to run `protoc` from a specific path on your file system. If you need to do this,
@@ -126,6 +139,19 @@ The syntax for this is `file://$PATH`, where `$PATH` is a relative or absolute p
 forward-slashes for this syntax rather than backslashes.
 
 Note that paths are resolved relative to the directory that Maven is invoked from.
+
+Users can include a digest to verify the binary contents against if they require reproducible
+builds:
+
+```
+<protoc kind="url">
+  <url>file:///opt/protoc/protoc.exe</url>
+  <digest>sha1:e4c905a33adcb9a589896d09f3604a7c5653b2c0</digest>
+</protoc>
+```
+
+The digest algorithm can be any algorithm supported by your JDK, such as `md5`, `sha1`,
+`sha256`, `sha512`, etc.
 
 ## Using protoc from a remote server
 
@@ -162,3 +188,16 @@ This is not recommended outside specific use cases, and care should be taken to 
 legitimacy and security of any URLs being provided prior to adding them.
 
 Providing authentication details or proxy details is not supported at this time.
+
+Users can include a digest to verify the binary contents against if they require reproducible
+builds:
+
+```xml
+<protoc kind="url">
+  <url>https://company-server.internal/protoc/protoc.exe</url>
+  <digest>sha1:e4c905a33adcb9a589896d09f3604a7c5653b2c0</digest>
+</protoc>
+```
+
+The digest algorithm can be any algorithm supported by your JDK, such as `md5`, `sha1`,
+`sha256`, `sha512`, etc.

--- a/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/mojo/AbstractGenerateMojoTestTemplate.java
+++ b/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/mojo/AbstractGenerateMojoTestTemplate.java
@@ -672,6 +672,8 @@ abstract class AbstractGenerateMojoTestTemplate<A extends AbstractGenerateMojo> 
   @NullSource
   @ValueSource(strings = "non-null")
   @ParameterizedTest(name = "for {0} digest")
+  @Deprecated(forRemoval = true)
+  @SuppressWarnings("removal")
   void protocDigestIsSetInTheRequest(@Nullable String digestValue) throws Throwable {
     // Given
     var digest = Optional.ofNullable(digestValue)


### PR DESCRIPTION
This deprecates protocDigest in the plugin configuration for eventual removal, and replaces it with a protocDistribution based digest attribute on path and URI distributions. This makes the API match the plugins API more consistently.

A side effect of this is that binary protoc distributions will not support digests in the future, but this is unadvisable behaviour anyway, given Maven already provides digest verification of the distributed binaries on Maven Central. Maven Central non-snapshot releases are also immutable generally anyway.

Fixes GH-968.