### PR TITLE
Added support for Solaris / illumos

### DIFF
--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/PlatformClassifierFactory.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/dependencies/PlatformClassifierFactory.java
@@ -54,6 +54,8 @@ public final class PlatformClassifierFactory {
       osKey = "linux";
     } else if (hostSystem.isProbablyMacOs()) {
       osKey = "macos";
+    } else if (hostSystem.isProbablySolaris()) {
+      osKey = "sunos";
     } else if (hostSystem.isProbablyWindows()) {
       osKey = "windows";
     } else {

--- a/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/system/HostSystem.java
+++ b/protobuf-maven-plugin/src/main/java/io/github/ascopes/protobufmavenplugin/system/HostSystem.java
@@ -126,6 +126,12 @@ public final class HostSystem {
     return operatingSystem.toLowerCase(Locale.ROOT).startsWith("mac");
   }
 
+  public boolean isProbablySolaris() {
+    var osNameNormalized = operatingSystem.toLowerCase(Locale.ROOT);
+
+    return osNameNormalized.startsWith("sunos") || osNameNormalized.startsWith("solaris");
+  }
+
   public boolean isProbablyWindows() {
     return operatingSystem.toLowerCase(Locale.ROOT).startsWith("win");
   }

--- a/protobuf-maven-plugin/src/main/resources/io/github/ascopes/protobufmavenplugin/dependencies/platforms.properties
+++ b/protobuf-maven-plugin/src/main/resources/io/github/ascopes/protobufmavenplugin/dependencies/platforms.properties
@@ -34,6 +34,20 @@ macos.amd64 = osx-x86_64
 macos.x86_64 = osx-x86_64
 
 #############
+## Solaris ##
+#############
+
+# Java on Solaris reports x86_64 as 'amd64' in 'os.arch'.
+sunos.amd64 = sunos-x86_64
+# There is no official protoc release for Solaris, so this resolves to a
+# custom-hosted artifact using 'sunos', as reported by Java in 'os.name'.
+sunos.x86_64 = sunos-x86_64
+# According to various sources the 'os.name' with 'Solaris' supposedly
+# exists, though I've never seen in "in the wild".
+solaris.amd64 = sunos-x86_64
+solaris.x86_64 = sunos-x86_64
+
+#############
 ## Windows ##
 #############
 

--- a/protobuf-maven-plugin/src/site/markdown/other-os-support.md
+++ b/protobuf-maven-plugin/src/site/markdown/other-os-support.md
@@ -1,0 +1,66 @@
+# Other OS support
+
+Not every OS has an official Java protocol buffers compiler (`protoc`) binary deployed to Maven Central. This plugin does however support detecting some of these OSes. For these OSes it still tries to download the `protoc` compiler the same way it would do for a supported OS. It is up to you to deploy the `protoc` binary for this unsupported OS to your local Maven repository.
+
+This is a list of OSes currently supported by this plugin which, do not have an official `protoc` binary deployed in Maven Central:
+
+* illumos / Solaris
+
+## Building protoc for illumos / Solaris
+
+Building the `protoc` binary for illumos and Solaris requires access to a machine or VM running illumos or Solaris. The following steps show how to build the `protoc` binary version 35.1 and how to deploy it to your own local Maven repository in such a way this plugin can automatically use it. This example uses a SmartOS (illumos) native zone with pkgsrc, but the instructions should be similar for other illumos distributions or Solaris.
+
+Install the required tooling for building protoc:
+
+```shell
+$ pkgin install git cmake gmake gcc13 openjdk21
+```
+
+Prepare the source tree for building version 35.1:
+
+```shell
+$ git clone https://github.com/protocolbuffers/protobuf.git
+$ cd protobuf/
+$ git checkout v35.1
+$ git submodule update --init --recursive
+```
+
+Build the Protobuf compiler:
+
+```shell
+$ rm -rf build CMakeCache.txt CMakeFiles
+$ cmake . -DCMAKE_CXX_STANDARD=17 \
+-DCMAKE_INSTALL_PREFIX=/opt/local \
+-Dprotobuf_BUILD_TESTS=OFF \
+-Dprotobuf_BUILD_LIBPROTOC=ON \
+-Dprotobuf_BUILD_PROTOC_BINARIES=ON \
+-Dprotobuf_BUILD_PROTOBUF_BINARIES=ON \
+-Dprotobuf_FORCE_FETCH_DEPENDENCIES=ON
+$ cmake --build . -j4
+```
+
+Remove the debug symbols (using `strip`) from the resulting executable and correct its name:
+
+```shell
+$ strip ./protoc
+$ mv ./protoc ~/protoc-4.35.1-sunos-x86_64.exe
+```
+
+You can now deploy the `protoc-4.35.1-sunos-x86_64.exe` (`protoc`) binary to your local Maven repository. 
+
+## Deploying a protoc binary to a repository
+
+Once you have build a `protoc` binary for an unsupported platform, you can deploy the binary to your Maven repository. This example shows how to deploy a `protoc` binary built for illumos to a local Maven repository in such a way that this plugin will automatically find it:
+
+```shell
+$ mvn deploy:deploy-file \
+-DrepositoryId=third-party \
+-Durl=https://reposilite.example.com/third-party/ \
+-Dfile="protoc-4.35.1-sunos-x86_64.exe" \
+-DgroupId="com.google.protobuf" \
+-DartifactId="protoc" \
+-Dversion="4.35.1" \
+-Dpackaging=exe \
+-Dclassifier="sunos-x86_64" \
+-DcreateChecksum=true
+```

--- a/protobuf-maven-plugin/src/site/site.xml
+++ b/protobuf-maven-plugin/src/site/site.xml
@@ -79,6 +79,7 @@
       <item name="Corporate Environments" href="corporate-environments.html"/>
       <item name="Faster Builds" href="faster-builds.html"/>
       <item name="Other Language Support" href="other-language-support.html"/>
+      <item name="Other OS Support" href="other-os-support.html"/>
       <item name="URL Support" href="url-support.html"/>
     </menu>
 

--- a/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/dependencies/PlatformClassifierFactoryTest.java
+++ b/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/dependencies/PlatformClassifierFactoryTest.java
@@ -20,6 +20,7 @@ import static io.github.ascopes.protobufmavenplugin.fixtures.HostSystemFixtures.
 import static io.github.ascopes.protobufmavenplugin.fixtures.HostSystemFixtures.linux;
 import static io.github.ascopes.protobufmavenplugin.fixtures.HostSystemFixtures.macOs;
 import static io.github.ascopes.protobufmavenplugin.fixtures.HostSystemFixtures.otherOs;
+import static io.github.ascopes.protobufmavenplugin.fixtures.HostSystemFixtures.solaris;
 import static io.github.ascopes.protobufmavenplugin.fixtures.HostSystemFixtures.windows;
 import static io.github.ascopes.protobufmavenplugin.fixtures.RandomFixtures.someBasicString;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -92,6 +93,8 @@ class PlatformClassifierFactoryTest {
         arguments(macOs().and(arch("amd64")), "osx-x86_64"),
         arguments(macOs().and(arch("x86_64")), "osx-x86_64"),
         arguments(macOs().and(arch("aarch64")), "osx-aarch_64"),
+        arguments(solaris().and(arch("amd64")), "sunos-x86_64"),
+        arguments(solaris().and(arch("x86_64")), "sunos-x86_64"),
         arguments(windows().and(arch("amd64")), "windows-x86_64"),
         arguments(windows().and(arch("x86_64")), "windows-x86_64"),
         arguments(windows().and(arch("x86")), "windows-x86_32"),
@@ -104,6 +107,7 @@ class PlatformClassifierFactoryTest {
     return Stream.of(
         linux().and(arch("some unknown CPU arch")),
         macOs().and(arch("some unknown CPU arch")),
+        solaris().and(arch("some unknown CPU arch")),
         windows().and(arch("some unknown CPU arch")),
         otherOs().and(arch("x86_32")),
         otherOs().and(arch("x86_64")),

--- a/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/fixtures/HostSystemFixtures.java
+++ b/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/fixtures/HostSystemFixtures.java
@@ -48,6 +48,7 @@ public final class HostSystemFixtures {
     return namedConfigurer("Linux", hs -> {
       when(hs.isProbablyLinux()).thenReturn(true);
       when(hs.isProbablyMacOs()).thenReturn(false);
+      when(hs.isProbablySolaris()).thenReturn(false);
       when(hs.isProbablyWindows()).thenReturn(false);
     });
   }
@@ -56,6 +57,16 @@ public final class HostSystemFixtures {
     return namedConfigurer("Mac OS", hs -> {
       when(hs.isProbablyLinux()).thenReturn(false);
       when(hs.isProbablyMacOs()).thenReturn(true);
+      when(hs.isProbablySolaris()).thenReturn(false);
+      when(hs.isProbablyWindows()).thenReturn(false);
+    });
+  }
+
+  public static HostSystemMockConfigurer solaris() {
+    return namedConfigurer("SunOS", hs -> {
+      when(hs.isProbablyLinux()).thenReturn(false);
+      when(hs.isProbablyMacOs()).thenReturn(false);
+      when(hs.isProbablySolaris()).thenReturn(true);
       when(hs.isProbablyWindows()).thenReturn(false);
     });
   }
@@ -64,6 +75,7 @@ public final class HostSystemFixtures {
     return namedConfigurer("Windows", hs -> {
       when(hs.isProbablyLinux()).thenReturn(false);
       when(hs.isProbablyMacOs()).thenReturn(false);
+      when(hs.isProbablySolaris()).thenReturn(false);
       when(hs.isProbablyWindows()).thenReturn(true);
     });
   }
@@ -72,6 +84,7 @@ public final class HostSystemFixtures {
     return namedConfigurer("an unknown OS", hs -> {
       when(hs.isProbablyLinux()).thenReturn(false);
       when(hs.isProbablyMacOs()).thenReturn(false);
+      when(hs.isProbablySolaris()).thenReturn(false);
       when(hs.isProbablyWindows()).thenReturn(false);
     });
   }

--- a/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/system/HostSystemTest.java
+++ b/protobuf-maven-plugin/src/test/java/io/github/ascopes/protobufmavenplugin/system/HostSystemTest.java
@@ -194,6 +194,47 @@ class HostSystemTest {
     Assertions.assertThat(actualResult).isEqualTo(expectedResult);
   }
 
+  @DisplayName(".isProbablySolaris() returns true if the OS is probably Solaris")
+  @CsvSource({
+      "              LINUX, false",
+      "              Linux, false",
+      "              linux, false",
+      "            FreeBSD, false",
+      "            OpenBSD, false",
+      "               OS/2, false",
+      "            Solaris, true",
+      "              SunOS, true",
+      "               Irix, false",
+      "             OS/400, false",
+      "              HP-UX, false",
+      "                AIX, false",
+      "      Mac OS X 10.0, false",
+      "     Mac OS X 10.15, false",
+      "        Mac OS X 11, false",
+      "        Mac OS X 12, false",
+      "        Mac OS X 13, false",
+      "          Windows 7, false",
+      "          Windows 8, false",
+      "        Windows 8.1, false",
+      "         Windows 10, false",
+      "         Windows 11, false",
+      "Windows Server 2019, false",
+  })
+  @ParameterizedTest(name = "returns {1} on {0}")
+  void isProbablySolarisReturnsTrueIfTheOsIsProbablySolaris(String osName, boolean expectedResult) {
+    // Given
+    var properties = new Properties();
+    var env = Map.<String, String>of();
+    properties.put("os.name", osName);
+    var hostSystemBean = newInstance(properties, env);
+
+    // When
+    var actualResult = hostSystemBean.isProbablySolaris();
+
+    // Then
+    Assertions.assertThat(actualResult).isEqualTo(expectedResult);
+  }
+
   @DisplayName(".getJavaExecutablePath() returns the Java executable")
   @CsvSource({
       " Windows, java.exe",


### PR DESCRIPTION
This change adds support for using the plugin on illumos and Solaris.

While there is no official protoc artifact in Maven central, it's quite easy to build protoc for Solaris and deploy it to a local repository. For example using a command like:

```
mvn deploy:deploy-file \
  -DrepositoryId=third-party \
  -Durl=https://reposilite.example.com/third-party/ \
  -Dfile="protoc-4.35.1-sunos-x86_64.exe" \
  -DgroupId="com.google.protobuf" \
  -DartifactId="protoc" \
  -Dversion="4.35.1" \
  -Dpackaging=exe \
  -Dclassifier="sunos-x86_64" \
  -DcreateChecksum=true
```

I've tested the plugin with this change on illumos.